### PR TITLE
pass data when resolving an interface or union in mock.ts

### DIFF
--- a/src/mock.ts
+++ b/src/mock.ts
@@ -187,7 +187,7 @@ function addMockFunctionsToSchema({
           implementationType = getRandomElement(possibleTypes);
         }
         return Object.assign(
-          { __typename: implementationType },
+          { __typename: implementationType, ...interfaceMockObj },
           mockType(implementationType)(root, args, context, info),
         );
       }


### PR DESCRIPTION
This will allow to pass the rest of the data resolved in the interface/union resolver, that would otherwise get lost

I'll do the rest when the general idea is approved:

- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

/label feature