### PR TITLE
Prevent addSchemaLevelResolveFunction from making an otherwise sync operation async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### vNext
 
 * TODO
+* Prevent `addSchemaLevelResolveFunction` from making an otherwise sync operation async. <br />
+  [@simoncave](https://github.com/simoncave) in [#1057](https://github.com/apollographql/graphql-tools/pull/1057)
+
 
 ### 4.0.4
 

--- a/src/test/testResolution.ts
+++ b/src/test/testResolution.ts
@@ -1,6 +1,12 @@
 import { assert } from 'chai';
 import { makeExecutableSchema, addSchemaLevelResolveFunction } from '..';
-import { parse, graphql, subscribe, ExecutionResult } from 'graphql';
+import {
+  parse,
+  graphql,
+  graphqlSync,
+  subscribe,
+  ExecutionResult,
+} from 'graphql';
 import { PubSub } from 'graphql-subscriptions';
 import { forAwaitEach } from 'iterall';
 
@@ -156,6 +162,19 @@ describe('Resolve', () => {
           pubsub.publish('printRootChannel', { printRoot: subscriptionRoot2 });
         })
         .catch(done);
+    });
+
+    it('should not force an otherwise synchronous schema to be asynchronous', () => {
+      const queryRoot = 'queryRoot';
+      graphqlSync(
+        schema,
+        `
+          query TestQuery {
+            printRoot
+          }
+        `,
+        queryRoot,
+      );
     });
   });
 });

--- a/src/test/testResolution.ts
+++ b/src/test/testResolution.ts
@@ -164,7 +164,7 @@ describe('Resolve', () => {
         .catch(done);
     });
 
-    it('should not force an otherwise synchronous schema to be asynchronous', () => {
+    it('should not force an otherwise synchronous operation to be asynchronous', () => {
       const queryRoot = 'queryRoot';
       // This will throw an error if schema has any asynchronous resolvers
       graphqlSync(

--- a/src/test/testResolution.ts
+++ b/src/test/testResolution.ts
@@ -166,6 +166,7 @@ describe('Resolve', () => {
 
     it('should not force an otherwise synchronous schema to be asynchronous', () => {
       const queryRoot = 'queryRoot';
+      // This will throw an error if schema has any asynchronous resolvers
       graphqlSync(
         schema,
         `


### PR DESCRIPTION
GraphQL operations can be asynchronous or synchronous. A GraphQL operation is synchronous if all the resolvers it hits are synchronous. GraphQL.js comes with an alternative to `graphql()` called `graphqlSync()` which will return an operation result synchronously, provided all of the resolvers it hits are synchronous (otherwise an error is thrown).

`addSchemaLevelResolveFunction()` synthesizes resolvers in order to apply a schema-level resolve function, but in doing so it forces the result from the wrapped resolver through `Promise.resolve` which forces an otherwise synchronous operation to become asynchronous.

This PR fixes the problem using a `resolveMaybePromise()` function which will map the result of a value which is _maybe_ wrapped in a promise. A test is added which confirms that a schema that has had `addSchemaLevelResolveFunction` applied to it does now throw an error when used with `graphqlSync`.

An unrelated test (`"can specify lexical parser options"` &rsaquo; `"can specify 'experimentalFragmentVariables' option"`) was already failing when I wrote this PR, so it remains the only failing test.

TODO:

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

