### PR TITLE
Interface stitching

### DIFF
--- a/src/test/testTransforms.ts
+++ b/src/test/testTransforms.ts
@@ -784,7 +784,7 @@ describe('transforms', () => {
               return `${parent.name} ${parent.surname}`;
             },
             specialName(parent) {
-              return data.u1.name
+              return data.u1.name;
             },
           },
         },
@@ -832,6 +832,6 @@ describe('transforms', () => {
           },
         },
       });
-    })
+    });
   });
 });


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.
- [ ] Move this logic to schema transform time, instead of at query time

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

This PR addresses an issue when stitching 2 schemas together. I have run into the need a few times to extend an interface with fields that can be derived from fields that are already on the interface. For example, if an interface looks like

```
interface WithProject {
    projectID: ID!
}
```

I want to be able to add the actual `project` associated with that ID:

```
extend WithProject { 
    project: Project!
}
```

This means adding a new resolver (and field) to every type that implements the interface. While this is cumbersome in general, it can be made a lot easier if the user can reuse the same stitching resolver. The `fragment` argument can just refer to the interface itself

```
{
    fragment: `... on WithProject { projectID },
    resolver: () => ....
}
```

however in the current implementation, the `... WithProject` does not impact the selection set of the query when they are getting stitched since the type name does not match up with the parent type. This PR fixes this issue by looking to see if the parent type implements and interface, and if so, looking for entries in the mapping under the interface.

One thing I would like to do before i think this is completely ready is to move this logic out of the main path when a query is fired and instead to the moment that the schema transform is applied. That would make the lookups a one-time cost instead of on every query.  