### PR TITLE
Failing test for AST Node duplication

### DIFF
--- a/src/test/FilterFields/FilterFields.ts
+++ b/src/test/FilterFields/FilterFields.ts
@@ -1,0 +1,96 @@
+import {
+  GraphQLSchema,
+  GraphQLNamedType,
+  GraphQLObjectType,
+  GraphQLField,
+  GraphQLFieldConfig,
+} from 'graphql';
+import {Transform} from '../..';
+import {visitSchema, VisitSchemaKind} from '../../transforms/visitSchema';
+import {
+  createResolveType,
+  fieldToFieldConfig,
+} from '../../stitching/schemaRecreation';
+import isEmptyObject from '../../isEmptyObject';
+
+// The bulk of the code in this Transformer is from
+// graphql-tools/src/transforms/TransformRootFields.ts
+
+export interface FieldsToFilter {
+  [type: string]: string[];
+}
+
+export default class FilterFields implements Transform {
+  private fieldsToFilter: FieldsToFilter;
+
+  constructor(fieldsToFilter: FieldsToFilter = {}) {
+    this.fieldsToFilter = fieldsToFilter;
+  }
+
+  public transformSchema(schema: GraphQLSchema): GraphQLSchema {
+    return visitSchema(schema, {
+      [VisitSchemaKind.OBJECT_TYPE]: type => {
+        if (
+          type instanceof GraphQLObjectType &&
+          this.fieldsToFilter[type.name]
+        ) {
+          return transformFields(
+            type,
+            (fieldName, field) =>
+              this.fieldsToFilter[type.name].includes(fieldName)
+                ? null
+                : undefined,
+          ) as GraphQLNamedType;
+        }
+
+        return (undefined as any) as GraphQLNamedType;
+      },
+    });
+  }
+}
+
+interface NewField {
+  name: string;
+  field: GraphQLFieldConfig<any, any>;
+}
+
+function transformFields(
+  type: GraphQLObjectType,
+  transformer: (
+    fieldName: string,
+    field: GraphQLField<any, any>,
+  ) =>
+    | GraphQLFieldConfig<any, any>
+    | {name: string; field: GraphQLFieldConfig<any, any>}
+    | null
+    | undefined,
+): GraphQLObjectType | null {
+  const resolveType = createResolveType((name, originalType) => originalType);
+  const fields = type.getFields();
+  const newFields: {[k: string]: any} = {};
+  Object.keys(fields).forEach(fieldName => {
+    const field = fields[fieldName];
+    const newField = transformer(fieldName, field);
+    if (typeof newField === 'undefined') {
+      newFields[fieldName] = fieldToFieldConfig(field, resolveType, true);
+    } else if (newField !== null) {
+      if ((newField as NewField).name) {
+        newFields[(newField as NewField).name] = (newField as NewField).field;
+      } else {
+        newFields[fieldName] = newField;
+      }
+    }
+  });
+  if (isEmptyObject(newFields)) {
+    return null;
+  } else {
+    return new GraphQLObjectType({
+      name: type.name,
+      description: type.description,
+      fields: newFields,
+      // This line can be commented out to fix this issue,
+      // at the cost of stripping all directives.
+      astNode: type.astNode,
+    });
+  }
+}

--- a/src/test/FilterFields/testAstNodeDuplication.ts
+++ b/src/test/FilterFields/testAstNodeDuplication.ts
@@ -1,0 +1,34 @@
+// graphql does export this function but it looks like the types are not up to date.
+// @ts-ignore
+import {assertValidSchema} from 'graphql';
+import {mergeSchemas, transformSchema} from '../..';
+import FilterFields from './FilterFields';
+import {propertySchema} from '../testingSchemas';
+
+describe('Filtering fields', () => {
+  // Use case: breaking apart monolithic GQL codebase into microservices.
+  // E.g. strip out types/fields from the monolith slowly and re-add them
+  // as stitched resolvers to another service.
+  it('should allow stitching a previously filtered field onto a type', async () => {
+    const filteredSchema = transformSchema(propertySchema, [
+      new FilterFields({
+        Property: ['location'],
+      }),
+    ]);
+
+    assertValidSchema(filteredSchema);
+
+    const mergedSchemas = mergeSchemas({
+      schemas: [
+        filteredSchema,
+        `
+          extend type Property {
+            location: Location
+          }
+        `,
+      ],
+    });
+
+    assertValidSchema(mergedSchemas);
+  });
+});

--- a/src/test/tests.ts
+++ b/src/test/tests.ts
@@ -7,6 +7,7 @@ import './testResolution';
 import './testMakeRemoteExecutableSchema';
 import './testMergeSchemas';
 import './testTransforms';
+import './FilterFields/testAstNodeDuplication';
 import './testAlternateMergeSchemas';
 import './testErrors';
 import './testDirectives';


### PR DESCRIPTION
Failing test as requested by @freiksenet in slack.

This problem arose for me when a transformer strips out a field from a type, then a stitching extension tries to add it back in again. The field is removed from the type but not the astNode, so field validation fails.

To reproduce this I've included the entire custom `FilterFields` transformer I adapted from `TransformRootFields`.