### PR TITLE
Fix tests on windows

### DIFF
--- a/packages/load/tests/loaders/documents/documents-from-glob.spec.ts
+++ b/packages/load/tests/loaders/documents/documents-from-glob.spec.ts
@@ -11,7 +11,7 @@ describe('documentsFromGlob', () => {
     sync: loadDocumentsSync
   })(load => {
     test(`Should load one GraphQL document from glob expression`, async () => {
-      const glob = join(__dirname, './test-files/', '*.query.graphql');
+      const glob = join(__dirname, 'test-files', '*.query.graphql');
       const result = await load(glob, {
         loaders: [new GraphQLFileLoader()]
       });
@@ -20,7 +20,7 @@ describe('documentsFromGlob', () => {
     });
 
     test(`Should load multiple GraphQL document from glob expression`, async () => {
-      const glob = join(__dirname, './test-files/', '*.graphql');
+      const glob = join(__dirname, 'test-files', '*.graphql');
       const result = await load(glob, {
         loaders: [new GraphQLFileLoader()]
       });
@@ -30,7 +30,7 @@ describe('documentsFromGlob', () => {
     });
 
     test(`Should load two GraphQL documents both for gatsby and graphql-tag by default`, async () => {
-      const glob = join(__dirname, './test-files/', 'tags.js');
+      const glob = join(__dirname, 'test-files', 'tags.js');
       const result = await load(glob, {
         loaders: [new CodeFileLoader()]
       });
@@ -40,7 +40,7 @@ describe('documentsFromGlob', () => {
     });
 
     test(`Should load GraphQL documents that match custom settings`, async () => {
-      const glob = join(__dirname, './test-files/', 'tags.js');
+      const glob = join(__dirname, 'test-files', 'tags.js');
 
       const result = await load(glob, {
         pluckConfig: {
@@ -64,7 +64,7 @@ describe('documentsFromGlob', () => {
 
     test(`Should throw on empty files and empty result`, async () => {
       try {
-        const glob = join(__dirname, './test-files/', '*.empty.graphql');
+        const glob = join(__dirname, 'test-files', '*.empty.graphql');
         await load(glob, {
           loaders: [new GraphQLFileLoader()]
         });
@@ -76,7 +76,7 @@ describe('documentsFromGlob', () => {
 
     test(`Should throw on invalid files`, async () => {
       try {
-        const glob = join(__dirname, './test-files/', 'invalid*.*.graphql');
+        const glob = join(__dirname, 'test-files', 'invalid*.*.graphql');
         await load(glob, {
           loaders: [new GraphQLFileLoader()]
         });
@@ -87,7 +87,7 @@ describe('documentsFromGlob', () => {
     });
 
     test(`Should ignore schema definitions`, async () => {
-      const glob = join(__dirname, './test-files/', '*.graphql');
+      const glob = join(__dirname, 'test-files', '*.graphql');
       const result = await load(glob, {
         loaders: [new GraphQLFileLoader()]
       });
@@ -95,8 +95,8 @@ describe('documentsFromGlob', () => {
     });
 
     test(`Should ignore files that is added to ignore glob (using options.ignore)`, async () => {
-      const glob = join(__dirname, './test-files/', '*.graphql');
-      const ignoreGlob = join(__dirname, './test-files/', '*.query.graphql');
+      const glob = join(__dirname, 'test-files', '*.graphql');
+      const ignoreGlob = join(__dirname, 'test-files', '*.query.graphql');
       const result = await load([glob], {
         ignore: ignoreGlob,
         loaders: [new GraphQLFileLoader()]
@@ -105,16 +105,17 @@ describe('documentsFromGlob', () => {
     });
 
     test(`Should ignore files that is added to ignore glob (using negative glob)`, async () => {
-      const glob = join(__dirname, './test-files/', '*.graphql');
-      const ignoreGlob = `!(${join(__dirname, './test-files/', '*.query.graphql')})`;
+      const glob = join(__dirname, 'test-files', '*.graphql');
+      const ignoreGlob = `!(${join(__dirname, 'test-files', '*.query.graphql')})`;
       const result = await load([glob, ignoreGlob], {
         loaders: [new GraphQLFileLoader()]
       });
+      console.log(result);
       expect(result.length).toBe(1);
     });
 
     test(`should respect brackets in file path`, async () => {
-      const glob = join(__dirname, './test-with-brackets/', '**/*.ts');
+      const glob = join(__dirname, 'test-with-brackets', '**', '*.ts');
       const result = await load(glob, {
         loaders: [new CodeFileLoader()],
       });


### PR DESCRIPTION
yarn test returns successfully even on windows, but jest plugin within vscode errors with posix path separator.