### PR TITLE
FilterTypes transformer fails on union member types

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "devDependencies": {
     "@types/chai": "4.0.10",
-    "@types/graphql": "0.11.7",
+    "@types/graphql": "0.13.1",
     "@types/dateformat": "^1.0.1",
     "@types/mocha": "^2.2.44",
     "@types/node": "^8.0.47",


### PR DESCRIPTION
Attempting to filter a type which is included in a union using the `FilterTypes` transformer produces an invalid schema. This is only noticeable once the schema is validated, which is only done at runtime by `graphql` & is not being tested for in `master`. The error is always:
```
TypeError: Cannot read property 'name' of null
```

I've added a few failing test cases against the test `bookingSchema` by trying to remove the `Bike` type. In the process I've bumped `@types/graphql` to 0.13.1 so TypeScript doesn't complain when using the `assertValidSchema` function from `graphql@^0.13.0`.

The problem can be seen clearly if you print the schema out. E.g. this union
```
union Vehicle = Bike | Car
```
is being transformed to this invalid syntax
```
union Vehicle =  | Car
```
instead of this
```
union Vehicle = Car
```

This is due to the transformer changing any `memberType` in the union that is rejected by the filter into `null` instead of removing it completely. E.g.
```
memberTypes: [
    {...},
    {...},
]
```
is becoming 
```
memberTypes: [
    null,
    {...},
]
```
rather than
```
memberTypes: [
    {...},
]
```

/label bug
/label schema-stitching