### PR TITLE
feat(delegate): pass info to fetcher/link

### DIFF
--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -173,16 +173,22 @@ declare module 'graphql' {
 // eslint-disable-next-line  @typescript-eslint/no-empty-interface
 export interface IGraphQLToolsResolveInfo extends GraphQLResolveInfo {}
 
-export type Fetcher = (
-  operation: IFetcherOperation,
-) => Promise<ExecutionResult>;
+export type Fetcher = (options: IFetcherOptions) => Promise<ExecutionResult>;
 
-export interface IFetcherOperation {
+export interface IFetcherOptions {
   query: DocumentNode;
   operationName?: string;
   variables?: Record<string, any>;
-  context?: Record<string, any>;
+  context?: {
+    graphqlContext?: Record<string, any>;
+    graphqlResolveInfo?: GraphQLResolveInfo;
+    [key: string]: any;
+  };
 }
+
+// for backwards compatibility
+// eslint-disable-next-line  @typescript-eslint/no-empty-interface
+export interface IFetcherOperation extends IFetcherOptions {}
 
 export type Dispatcher = (context: any) => ApolloLink | Fetcher;
 

--- a/src/stitch/linkToFetcher.ts
+++ b/src/stitch/linkToFetcher.ts
@@ -1,10 +1,15 @@
 import { ApolloLink, toPromise, execute, ExecutionResult } from 'apollo-link';
 
-import { Fetcher, IFetcherOperation } from '../Interfaces';
+import { Fetcher, IFetcherOptions } from '../Interfaces';
 
 export { execute } from 'apollo-link';
 
 export default function linkToFetcher(link: ApolloLink): Fetcher {
-  return (fetcherOperation: IFetcherOperation): Promise<ExecutionResult> =>
-    toPromise(execute(link, fetcherOperation));
+  return ({
+    query,
+    operationName,
+    variables,
+    context,
+  }: IFetcherOptions): Promise<ExecutionResult> =>
+    toPromise(execute(link, { query, operationName, variables, context }));
 }


### PR DESCRIPTION
info argument may have additional functionality added to it via extensions that custom fetchers or links defined on subschemas may wish to use, such as dynamic cacheControl hints, see #1380