### PR TITLE
fix(toConfig): should properly map types to individual configs

### DIFF
--- a/src/stitch/mergeSchemas.ts
+++ b/src/stitch/mergeSchemas.ts
@@ -354,12 +354,13 @@ function merge(
       fields: candidates.reduce(
         (acc, candidate) => ({
           ...acc,
-          ...toConfig(candidate.type).fields,
+          ...toConfig(candidate.type as GraphQLObjectType).fields,
         }),
         {},
       ),
       interfaces: candidates.reduce((acc, candidate) => {
-        const interfaces = toConfig(candidate.type).interfaces;
+        const interfaces = toConfig(candidate.type as GraphQLObjectType)
+          .interfaces;
         return interfaces != null ? acc.concat(interfaces) : acc;
       }, []),
     });
@@ -369,14 +370,16 @@ function merge(
       fields: candidates.reduce(
         (acc, candidate) => ({
           ...acc,
-          ...toConfig(candidate.type).fields,
+          ...toConfig(candidate.type as GraphQLInterfaceType).fields,
         }),
         {},
       ),
       ...((graphqlVersion() >= 15
         ? {
             interfaces: candidates.reduce((acc, candidate) => {
-              const interfaces = toConfig(candidate.type).interfaces;
+              const interfaces = toConfig(
+                candidate.type as GraphQLInterfaceType,
+              ).interfaces;
               return interfaces != null ? acc.concat(interfaces) : acc;
             }, []),
           }
@@ -387,7 +390,8 @@ function merge(
     return new GraphQLUnionType({
       name: typeName,
       types: candidates.reduce(
-        (acc, candidate) => acc.concat(toConfig(candidate.type).types),
+        (acc, candidate) =>
+          acc.concat(toConfig(candidate.type as GraphQLUnionType).types),
         [],
       ),
     });

--- a/src/stitch/mergeSchemas.ts
+++ b/src/stitch/mergeSchemas.ts
@@ -397,7 +397,7 @@ function merge(
       values: candidates.reduce(
         (acc, candidate) => ({
           ...acc,
-          ...toConfig(candidate.type).values,
+          ...toConfig(candidate.type as GraphQLEnumType).values,
         }),
         {},
       ),

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -19,7 +19,9 @@ describe('heal', () => {
     });
     const originalTypeMap = schema.getTypeMap();
 
-    const config = toConfig(originalTypeMap['WillBeEmptyObject']);
+    const config = toConfig(
+      originalTypeMap['WillBeEmptyObject'] as GraphQLObjectType,
+    );
     originalTypeMap['WillBeEmptyObject'] = new GraphQLObjectType({
       ...config,
       fields: {},

--- a/src/utils/fields.ts
+++ b/src/utils/fields.ts
@@ -14,7 +14,7 @@ export function appendFields(
 ): void {
   let type = typeMap[typeName];
   if (type != null) {
-    const typeConfig = toConfig(type);
+    const typeConfig = toConfig(type as GraphQLObjectType);
 
     const newFields: any = Object.entries(typeConfig.fields).reduce(
       (prev, [key, val]) => ({
@@ -46,7 +46,7 @@ export function removeFields(
   testFn: (fieldName: string, field: GraphQLFieldConfig<any, any>) => boolean,
 ): GraphQLFieldConfigMap<any, any> {
   let type = typeMap[typeName];
-  const typeConfig = toConfig(type);
+  const typeConfig = toConfig(type as GraphQLObjectType);
   const originalFields = typeConfig.fields;
   const newFields = {};
   const removedFields = {};

--- a/src/utils/filterSchema.ts
+++ b/src/utils/filterSchema.ts
@@ -6,6 +6,7 @@ import {
   GraphQLScalarType,
   GraphQLUnionType,
   GraphQLType,
+  GraphQLField,
 } from 'graphql';
 
 import {
@@ -64,7 +65,13 @@ function filterRootFields(
 ): GraphQLObjectType {
   const config = toConfig(type);
   Object.keys(config.fields).forEach((fieldName) => {
-    if (!rootFieldFilter(operation, fieldName, config.fields[fieldName])) {
+    if (
+      !rootFieldFilter(
+        operation,
+        fieldName,
+        (config.fields[fieldName] as unknown) as GraphQLField<any, any>,
+      )
+    ) {
       delete config.fields[fieldName];
     }
   });
@@ -77,7 +84,13 @@ function filterObjectFields(
 ): GraphQLObjectType {
   const config = toConfig(type);
   Object.keys(config.fields).forEach((fieldName) => {
-    if (!fieldFilter(type.name, fieldName, config.fields[fieldName])) {
+    if (
+      !fieldFilter(
+        type.name,
+        fieldName,
+        (config.fields[fieldName] as unknown) as GraphQLField<any, any>,
+      )
+    ) {
       delete config.fields[fieldName];
     }
   });

--- a/src/wrap/transforms/RenameTypes.ts
+++ b/src/wrap/transforms/RenameTypes.ts
@@ -63,23 +63,36 @@ export default class RenameTypes implements Transform {
           this.map[oldName] = newName;
           this.reverseMap[newName] = oldName;
 
-          const newConfig = {
-            ...toConfig(type),
-            name: newName,
-          };
-
           if (isObjectType(type)) {
-            return new GraphQLObjectType(newConfig);
+            return new GraphQLObjectType({
+              ...toConfig(type),
+              name: newName,
+            });
           } else if (isInterfaceType(type)) {
-            return new GraphQLInterfaceType(newConfig);
+            return new GraphQLInterfaceType({
+              ...toConfig(type),
+              name: newName,
+            });
           } else if (isUnionType(type)) {
-            return new GraphQLUnionType(newConfig);
+            return new GraphQLUnionType({
+              ...toConfig(type),
+              name: newName,
+            });
           } else if (isInputObjectType(type)) {
-            return new GraphQLInputObjectType(newConfig);
+            return new GraphQLInputObjectType({
+              ...toConfig(type),
+              name: newName,
+            });
           } else if (isEnumType(type)) {
-            return new GraphQLEnumType(newConfig);
+            return new GraphQLEnumType({
+              ...toConfig(type),
+              name: newName,
+            });
           } else if (isScalarType(type)) {
-            return new GraphQLScalarType(newConfig);
+            return new GraphQLScalarType({
+              ...toConfig(type),
+              name: newName,
+            });
           }
 
           throw new Error(`Unknown type ${type as string}.`);

--- a/src/wrap/transforms/TransformCompositeFields.ts
+++ b/src/wrap/transforms/TransformCompositeFields.ts
@@ -81,7 +81,10 @@ export default class TransformCompositeFields implements Transform {
     fieldTransformer: FieldTransformer,
   ): GraphQLInterfaceType;
 
-  private transformFields(type: any, fieldTransformer: FieldTransformer): any {
+  private transformFields(
+    type: GraphQLObjectType | GraphQLInterfaceType,
+    fieldTransformer: FieldTransformer,
+  ): any {
     const typeConfig = toConfig(type);
     const fields = type.getFields();
     const newFields = {};


### PR DESCRIPTION
It should also narrow return type when argument passed is a union of possible types.