### PR TITLE
Wrap captureStackTrace in check

### DIFF
--- a/src/generate/SchemaError.ts
+++ b/src/generate/SchemaError.ts
@@ -6,6 +6,8 @@ export default class SchemaError extends Error {
   constructor(message: string) {
     super(message);
     this.message = message;
-    Error.captureStackTrace(this, this.constructor);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
   }
 }


### PR DESCRIPTION
I am running graphql under the chakracore JS runtime that does not implement
Error.captureStackTrace.

Note that the facebook graphql library also checks for the presence of Error.captureStackTrace:

https://github.com/graphql/graphql-js/blob/f0ae3f4c0ba469c8f2147f8d12c9e670313b865c/src/error/GraphQLError.js#L201

Please consider wrapping this call in a check to prevent runtime errors in this error handling code.

<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

