### PR TITLE
refactor(types): use declaration merging

### DIFF
--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -163,9 +163,15 @@ export type RenameTypesOptions = {
   renameScalars: boolean;
 };
 
-export interface IGraphQLToolsResolveInfo extends GraphQLResolveInfo {
-  mergeInfo?: MergeInfo;
+declare module 'graphql' {
+  interface GraphQLResolveInfo {
+    mergeInfo?: MergeInfo;
+  }
 }
+
+// for backwards compatibility
+// eslint-disable-next-line  @typescript-eslint/no-empty-interface
+export interface IGraphQLToolsResolveInfo extends GraphQLResolveInfo {}
 
 export type Fetcher = (
   operation: IFetcherOperation,
@@ -201,7 +207,7 @@ export interface MergedTypeConfig {
 export type MergedTypeResolver = (
   originalResult: any,
   context: Record<string, any>,
-  info: IGraphQLToolsResolveInfo,
+  info: GraphQLResolveInfo,
   subschema: GraphQLSchema | SubschemaConfig,
   selectionSet: SelectionSetNode,
 ) => any;
@@ -235,7 +241,7 @@ export interface IDelegateToSchemaOptions<
   selectionSet?: SelectionSetNode;
   fieldNodes?: ReadonlyArray<FieldNode>;
   context?: TContext;
-  info: IGraphQLToolsResolveInfo;
+  info: GraphQLResolveInfo;
   rootValue?: Record<string, any>;
   transforms?: Array<Transform>;
   skipValidation?: boolean;
@@ -243,7 +249,7 @@ export interface IDelegateToSchemaOptions<
 }
 
 export interface ICreateRequestFromInfo {
-  info: IGraphQLToolsResolveInfo;
+  info: GraphQLResolveInfo;
   operation: Operation;
   fieldName: string;
   selectionSet?: SelectionSetNode;
@@ -315,7 +321,7 @@ export type IFieldResolver<
   source: TSource,
   args: TArgs,
   context: TContext,
-  info: IGraphQLToolsResolveInfo,
+  info: GraphQLResolveInfo,
 ) => TReturn;
 
 export type ITypedef = (() => Array<ITypedef>) | string | DocumentNode;

--- a/src/delegate/checkResultAndHandleErrors.ts
+++ b/src/delegate/checkResultAndHandleErrors.ts
@@ -11,7 +11,7 @@ import {
   GraphQLSchema,
 } from 'graphql';
 
-import { SubschemaConfig, IGraphQLToolsResolveInfo } from '../Interfaces';
+import { SubschemaConfig } from '../Interfaces';
 import { getResponseKeyFromInfo } from '../stitch/getResponseKeyFromInfo';
 
 import { handleNull } from './results/handleNull';
@@ -46,7 +46,7 @@ export function handleResult(
   errors: ReadonlyArray<GraphQLError>,
   subschema: GraphQLSchema | SubschemaConfig,
   context: Record<string, any>,
-  info: IGraphQLToolsResolveInfo,
+  info: GraphQLResolveInfo,
   returnType = info.returnType,
   skipTypeMerging?: boolean,
 ): any {

--- a/src/delegate/delegateToSchema.ts
+++ b/src/delegate/delegateToSchema.ts
@@ -9,6 +9,7 @@ import {
   GraphQLOutputType,
   isSchema,
   DocumentNode,
+  GraphQLResolveInfo,
 } from 'graphql';
 
 import {
@@ -17,7 +18,6 @@ import {
   Fetcher,
   SubschemaConfig,
   isSubschemaConfig,
-  IGraphQLToolsResolveInfo,
   Transform,
 } from '../Interfaces';
 import ExpandAbstractTypes from '../wrap/transforms/ExpandAbstractTypes';
@@ -78,7 +78,7 @@ export default function delegateToSchema(
 
 function buildDelegationTransforms(
   subschemaOrSubschemaConfig: GraphQLSchema | SubschemaConfig,
-  info: IGraphQLToolsResolveInfo,
+  info: GraphQLResolveInfo,
   context: Record<string, any>,
   targetSchema: GraphQLSchema,
   fieldName: string,

--- a/src/delegate/results/handleList.ts
+++ b/src/delegate/results/handleList.ts
@@ -2,6 +2,7 @@ import {
   GraphQLList,
   GraphQLSchema,
   GraphQLError,
+  GraphQLResolveInfo,
   getNullableType,
   GraphQLType,
   responsePathAsArray,
@@ -10,7 +11,7 @@ import {
   isListType,
 } from 'graphql';
 
-import { SubschemaConfig, IGraphQLToolsResolveInfo } from '../../Interfaces';
+import { SubschemaConfig } from '../../Interfaces';
 import { getErrorsByPathSegment } from '../../stitch/errors';
 
 import { handleNull } from './handleNull';
@@ -22,7 +23,7 @@ export function handleList(
   errors: ReadonlyArray<GraphQLError>,
   subschema: GraphQLSchema | SubschemaConfig,
   context: Record<string, any>,
-  info: IGraphQLToolsResolveInfo,
+  info: GraphQLResolveInfo,
   skipTypeMerging?: boolean,
 ) {
   const childErrors = getErrorsByPathSegment(errors);
@@ -48,7 +49,7 @@ function handleListMember(
   errors: ReadonlyArray<GraphQLError>,
   subschema: GraphQLSchema | SubschemaConfig,
   context: Record<string, any>,
-  info: IGraphQLToolsResolveInfo,
+  info: GraphQLResolveInfo,
   skipTypeMerging?: boolean,
 ): any {
   if (listMember == null) {

--- a/src/delegate/results/handleObject.ts
+++ b/src/delegate/results/handleObject.ts
@@ -5,13 +5,13 @@ import {
   isAbstractType,
   FieldNode,
   GraphQLObjectType,
+  GraphQLResolveInfo,
 } from 'graphql';
 
 import { collectFields } from '../../utils/collectFields';
 
 import {
   SubschemaConfig,
-  IGraphQLToolsResolveInfo,
   MergedTypeInfo,
   isSubschemaConfig,
   GraphQLExecutionContext,
@@ -27,7 +27,7 @@ export function handleObject(
   errors: ReadonlyArray<GraphQLError>,
   subschema: GraphQLSchema | SubschemaConfig,
   context: Record<string, any>,
-  info: IGraphQLToolsResolveInfo,
+  info: GraphQLResolveInfo,
   skipTypeMerging?: boolean,
 ) {
   setErrors(
@@ -81,7 +81,7 @@ export function handleObject(
   );
 }
 
-function collectSubFields(info: IGraphQLToolsResolveInfo, typeName: string) {
+function collectSubFields(info: GraphQLResolveInfo, typeName: string) {
   let subFieldNodes: Record<string, Array<FieldNode>> = Object.create(null);
   const visitedFragmentNames = Object.create(null);
   info.fieldNodes.forEach((fieldNode) => {

--- a/src/stitch/defaultMergedResolver.ts
+++ b/src/stitch/defaultMergedResolver.ts
@@ -1,6 +1,5 @@
-import { defaultFieldResolver } from 'graphql';
+import { defaultFieldResolver, GraphQLResolveInfo } from 'graphql';
 
-import { IGraphQLToolsResolveInfo } from '../Interfaces';
 import { handleResult } from '../delegate/checkResultAndHandleErrors';
 
 import { getSubschema } from './subSchema';
@@ -17,7 +16,7 @@ export default function defaultMergedResolver(
   parent: Record<string, any>,
   args: Record<string, any>,
   context: Record<string, any>,
-  info: IGraphQLToolsResolveInfo,
+  info: GraphQLResolveInfo,
 ) {
   if (!parent) {
     return null;

--- a/src/stitch/mergeFields.ts
+++ b/src/stitch/mergeFields.ts
@@ -1,10 +1,6 @@
-import { FieldNode, SelectionNode, Kind } from 'graphql';
+import { FieldNode, SelectionNode, Kind, GraphQLResolveInfo } from 'graphql';
 
-import {
-  SubschemaConfig,
-  IGraphQLToolsResolveInfo,
-  MergedTypeInfo,
-} from '../Interfaces';
+import { SubschemaConfig, MergedTypeInfo } from '../Interfaces';
 
 import { mergeProxiedResults } from './proxiedResult';
 
@@ -102,7 +98,7 @@ export function mergeFields(
   sourceSubschemas: Array<SubschemaConfig>,
   targetSubschemas: Array<SubschemaConfig>,
   context: Record<string, any>,
-  info: IGraphQLToolsResolveInfo,
+  info: GraphQLResolveInfo,
 ): any {
   if (!originalSelections.length) {
     return object;

--- a/src/stitch/mergeInfo.ts
+++ b/src/stitch/mergeInfo.ts
@@ -1,6 +1,7 @@
 import {
   GraphQLNamedType,
   GraphQLObjectType,
+  GraphQLResolveInfo,
   GraphQLSchema,
   Kind,
   SelectionNode,
@@ -15,7 +16,6 @@ import {
   IResolversParameter,
   isSubschemaConfig,
   SubschemaConfig,
-  IGraphQLToolsResolveInfo,
   MergedTypeInfo,
   Transform,
   TypeMap,
@@ -58,7 +58,7 @@ export function createMergeInfo(
       fieldName: string,
       args: Record<string, any>,
       context: Record<string, any>,
-      info: IGraphQLToolsResolveInfo,
+      info: GraphQLResolveInfo,
       transforms: Array<Transform> = [],
     ) {
       const schema = guessSchemaByRootField(allSchemas, operation, fieldName);

--- a/src/stitch/proxiedResult.ts
+++ b/src/stitch/proxiedResult.ts
@@ -1,6 +1,6 @@
-import { GraphQLError, responsePathAsArray } from 'graphql';
+import { GraphQLError, responsePathAsArray, GraphQLResolveInfo } from 'graphql';
 
-import { SubschemaConfig, IGraphQLToolsResolveInfo } from '../Interfaces';
+import { SubschemaConfig } from '../Interfaces';
 import { mergeDeep } from '../esUtils/mergeDeep';
 import { handleNull } from '../delegate/results/handleNull';
 
@@ -18,7 +18,7 @@ export function isProxiedResult(result: any) {
 
 export function unwrapResult(
   parent: any,
-  info: IGraphQLToolsResolveInfo,
+  info: GraphQLResolveInfo,
   path: Array<string>,
 ): any {
   let newParent: any = parent;

--- a/src/test/dataloader.test.ts
+++ b/src/test/dataloader.test.ts
@@ -1,10 +1,9 @@
 import DataLoader from 'dataloader';
-import { graphql, GraphQLList } from 'graphql';
+import { graphql, GraphQLList, GraphQLResolveInfo } from 'graphql';
 
 import { delegateToSchema } from '../delegate/index';
 import { makeExecutableSchema } from '../generate/index';
 import { mergeSchemas } from '../stitch/index';
-import { IGraphQLToolsResolveInfo } from '../Interfaces';
 
 describe('dataloader', () => {
   test('should work', async () => {
@@ -68,7 +67,7 @@ describe('dataloader', () => {
     });
 
     const usersLoader = new DataLoader(
-      async (keys: Array<{ id: any; info: IGraphQLToolsResolveInfo }>) => {
+      async (keys: Array<{ id: any; info: GraphQLResolveInfo }>) => {
         const users = await delegateToSchema({
           schema: userSchema,
           operation: 'query',

--- a/src/test/errors.test.ts
+++ b/src/test/errors.test.ts
@@ -1,10 +1,9 @@
-import { GraphQLError, graphql } from 'graphql';
+import { GraphQLError, GraphQLResolveInfo, graphql } from 'graphql';
 
 import { relocatedError, getErrors } from '../stitch/errors';
 import { checkResultAndHandleErrors } from '../delegate/checkResultAndHandleErrors';
 import { makeExecutableSchema } from '../generate/index';
 import { mergeSchemas } from '../stitch/index';
-import { IGraphQLToolsResolveInfo } from '../Interfaces';
 import { ERROR_SYMBOL } from '../stitch/symbols';
 
 class ErrorWithExtensions extends GraphQLError {
@@ -53,7 +52,7 @@ describe('Errors', () => {
         checkResultAndHandleErrors(
           result,
           {},
-          ({} as unknown) as IGraphQLToolsResolveInfo,
+          ({} as unknown) as GraphQLResolveInfo,
           'responseKey',
         );
       } catch (e) {
@@ -70,7 +69,7 @@ describe('Errors', () => {
         checkResultAndHandleErrors(
           result,
           {},
-          ({} as unknown) as IGraphQLToolsResolveInfo,
+          ({} as unknown) as GraphQLResolveInfo,
           'responseKey',
         );
       } catch (e) {
@@ -88,7 +87,7 @@ describe('Errors', () => {
         checkResultAndHandleErrors(
           result,
           {},
-          ({} as unknown) as IGraphQLToolsResolveInfo,
+          ({} as unknown) as GraphQLResolveInfo,
           'responseKey',
         );
       } catch (e) {

--- a/src/wrap/transforms/CheckResultAndHandleErrors.ts
+++ b/src/wrap/transforms/CheckResultAndHandleErrors.ts
@@ -1,22 +1,18 @@
-import { GraphQLSchema, GraphQLOutputType } from 'graphql';
+import { GraphQLSchema, GraphQLOutputType, GraphQLResolveInfo } from 'graphql';
 
 import { checkResultAndHandleErrors } from '../../delegate/checkResultAndHandleErrors';
-import {
-  Transform,
-  SubschemaConfig,
-  IGraphQLToolsResolveInfo,
-} from '../../Interfaces';
+import { Transform, SubschemaConfig } from '../../Interfaces';
 
 export default class CheckResultAndHandleErrors implements Transform {
   private readonly context?: Record<string, any>;
-  private readonly info: IGraphQLToolsResolveInfo;
+  private readonly info: GraphQLResolveInfo;
   private readonly fieldName?: string;
   private readonly subschema?: GraphQLSchema | SubschemaConfig;
   private readonly returnType?: GraphQLOutputType;
   private readonly typeMerge?: boolean;
 
   constructor(
-    info: IGraphQLToolsResolveInfo,
+    info: GraphQLResolveInfo,
     fieldName?: string,
     subschema?: GraphQLSchema | SubschemaConfig,
     context?: Record<string, any>,


### PR DESCRIPTION
use declaration merging to add optional properties to GraphQLResolveInfo rather than rely on new interface.

Retain IGraphQLToolsResolveInfo interface for backwards compatibility.