### PR TITLE
Submitted on behalf of a third-party: add mergeResolvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fixes a bug where schemas with scalars could not be merged when passed to
   `mergeSchemas` as a string or `GraphQLSchema`.  <br/>
   [@hayes](https://github.com/hayes) in [#1062](https://github.com/apollographql/graphql-tools/pull/1062)
+* Adds `mergeResolvers` API to allow merging one resolver map on top of another (useful for schema mocking and merging test-specific resolver mocks on top of a base set of resolvers) in [#1084](https://github.com/apollographql/graphql-tools/pull/1084).
 
 ### 4.0.4
 

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -213,3 +213,15 @@ export type GraphQLParseOptions = {
   allowLegacySDLImplementsInterfaces?: boolean;
   experimentalFragmentVariables?: boolean;
 };
+
+type ResolvedScalar = string | number | boolean | null;
+type ResolvedValue = ResolvedScalar | ResolvedScalar[] | { [key: string]: ResolvedValue };
+type ResolverFunction = (...args: any[]) => ResolvedValue;
+
+export type ResolverMap = {
+  [key: string]: () =>
+    | { [key: string]: ResolvedValue | ResolverFunction }
+    | null
+    | ResolvedValue
+    | ResolverMap;
+};

--- a/src/generate/index.ts
+++ b/src/generate/index.ts
@@ -11,4 +11,5 @@ export { default as decorateWithLogger } from './decorateWithLogger';
 export { default as extendResolversFromInterfaces } from './extendResolversFromInterfaces';
 export { default as extractExtensionDefinitions } from './extractExtensionDefinitions';
 export { default as forEachField } from './forEachField';
+export { default as mergeResolvers } from './mergeResolvers';
 export { default as SchemaError } from './SchemaError';

--- a/src/generate/mergeResolvers.ts
+++ b/src/generate/mergeResolvers.ts
@@ -1,0 +1,49 @@
+// from https://gist.github.com/hellendag/2aa9ad1f9b771f38802760c269bb1b76
+
+import { ResolverMap } from '../Interfaces';
+
+/**
+ * Given a map of mock GraphQL resolver functions, merge in a map of
+ * desired mocks. Generally, `target` will be the default mocked values,
+ * and `input` will be the values desired for a portal example or Jest tests.
+ */
+const mergeResolver = (target: ResolverMap, input: ResolverMap) => {
+  const inputTypenames = Object.keys(input);
+  const merged = inputTypenames.reduce(
+    (accum, key) => {
+      const inputResolver = input[key];
+      if (target.hasOwnProperty(key)) {
+        const targetResolver = target[key];
+        const resolvedInput = inputResolver();
+        const resolvedTarget = targetResolver();
+        if (
+          !!resolvedTarget &&
+          !!resolvedInput &&
+          typeof resolvedTarget === 'object' &&
+          typeof resolvedInput === 'object' &&
+          !Array.isArray(resolvedTarget) &&
+          !Array.isArray(resolvedInput)
+        ) {
+          const newValue = { ...resolvedTarget, ...resolvedInput };
+          return {
+            ...accum,
+            [key]: () => newValue,
+          };
+        }
+      }
+      return { ...accum, [key]: inputResolver };
+    },
+    { ...target },
+  ) as ResolverMap;
+  return merged;
+};
+
+const mergeResolvers = (target: ResolverMap, ...inputs: ResolverMap[]) => {
+  let resolver = target;
+  inputs.forEach(input => {
+    resolver = mergeResolver(resolver, input);
+  });
+  return resolver;
+};
+
+export default mergeResolvers;


### PR DESCRIPTION
TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

Implements https://github.com/apollographql/graphql-tools/issues/1083.

This PR takes an existing well-publicized gist https://gist.github.com/hellendag/2aa9ad1f9b771f38802760c269bb1b76 (with two small Typescript typing changes) and exposes it as part of graphql-tools. Currently we copy-pasted the gist into our codebase but we don't want to have to maintain it ourselves and keep it in sync with the rest of graphql/graphql-tools. It is generally useful for schema mocking and makes sense to expose in the graphql-tools lib.
