### PR TITLE
use improved mapSchema to make schema package functions not modify existing schema

### DIFF
--- a/packages/delegate/src/transforms/FilterToSchema.ts
+++ b/packages/delegate/src/transforms/FilterToSchema.ts
@@ -19,10 +19,9 @@ import {
   getNamedType,
   isObjectType,
   isInterfaceType,
-  GraphQLNamedType,
 } from 'graphql';
 
-import { Transform, Request, implementsAbstractType } from '@graphql-tools/utils';
+import { Transform, Request, implementsAbstractType, TypeMap } from '@graphql-tools/utils';
 
 export default class FilterToSchema implements Transform {
   private readonly targetSchema: GraphQLSchema;
@@ -61,7 +60,7 @@ function filterToSchema(
     return Boolean(targetSchema.getType(typeName));
   });
 
-  const validFragmentsWithType: Record<string, GraphQLNamedType> = validFragments.reduce(
+  const validFragmentsWithType: TypeMap = validFragments.reduce(
     (prev, fragment) => ({
       ...prev,
       [fragment.name.value]: targetSchema.getType(fragment.typeCondition.name.value),

--- a/packages/merge/src/merge-schemas.ts
+++ b/packages/merge/src/merge-schemas.ts
@@ -74,11 +74,11 @@ function makeSchema(
   }: { resolvers: IResolvers; typeDefs: string | DocumentNode; extensions: SchemaExtensions },
   config: MergeSchemasConfig
 ) {
-  const schema = typeof typeDefs === 'string' ? buildSchema(typeDefs, config) : buildASTSchema(typeDefs, config);
+  let schema = typeof typeDefs === 'string' ? buildSchema(typeDefs, config) : buildASTSchema(typeDefs, config);
 
   // add resolvers
   if (resolvers) {
-    addResolversToSchema({
+    schema = addResolversToSchema({
       schema,
       resolvers,
       resolverValidationOptions: {
@@ -90,7 +90,7 @@ function makeSchema(
 
   // use logger
   if (config.logger) {
-    addErrorLoggingToSchema(schema, config.logger);
+    schema = addErrorLoggingToSchema(schema, config.logger);
   }
 
   // use schema directives

--- a/packages/mock/tests/mocking.spec.ts
+++ b/packages/mock/tests/mocking.spec.ts
@@ -123,9 +123,9 @@ describe('Mock', () => {
   });
 
   test('mocks the default types for you', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = {};
-    addMocksToSchema({ schema: jsSchema, mocks: mockMap });
+    jsSchema = addMocksToSchema({ schema: jsSchema, mocks: mockMap });
     const testQuery = `{
       returnInt
       returnFloat
@@ -184,13 +184,13 @@ describe('Mock', () => {
   });
 
   test('mockServer is able to preserveResolvers of a prebuilt schema', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const resolvers = {
       RootQuery: {
         returnString: () => 'someString',
       },
     };
-    addResolversToSchema(jsSchema, resolvers);
+    jsSchema = addResolversToSchema(jsSchema, resolvers);
     const testQuery = `{
       returnInt
       returnString
@@ -261,7 +261,7 @@ describe('Mock', () => {
   });
 
   test('does not mask resolveType functions if you tell it not to', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     let spy = 0;
     const resolvers = {
       BirdsAndBees: {
@@ -271,8 +271,8 @@ describe('Mock', () => {
         },
       },
     };
-    addResolversToSchema(jsSchema, resolvers);
-    addMocksToSchema({
+    jsSchema = addResolversToSchema(jsSchema, resolvers);
+    jsSchema = addMocksToSchema({
       schema: jsSchema,
       mocks: {},
       preserveResolvers: true,
@@ -297,9 +297,9 @@ describe('Mock', () => {
 
   // TODO test mockServer with precompiled schema
   test('can mock Enum', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = {};
-    addMocksToSchema({ schema: jsSchema, mocks: mockMap });
+    jsSchema = addMocksToSchema({ schema: jsSchema, mocks: mockMap });
     const testQuery = `{
       returnEnum
     }`;
@@ -309,11 +309,11 @@ describe('Mock', () => {
   });
 
   test('can mock Enum with a certain value', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = {
       SomeEnum: () => 'C',
     };
-    addMocksToSchema({ schema: jsSchema, mocks: mockMap });
+    jsSchema = addMocksToSchema({ schema: jsSchema, mocks: mockMap });
     const testQuery = `{
       returnEnum
     }`;
@@ -323,8 +323,8 @@ describe('Mock', () => {
   });
 
   test('can mock Unions', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
-    addResolversToSchema(jsSchema, resolveFunctions);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    jsSchema = addResolversToSchema(jsSchema, resolveFunctions);
     const mockMap = {
       Int: () => 10,
       String: () => 'aha',
@@ -333,7 +333,7 @@ describe('Mock', () => {
         returnBirdsAndBees: () => new MockList(40),
       }),
     };
-    addMocksToSchema({ schema: jsSchema, mocks: mockMap });
+    jsSchema = addMocksToSchema({ schema: jsSchema, mocks: mockMap });
     const testQuery = `{
       returnBirdsAndBees {
         ... on Bird {
@@ -364,8 +364,8 @@ describe('Mock', () => {
   });
 
   test('can mock Interfaces by default', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
-    addResolversToSchema(jsSchema, resolveFunctions);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    jsSchema = addResolversToSchema(jsSchema, resolveFunctions);
     const mockMap = {
       Int: () => 10,
       String: () => 'aha',
@@ -374,7 +374,7 @@ describe('Mock', () => {
         returnFlying: () => new MockList(40),
       }),
     };
-    addMocksToSchema({
+    jsSchema = addMocksToSchema({
       schema: jsSchema,
       mocks: mockMap,
       preserveResolvers: true,
@@ -408,9 +408,9 @@ describe('Mock', () => {
   });
 
   it('can mock nullable Interfaces', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
 
-    addResolversToSchema(jsSchema, resolveFunctions);
+    jsSchema = addResolversToSchema(jsSchema, resolveFunctions);
 
     const mockMap = {
       Bird: (): null => null,
@@ -426,7 +426,7 @@ describe('Mock', () => {
       },
     };
 
-    addMocksToSchema({
+    jsSchema = addMocksToSchema({
       schema: jsSchema,
       mocks: mockMap,
       preserveResolvers: true,
@@ -444,8 +444,8 @@ describe('Mock', () => {
   });
 
   test('can support explicit Interface mock', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
-    addResolversToSchema(jsSchema, resolveFunctions);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    jsSchema = addResolversToSchema(jsSchema, resolveFunctions);
     let spy = 0;
     const mockMap = {
       Bird: (_root: any, args: any) => ({
@@ -466,7 +466,7 @@ describe('Mock', () => {
         return { __typename };
       },
     };
-    addMocksToSchema({
+    jsSchema = addMocksToSchema({
       schema: jsSchema,
       mocks: mockMap,
       preserveResolvers: true,
@@ -488,8 +488,8 @@ describe('Mock', () => {
   });
 
   test('can support explicit UnionType mock', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
-    addResolversToSchema(jsSchema, resolveFunctions);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    jsSchema = addResolversToSchema(jsSchema, resolveFunctions);
     let spy = 0;
     const mockMap = {
       Bird: (_root: any, args: any) => ({
@@ -509,7 +509,7 @@ describe('Mock', () => {
         };
       },
     };
-    addMocksToSchema({
+    jsSchema = addMocksToSchema({
       schema: jsSchema,
       mocks: mockMap,
       preserveResolvers: true,
@@ -533,8 +533,8 @@ describe('Mock', () => {
   });
 
   test('throws an error when __typename is not returned within an explicit interface mock', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
-    addResolversToSchema(jsSchema, resolveFunctions);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    jsSchema = addResolversToSchema(jsSchema, resolveFunctions);
     const mockMap = {
       Bird: (_root: any, args: any) => ({
         id: args.id,
@@ -546,7 +546,7 @@ describe('Mock', () => {
       }),
       Flying: (_root: any, _args: any) => ({}),
     };
-    addMocksToSchema({ schema: jsSchema, mocks: mockMap });
+    jsSchema = addMocksToSchema({ schema: jsSchema, mocks: mockMap });
     const testQuery = `{
           node(id:"bee:123456"){
             id,
@@ -560,9 +560,9 @@ describe('Mock', () => {
   });
 
   test('throws an error in resolve if mock type is not defined', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = {};
-    addMocksToSchema({ schema: jsSchema, mocks: mockMap });
+    jsSchema = addMocksToSchema({ schema: jsSchema, mocks: mockMap });
     const testQuery = `{
       returnMockError
     }`;
@@ -573,7 +573,7 @@ describe('Mock', () => {
   });
 
   test('throws an error in resolve if mock type is not defined and resolver failed', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const resolvers = {
       MissingMockType: {
         __serialize: (val: string) => val,
@@ -584,10 +584,10 @@ describe('Mock', () => {
         returnMockError: (): string => undefined,
       },
     };
-    addResolversToSchema(jsSchema, resolvers);
+    jsSchema = addResolversToSchema(jsSchema, resolvers);
 
     const mockMap = {};
-    addMocksToSchema({
+    jsSchema = addMocksToSchema({
       schema: jsSchema,
       mocks: mockMap,
       preserveResolvers: true,
@@ -602,7 +602,7 @@ describe('Mock', () => {
   });
 
   test('can preserve scalar resolvers', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const resolvers = {
       MissingMockType: {
         __serialize: (val: string) => val,
@@ -613,7 +613,7 @@ describe('Mock', () => {
         returnMockError: () => '10-11-2012',
       },
     };
-    addResolversToSchema(jsSchema, resolvers);
+    jsSchema = addResolversToSchema(jsSchema, resolvers);
 
     const mockMap = {};
     addMocksToSchema({
@@ -634,9 +634,9 @@ describe('Mock', () => {
   });
 
   test('can mock an Int', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = { Int: () => 55 };
-    addMocksToSchema({ schema: jsSchema, mocks: mockMap });
+    jsSchema = addMocksToSchema({ schema: jsSchema, mocks: mockMap });
     const testQuery = `{
       returnInt
     }`;
@@ -646,9 +646,9 @@ describe('Mock', () => {
   });
 
   test('can mock a Float', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = { Float: () => 55.5 };
-    addMocksToSchema({ schema: jsSchema, mocks: mockMap });
+    jsSchema = addMocksToSchema({ schema: jsSchema, mocks: mockMap });
     const testQuery = `{
       returnFloat
     }`;
@@ -657,9 +657,9 @@ describe('Mock', () => {
     });
   });
   test('can mock a String', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = { String: () => 'a string' };
-    addMocksToSchema({ schema: jsSchema, mocks: mockMap });
+    jsSchema = addMocksToSchema({ schema: jsSchema, mocks: mockMap });
     const testQuery = `{
       returnString
     }`;
@@ -668,9 +668,9 @@ describe('Mock', () => {
     });
   });
   test('can mock a Boolean', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = { Boolean: () => true };
-    addMocksToSchema({ schema: jsSchema, mocks: mockMap });
+    jsSchema = addMocksToSchema({ schema: jsSchema, mocks: mockMap });
     const testQuery = `{
       returnBoolean
     }`;
@@ -679,9 +679,9 @@ describe('Mock', () => {
     });
   });
   test('can mock an ID', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = { ID: () => 'ea5bdc19' };
-    addMocksToSchema({ schema: jsSchema, mocks: mockMap });
+    jsSchema = addMocksToSchema({ schema: jsSchema, mocks: mockMap });
     const testQuery = `{
       returnID
     }`;
@@ -690,9 +690,9 @@ describe('Mock', () => {
     });
   });
   test('nullable type is nullable', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = { String: (): null => null };
-    addMocksToSchema({ schema: jsSchema, mocks: mockMap });
+    jsSchema = addMocksToSchema({ schema: jsSchema, mocks: mockMap });
     const testQuery = `{
       returnNullableString
     }`;
@@ -701,9 +701,9 @@ describe('Mock', () => {
     });
   });
   test('can mock a nonNull type', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = { String: () => 'nonnull' };
-    addMocksToSchema({ schema: jsSchema, mocks: mockMap });
+    jsSchema = addMocksToSchema({ schema: jsSchema, mocks: mockMap });
     const testQuery = `{
       returnNonNullString
     }`;
@@ -712,9 +712,9 @@ describe('Mock', () => {
     });
   });
   test('nonNull type is not nullable', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = { String: (): null => null };
-    addMocksToSchema({ schema: jsSchema, mocks: mockMap });
+    jsSchema = addMocksToSchema({ schema: jsSchema, mocks: mockMap });
     const testQuery = `{
       returnNonNullString
     }`;
@@ -724,12 +724,12 @@ describe('Mock', () => {
     });
   });
   test('can mock object types', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = {
       String: () => 'abc',
       Int: () => 123,
     };
-    addMocksToSchema({ schema: jsSchema, mocks: mockMap });
+    jsSchema = addMocksToSchema({ schema: jsSchema, mocks: mockMap });
     const testQuery = `{
       returnObject { returnInt, returnString }
     }`;
@@ -742,9 +742,9 @@ describe('Mock', () => {
   });
 
   test('can mock a list of ints', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = { Int: () => 123 };
-    addMocksToSchema({ schema: jsSchema, mocks: mockMap });
+    jsSchema = addMocksToSchema({ schema: jsSchema, mocks: mockMap });
     const testQuery = `{
       returnListOfInt
     }`;
@@ -757,12 +757,12 @@ describe('Mock', () => {
   });
 
   test('can mock a list of lists of objects', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = {
       String: () => 'a',
       Int: () => 1,
     };
-    addMocksToSchema({ schema: jsSchema, mocks: mockMap });
+    jsSchema = addMocksToSchema({ schema: jsSchema, mocks: mockMap });
     const testQuery = `{
       returnListOfListOfObject { returnInt, returnString }
     }`;
@@ -784,7 +784,7 @@ describe('Mock', () => {
   });
 
   test('does not mask resolvers if you tell it not to', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = {
       RootQuery: () => ({
         returnInt: (_root: any, _args: Record<string, any>) => 42, // a) in resolvers, will not be used
@@ -799,8 +799,8 @@ describe('Mock', () => {
         returnString: () => Promise.resolve('bar'), // see c)
       },
     };
-    addResolversToSchema(jsSchema, resolvers);
-    addMocksToSchema({
+    jsSchema = addResolversToSchema(jsSchema, resolvers);
+    jsSchema = addMocksToSchema({
       schema: jsSchema,
       mocks: mockMap,
       preserveResolvers: true,
@@ -821,7 +821,7 @@ describe('Mock', () => {
   });
 
   test('lets you mock non-leaf types conveniently', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = {
       Bird: () => ({
         returnInt: 12,
@@ -829,7 +829,7 @@ describe('Mock', () => {
       }),
       Int: () => 15,
     };
-    addMocksToSchema({ schema: jsSchema, mocks: mockMap });
+    jsSchema = addMocksToSchema({ schema: jsSchema, mocks: mockMap });
     const testQuery = `{
       returnObject{
         returnInt
@@ -850,7 +850,7 @@ describe('Mock', () => {
   });
 
   test('lets you mock and resolve non-leaf types concurrently', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const resolvers = {
       RootQuery: {
         returnListOfInt: () => [1, 2, 3],
@@ -860,7 +860,7 @@ describe('Mock', () => {
         }),
       },
     };
-    addResolversToSchema(jsSchema, resolvers);
+    jsSchema = addResolversToSchema(jsSchema, resolvers);
     const mockMap = {
       returnListOfInt: () => [5, 6, 7],
       Bird: () => ({
@@ -868,7 +868,7 @@ describe('Mock', () => {
         returnString: 'woot!?', // b) another part of a Bird
       }),
     };
-    addMocksToSchema({
+    jsSchema = addMocksToSchema({
       schema: jsSchema,
       mocks: mockMap,
       preserveResolvers: true,
@@ -893,7 +893,7 @@ describe('Mock', () => {
   });
 
   test('lets you mock and resolve non-leaf types concurrently, support promises', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const resolvers = {
       RootQuery: {
         returnObject: () =>
@@ -903,14 +903,14 @@ describe('Mock', () => {
           }),
       },
     };
-    addResolversToSchema(jsSchema, resolvers);
+    jsSchema = addResolversToSchema(jsSchema, resolvers);
     const mockMap = {
       Bird: () => ({
         returnInt: 3, // see a)
         returnString: 'woot!?', // b) another part of a Bird
       }),
     };
-    addMocksToSchema({
+    jsSchema = addMocksToSchema({
       schema: jsSchema,
       mocks: mockMap,
       preserveResolvers: true,
@@ -933,7 +933,7 @@ describe('Mock', () => {
   });
 
   test('lets you mock and resolve non-leaf types concurrently, support defineProperty', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const objProxy = {};
     Object.defineProperty(
       objProxy,
@@ -945,14 +945,14 @@ describe('Mock', () => {
         returnObject: () => objProxy,
       },
     };
-    addResolversToSchema(jsSchema, resolvers);
+    jsSchema = addResolversToSchema(jsSchema, resolvers);
     const mockMap = {
       Bird: () => ({
         returnInt: 3, // see a)
         returnString: 'woot!?', // b) another part of a Bird
       }),
     };
-    addMocksToSchema({
+    jsSchema = addMocksToSchema({
       schema: jsSchema,
       mocks: mockMap,
       preserveResolvers: true,
@@ -980,7 +980,7 @@ describe('Mock', () => {
         returnString: () => 'woot!?', // a) resolve of a string
       },
     };
-    const jsSchema = makeExecutableSchema({
+    let jsSchema = makeExecutableSchema({
       typeDefs: [shorthand],
       resolvers,
       resolverValidationOptions: {
@@ -993,7 +993,7 @@ describe('Mock', () => {
     const mockMap = {
       Int: () => 123, // b) mock of Int.
     };
-    addMocksToSchema({
+    jsSchema = addMocksToSchema({
       schema: jsSchema,
       mocks: mockMap,
       preserveResolvers: true,
@@ -1018,17 +1018,17 @@ describe('Mock', () => {
   });
 
   test('let you resolve null with mocking and preserving resolvers', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const resolvers = {
       RootQuery: {
         returnString: (): string => null, // a) resolve of a string
       },
     };
-    addResolversToSchema(jsSchema, resolvers);
+    jsSchema = addResolversToSchema(jsSchema, resolvers);
     const mockMap = {
       Int: () => 666, // b) mock of Int.
     };
-    addMocksToSchema({
+    jsSchema = addMocksToSchema({
       schema: jsSchema,
       mocks: mockMap,
       preserveResolvers: true,
@@ -1053,13 +1053,13 @@ describe('Mock', () => {
   });
 
   test('lets you mock root query fields', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = {
       RootQuery: () => ({
         returnStringArgument: (_o: any, a: Record<string, any>) => a.s,
       }),
     };
-    addMocksToSchema({ schema: jsSchema, mocks: mockMap });
+    jsSchema = addMocksToSchema({ schema: jsSchema, mocks: mockMap });
     const testQuery = `{
       returnStringArgument(s: "adieu")
     }`;
@@ -1072,13 +1072,13 @@ describe('Mock', () => {
   });
 
   test('lets you mock root mutation fields', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = {
       RootMutation: () => ({
         returnStringArgument: (_o: any, a: Record<string, any>) => a.s,
       }),
     };
-    addMocksToSchema({ schema: jsSchema, mocks: mockMap });
+    jsSchema = addMocksToSchema({ schema: jsSchema, mocks: mockMap });
     const testQuery = `mutation {
       returnStringArgument(s: "adieu")
     }`;
@@ -1091,12 +1091,12 @@ describe('Mock', () => {
   });
 
   test('lets you mock a list of a certain length', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = {
       RootQuery: () => ({ returnListOfInt: () => new MockList(3) }),
       Int: () => 12,
     };
-    addMocksToSchema({ schema: jsSchema, mocks: mockMap });
+    jsSchema = addMocksToSchema({ schema: jsSchema, mocks: mockMap });
     const testQuery = `{
       returnListOfInt
     }`;
@@ -1109,12 +1109,12 @@ describe('Mock', () => {
   });
 
   test('lets you mock a list of a random length', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = {
       RootQuery: () => ({ returnListOfInt: () => new MockList([10, 20]) }),
       Int: () => 12,
     };
-    addMocksToSchema({ schema: jsSchema, mocks: mockMap });
+    jsSchema = addMocksToSchema({ schema: jsSchema, mocks: mockMap });
     const testQuery = `{
       returnListOfInt
     }`;
@@ -1126,7 +1126,7 @@ describe('Mock', () => {
   });
 
   test('lets you mock a list of specific variable length', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = {
       RootQuery: () => ({
         returnListOfIntArg: (_o: any, a: Record<string, any>) =>
@@ -1134,7 +1134,7 @@ describe('Mock', () => {
       }),
       Int: () => 12,
     };
-    addMocksToSchema({ schema: jsSchema, mocks: mockMap });
+    jsSchema = addMocksToSchema({ schema: jsSchema, mocks: mockMap });
     const testQuery = `{
       l3: returnListOfIntArg(l: 3)
       l5: returnListOfIntArg(l: 5)
@@ -1146,14 +1146,14 @@ describe('Mock', () => {
   });
 
   test('lets you provide a function for your MockList', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = {
       RootQuery: () => ({
         returnListOfInt: () => new MockList(2, () => 33),
       }),
       Int: () => 12,
     };
-    addMocksToSchema({ schema: jsSchema, mocks: mockMap });
+    jsSchema = addMocksToSchema({ schema: jsSchema, mocks: mockMap });
     const testQuery = `{
       returnListOfInt
     }`;
@@ -1175,14 +1175,14 @@ describe('Mock', () => {
   });
 
   test('lets you nest MockList in MockList', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = {
       RootQuery: () => ({
         returnListOfListOfInt: () => new MockList(2, () => new MockList(3)),
       }),
       Int: () => 12,
     };
-    addMocksToSchema({ schema: jsSchema, mocks: mockMap });
+    jsSchema = addMocksToSchema({ schema: jsSchema, mocks: mockMap });
     const testQuery = `{
       returnListOfListOfInt
     }`;
@@ -1198,7 +1198,7 @@ describe('Mock', () => {
   });
 
   test('lets you use arguments in nested MockList', () => {
-    const jsSchema = buildSchemaFromTypeDefinitions(shorthand);
+    let jsSchema = buildSchemaFromTypeDefinitions(shorthand);
     const mockMap = {
       RootQuery: () => ({
         returnListOfListOfIntArg: () =>
@@ -1209,7 +1209,7 @@ describe('Mock', () => {
       }),
       Int: () => 12,
     };
-    addMocksToSchema({ schema: jsSchema, mocks: mockMap });
+    jsSchema = addMocksToSchema({ schema: jsSchema, mocks: mockMap });
     const testQuery = `{
       returnListOfListOfIntArg(l: 1)
     }`;
@@ -1248,7 +1248,7 @@ describe('Mock', () => {
         query: RootQuery
       }
     `;
-    const jsSchema = buildSchemaFromTypeDefinitions(short);
+    let jsSchema = buildSchemaFromTypeDefinitions(short);
     const ITEMS_PER_PAGE = 2;
     // This mock map demonstrates default merging on objects and nested lists.
     // thread on root query will have id a.id, and missing properties
@@ -1278,7 +1278,7 @@ describe('Mock', () => {
       }),
       Int: () => 123,
     };
-    addMocksToSchema({ schema: jsSchema, mocks: mockMap });
+    jsSchema = addMocksToSchema({ schema: jsSchema, mocks: mockMap });
     const testQuery = `query abc{
       thread(id: "67"){
         id
@@ -1338,12 +1338,12 @@ describe('Mock', () => {
       },
     };
 
-    const schema = makeExecutableSchema({
+    let schema = makeExecutableSchema({
       typeDefs,
       resolvers,
     });
 
-    addMocksToSchema({
+    schema = addMocksToSchema({
       schema,
       mocks: {
         Date: () => new Date('2016-05-04'),
@@ -1418,12 +1418,12 @@ describe('Mock', () => {
       },
     };
 
-    const schema = makeExecutableSchema({
+    let schema = makeExecutableSchema({
       typeDefs,
       resolvers,
     });
 
-    addMocksToSchema({
+    schema = addMocksToSchema({
       schema,
       preserveResolvers: true,
     });
@@ -1481,7 +1481,7 @@ describe('Mock', () => {
       },
     };
 
-    const schema = makeExecutableSchema({
+    let schema = makeExecutableSchema({
       typeDefs,
       resolvers,
     });
@@ -1491,7 +1491,7 @@ describe('Mock', () => {
       DateTime: () => '2000-01-01T00:00:00.270Z',
     };
 
-    addMocksToSchema({
+    schema = addMocksToSchema({
       schema,
       mocks,
       preserveResolvers: true,
@@ -1536,7 +1536,7 @@ describe('Mock', () => {
       }),
     };
 
-    const schema = buildSchema(/* GraphQL */ `
+    let schema = buildSchema(/* GraphQL */ `
       scalar Date
       type Review {
         sentence: String
@@ -1550,7 +1550,7 @@ describe('Mock', () => {
       }
     `);
 
-    addMocksToSchema({ schema, mocks });
+    schema = addMocksToSchema({ schema, mocks });
 
     const result = await graphql({
       schema,

--- a/packages/schema/src/addCatchUndefinedToSchema.ts
+++ b/packages/schema/src/addCatchUndefinedToSchema.ts
@@ -1,5 +1,5 @@
 import { GraphQLFieldResolver, defaultFieldResolver, GraphQLSchema } from 'graphql';
-import { forEachField } from '@graphql-tools/utils';
+import { mapSchema, MapperKind } from '@graphql-tools/utils';
 
 function decorateToCatchUndefined(fn: GraphQLFieldResolver<any, any>, hint: string): GraphQLFieldResolver<any, any> {
   const resolve = fn == null ? defaultFieldResolver : fn;
@@ -12,9 +12,11 @@ function decorateToCatchUndefined(fn: GraphQLFieldResolver<any, any>, hint: stri
   };
 }
 
-export function addCatchUndefinedToSchema(schema: GraphQLSchema): void {
-  forEachField(schema, (field, typeName, fieldName) => {
-    const errorHint = `${typeName}.${fieldName}`;
-    field.resolve = decorateToCatchUndefined(field.resolve, errorHint);
+export function addCatchUndefinedToSchema(schema: GraphQLSchema): GraphQLSchema {
+  return mapSchema(schema, {
+    [MapperKind.OBJECT_FIELD]: (fieldConfig, fieldName, typeName) => ({
+      ...fieldConfig,
+      resolve: decorateToCatchUndefined(fieldConfig.resolve, `${typeName}.${fieldName}`),
+    }),
   });
 }

--- a/packages/schema/src/addErrorLoggingToSchema.ts
+++ b/packages/schema/src/addErrorLoggingToSchema.ts
@@ -1,17 +1,19 @@
 import { GraphQLSchema } from 'graphql';
-import { forEachField } from '@graphql-tools/utils';
+import { mapSchema, MapperKind } from '@graphql-tools/utils';
 import { decorateWithLogger } from './decorateWithLogger';
 import { ILogger } from './types';
 
-export function addErrorLoggingToSchema(schema: GraphQLSchema, logger?: ILogger): void {
+export function addErrorLoggingToSchema(schema: GraphQLSchema, logger?: ILogger): GraphQLSchema {
   if (!logger) {
     throw new Error('Must provide a logger');
   }
   if (typeof logger.log !== 'function') {
     throw new Error('Logger.log must be a function');
   }
-  forEachField(schema, (field, typeName, fieldName) => {
-    const errorHint = `${typeName}.${fieldName}`;
-    field.resolve = decorateWithLogger(field.resolve, logger, errorHint);
+  return mapSchema(schema, {
+    [MapperKind.OBJECT_FIELD]: (fieldConfig, fieldName, typeName) => ({
+      ...fieldConfig,
+      resolve: decorateWithLogger(fieldConfig.resolve, logger, `${typeName}.${fieldName}`),
+    }),
   });
 }

--- a/packages/schema/src/extendResolversFromInterfaces.ts
+++ b/packages/schema/src/extendResolversFromInterfaces.ts
@@ -2,7 +2,7 @@ import { GraphQLSchema } from 'graphql';
 
 import { IResolvers, IObjectTypeResolver } from '@graphql-tools/utils';
 
-export function extendResolversFromInterfaces(schema: GraphQLSchema, resolvers: IResolvers) {
+export function extendResolversFromInterfaces(schema: GraphQLSchema, resolvers: IResolvers): IResolvers {
   const typeNames = Object.keys({
     ...schema.getTypeMap(),
     ...resolvers,

--- a/packages/schema/src/makeExecutableSchema.ts
+++ b/packages/schema/src/makeExecutableSchema.ts
@@ -36,9 +36,9 @@ export function makeExecutableSchema<TContext = any>({
 
   // Arguments are now validated and cleaned up
 
-  const schema = buildSchemaFromTypeDefinitions(typeDefs, parseOptions);
+  let schema = buildSchemaFromTypeDefinitions(typeDefs, parseOptions);
 
-  addResolversToSchema({
+  schema = addResolversToSchema({
     schema,
     resolvers: resolverMap,
     resolverValidationOptions,
@@ -48,19 +48,21 @@ export function makeExecutableSchema<TContext = any>({
   assertResolversPresent(schema, resolverValidationOptions);
 
   if (!allowUndefinedInResolve) {
-    addCatchUndefinedToSchema(schema);
+    schema = addCatchUndefinedToSchema(schema);
   }
 
   if (logger != null) {
-    addErrorLoggingToSchema(schema, logger);
+    schema = addErrorLoggingToSchema(schema, logger);
   }
 
   if (typeof resolvers['__schema'] === 'function') {
     // TODO a bit of a hack now, better rewrite generateSchema to attach it there.
     // not doing that now, because I'd have to rewrite a lot of tests.
-    addSchemaLevelResolver(schema, resolvers['__schema'] as GraphQLFieldResolver<any, any>);
+    schema = addSchemaLevelResolver(schema, resolvers['__schema'] as GraphQLFieldResolver<any, any>);
   }
 
+  // directive resolvers are implemented using SchemaDirectiveVisitor.visitSchemaDirectives
+  // schema visiting modifies the schema in place
   if (directiveResolvers != null) {
     attachDirectiveResolvers(schema, directiveResolvers);
   }

--- a/packages/schema/tests/resolution.test.ts
+++ b/packages/schema/tests/resolution.test.ts
@@ -50,9 +50,9 @@ describe('Resolve', () => {
         },
       },
     };
-    const schema = makeExecutableSchema({ typeDefs, resolvers });
+    let schema = makeExecutableSchema({ typeDefs, resolvers });
     let schemaLevelResolverCalls = 0;
-    addSchemaLevelResolver(schema, (root) => {
+    schema = addSchemaLevelResolver(schema, (root) => {
       schemaLevelResolverCalls += 1;
       return root;
     });

--- a/packages/schema/tests/schemaGenerator.test.ts
+++ b/packages/schema/tests/schemaGenerator.test.ts
@@ -815,7 +815,7 @@ describe('generating schema from shorthand', () => {
           foo: () => ({ aField: true }),
         },
       };
-      const jsSchema = makeExecutableSchema({
+      let jsSchema = makeExecutableSchema({
         typeDefs: shorthand,
         resolvers: resolveFunctions,
       });
@@ -828,7 +828,7 @@ describe('generating schema from shorthand', () => {
       `;
       const result = graphqlSync(jsSchema, testQuery);
       expect(result.data.foo.aField).toBe(false);
-      addResolversToSchema({
+      jsSchema = addResolversToSchema({
         schema: jsSchema,
         resolvers: {
           Boolean: {
@@ -1338,12 +1338,12 @@ describe('generating schema from shorthand', () => {
         },
       };
 
-      const jsSchema = makeExecutableSchema({
+      let jsSchema = makeExecutableSchema({
         typeDefs: shorthand,
         resolvers: resolveFunctions,
       });
 
-      addResolversToSchema({
+      jsSchema = addResolversToSchema({
         schema: jsSchema,
         resolvers: {
           Color: {
@@ -1907,12 +1907,12 @@ describe('Add error logging to schema', () => {
 describe('Attaching external data fetchers to schema', () => {
   describe('Schema level resolver', () => {
     test('actually runs', () => {
-      const jsSchema = makeExecutableSchema({
+      let jsSchema = makeExecutableSchema({
         typeDefs: testSchema,
         resolvers: testResolvers,
       });
       const rootResolver = () => ({ species: 'ROOT' });
-      addSchemaLevelResolver(jsSchema, rootResolver);
+      jsSchema = addSchemaLevelResolver(jsSchema, rootResolver);
       const query = `{
         species(name: "strix")
       }`;
@@ -1922,12 +1922,12 @@ describe('Attaching external data fetchers to schema', () => {
     });
 
     test('can wrap fields that do not have a resolver defined', () => {
-      const jsSchema = makeExecutableSchema({
+      let jsSchema = makeExecutableSchema({
         typeDefs: testSchema,
         resolvers: testResolvers,
       });
       const rootResolver = () => ({ stuff: 'stuff' });
-      addSchemaLevelResolver(jsSchema, rootResolver);
+      jsSchema = addSchemaLevelResolver(jsSchema, rootResolver);
       const query = `{
         stuff
       }`;
@@ -1945,7 +1945,7 @@ describe('Attaching external data fetchers to schema', () => {
             (root.species as string) + name,
         },
       };
-      const jsSchema = makeExecutableSchema({
+      let jsSchema = makeExecutableSchema({
         typeDefs: testSchema,
         resolvers: simpleResolvers,
       });
@@ -1957,7 +1957,7 @@ describe('Attaching external data fetchers to schema', () => {
         }
         return { stuff: 'EEE', species: 'EEE' };
       };
-      addSchemaLevelResolver(jsSchema, rootResolver);
+      jsSchema = addSchemaLevelResolver(jsSchema, rootResolver);
       const query = `{
         species(name: "strix")
         stuff
@@ -1980,7 +1980,7 @@ describe('Attaching external data fetchers to schema', () => {
             (root.species as string) + name,
         },
       };
-      const jsSchema = makeExecutableSchema({
+      let jsSchema = makeExecutableSchema({
         typeDefs: testSchema,
         resolvers: simpleResolvers,
       });
@@ -1996,7 +1996,7 @@ describe('Attaching external data fetchers to schema', () => {
         }
         return { stuff: 'EEE', species: 'EEE' };
       };
-      addSchemaLevelResolver(jsSchema, rootResolver);
+      jsSchema = addSchemaLevelResolver(jsSchema, rootResolver);
       const query = `{
         species(name: "strix")
         stuff
@@ -2018,14 +2018,14 @@ describe('Attaching external data fetchers to schema', () => {
     });
 
     test('can attach things to context', () => {
-      const jsSchema = makeExecutableSchema({
+      let jsSchema = makeExecutableSchema({
         typeDefs: testSchema,
         resolvers: testResolvers,
       });
       const rootResolver = (_o: any, _a: Record<string, any>, ctx: any) => {
         ctx.usecontext = 'ABC';
       };
-      addSchemaLevelResolver(jsSchema, rootResolver);
+      jsSchema = addSchemaLevelResolver(jsSchema, rootResolver);
       const query = `{
         usecontext
       }`;

--- a/packages/stitch/src/stitchSchemas.ts
+++ b/packages/stitch/src/stitchSchemas.ts
@@ -132,7 +132,7 @@ export function stitchSchemas({
 
   mergeInfo = completeMergeInfo(mergeInfo, finalResolvers);
 
-  addResolversToSchema({
+  schema = addResolversToSchema({
     schema,
     resolvers: finalResolvers,
     resolverValidationOptions,
@@ -144,17 +144,17 @@ export function stitchSchemas({
   schema = addMergeInfo(schema, mergeInfo);
 
   if (!allowUndefinedInResolve) {
-    addCatchUndefinedToSchema(schema);
+    schema = addCatchUndefinedToSchema(schema);
   }
 
   if (logger != null) {
-    addErrorLoggingToSchema(schema, logger);
+    schema = addErrorLoggingToSchema(schema, logger);
   }
 
   if (typeof finalResolvers['__schema'] === 'function') {
     // TODO a bit of a hack now, better rewrite generateSchema to attach it there.
     // not doing that now, because I'd have to rewrite a lot of tests.
-    addSchemaLevelResolver(schema, finalResolvers['__schema']);
+    schema = addSchemaLevelResolver(schema, finalResolvers['__schema']);
   }
 
   if (directiveResolvers != null) {

--- a/packages/stitch/src/typeCandidates.ts
+++ b/packages/stitch/src/typeCandidates.ts
@@ -34,6 +34,7 @@ import {
 
 import typeFromAST from './typeFromAST';
 import { MergeTypeCandidate, MergeTypeFilter, OnTypeConflict, MergeInfo } from './types';
+import { TypeMap } from '@graphql-tools/utils';
 
 type CandidateSelector = (candidates: Array<MergeTypeCandidate>) => MergeTypeCandidate;
 
@@ -202,8 +203,8 @@ export function buildTypeMap({
   mergeInfo: MergeInfo;
   onTypeConflict: OnTypeConflict;
   operationTypeNames: Record<string, any>;
-}): Record<string, GraphQLNamedType> {
-  const typeMap: Record<string, GraphQLNamedType> = Object.create(null);
+}): TypeMap {
+  const typeMap: TypeMap = Object.create(null);
 
   Object.keys(typeCandidates).forEach(typeName => {
     if (

--- a/packages/stitch/tests/example.test.ts
+++ b/packages/stitch/tests/example.test.ts
@@ -7,7 +7,7 @@ import { stitchSchemas } from '@graphql-tools/stitch';
 
 describe('basic stitching example', () => {
   test('works', async () => {
-    const chirpSchema = makeExecutableSchema({
+    let chirpSchema = makeExecutableSchema({
       typeDefs: `
         type Chirp {
           id: ID!
@@ -22,10 +22,10 @@ describe('basic stitching example', () => {
       `
     });
 
-    addMocksToSchema({ schema: chirpSchema });
+    chirpSchema = addMocksToSchema({ schema: chirpSchema });
 
     // Mocked author schema
-    const authorSchema = makeExecutableSchema({
+    let authorSchema = makeExecutableSchema({
       typeDefs: `
         type User {
           id: ID!
@@ -38,7 +38,7 @@ describe('basic stitching example', () => {
       `
     });
 
-    addMocksToSchema({ schema: authorSchema });
+    authorSchema = addMocksToSchema({ schema: authorSchema });
 
     const linkTypeDefs = `
       extend type User {
@@ -116,7 +116,7 @@ describe('basic stitching example', () => {
 describe('stitching to interfaces', () => {
   let stitchedSchema: GraphQLSchema;
   beforeAll(() => {
-    const chirpSchema = makeExecutableSchema({
+    let chirpSchema = makeExecutableSchema({
       typeDefs: `
         interface Node {
           id: ID!
@@ -135,9 +135,9 @@ describe('stitching to interfaces', () => {
       `
     });
 
-    addMocksToSchema({ schema: chirpSchema });
+    chirpSchema = addMocksToSchema({ schema: chirpSchema });
 
-    const authorSchema = makeExecutableSchema({
+    let authorSchema = makeExecutableSchema({
       typeDefs: `
         interface Node {
           id: ID!
@@ -154,7 +154,7 @@ describe('stitching to interfaces', () => {
       `
     });
 
-    addMocksToSchema({ schema: authorSchema });
+    authorSchema = addMocksToSchema({ schema: authorSchema });
 
     const linkTypeDefs = `
       extend type User {

--- a/packages/stitch/tests/stitchSchemas.test.ts
+++ b/packages/stitch/tests/stitchSchemas.test.ts
@@ -2988,7 +2988,7 @@ fragment BookingFragment on Booking {
 
   describe('new root type name', () => {
     test('works', async () => {
-      const bookSchema = makeExecutableSchema({
+      let bookSchema = makeExecutableSchema({
         typeDefs: `
           type Query {
             book: Book
@@ -2999,7 +2999,7 @@ fragment BookingFragment on Booking {
         `,
       });
 
-      const movieSchema = makeExecutableSchema({
+      let movieSchema = makeExecutableSchema({
         typeDefs: `
           type Query {
             movie: Movie
@@ -3011,8 +3011,8 @@ fragment BookingFragment on Booking {
         `,
       });
 
-      addMocksToSchema({ schema: bookSchema });
-      addMocksToSchema({ schema: movieSchema });
+      bookSchema = addMocksToSchema({ schema: bookSchema });
+      movieSchema = addMocksToSchema({ schema: movieSchema });
 
       const stitchedSchema = stitchSchemas({
         schemas: [bookSchema, movieSchema],

--- a/packages/stitch/tests/stitchingFromSubschemas.test.ts
+++ b/packages/stitch/tests/stitchingFromSubschemas.test.ts
@@ -38,7 +38,7 @@ const authorTypeDefs = `
 const schemas: Record<string, GraphQLSchema> = {};
 const getSchema = (name: string) => schemas[name];
 
-const chirpSchema = stitchSchemas({
+let chirpSchema = stitchSchemas({
   schemas: [
     chirpTypeDefs,
     authorTypeDefs,
@@ -66,7 +66,7 @@ const chirpSchema = stitchSchemas({
   },
 });
 
-addMocksToSchema({
+chirpSchema = addMocksToSchema({
   schema: chirpSchema,
   mocks: {
     Chirp: () => ({
@@ -76,7 +76,7 @@ addMocksToSchema({
   preserveResolvers: true,
 });
 
-const authorSchema = stitchSchemas({
+let authorSchema = stitchSchemas({
   schemas: [
     chirpTypeDefs,
     authorTypeDefs,
@@ -103,7 +103,7 @@ const authorSchema = stitchSchemas({
   },
 });
 
-addMocksToSchema({
+authorSchema = addMocksToSchema({
   schema: authorSchema,
   mocks: {
     User: () => ({

--- a/packages/stitch/tests/transforms.test.ts
+++ b/packages/stitch/tests/transforms.test.ts
@@ -14,7 +14,7 @@ import { propertySchema } from './fixtures/schemas';
 
 describe('rename root type', () => {
   test('works with stitchSchemas', async () => {
-    const schemaWithCustomRootTypeNames = makeExecutableSchema({
+    let schemaWithCustomRootTypeNames = makeExecutableSchema({
       typeDefs: `
         schema {
           query: QueryRoot
@@ -36,9 +36,9 @@ describe('rename root type', () => {
       `,
     });
 
-    addMocksToSchema({ schema: schemaWithCustomRootTypeNames });
+    schemaWithCustomRootTypeNames = addMocksToSchema({ schema: schemaWithCustomRootTypeNames });
 
-    const schemaWithDefaultRootTypeNames = makeExecutableSchema({
+    let schemaWithDefaultRootTypeNames = makeExecutableSchema({
       typeDefs: `
         type Query {
           bar: String!
@@ -55,7 +55,7 @@ describe('rename root type', () => {
       `,
     });
 
-    addMocksToSchema({ schema: schemaWithDefaultRootTypeNames });
+    schemaWithDefaultRootTypeNames = addMocksToSchema({ schema: schemaWithDefaultRootTypeNames });
 
     const stitchedSchema = stitchSchemas({
       subschemas: [

--- a/packages/stitch/tests/typeMerging.test.ts
+++ b/packages/stitch/tests/typeMerging.test.ts
@@ -9,7 +9,7 @@ import { addMocksToSchema } from '@graphql-tools/mock';
 
 import { stitchSchemas } from '../src/stitchSchemas';
 
-const chirpSchema = makeExecutableSchema({
+let chirpSchema = makeExecutableSchema({
   typeDefs: `
     type Chirp {
       id: ID!
@@ -27,9 +27,9 @@ const chirpSchema = makeExecutableSchema({
   `,
 });
 
-addMocksToSchema({ schema: chirpSchema });
+chirpSchema = addMocksToSchema({ schema: chirpSchema });
 
-const authorSchema = makeExecutableSchema({
+let authorSchema = makeExecutableSchema({
   typeDefs: `
     type User {
       id: ID!
@@ -41,7 +41,7 @@ const authorSchema = makeExecutableSchema({
   `,
 });
 
-addMocksToSchema({ schema: authorSchema });
+authorSchema = addMocksToSchema({ schema: authorSchema });
 
 const stitchedSchema = stitchSchemas({
   subschemas: [

--- a/packages/utils/src/Interfaces.ts
+++ b/packages/utils/src/Interfaces.ts
@@ -390,6 +390,7 @@ export interface SchemaMapper {
   [MapperKind.MUTATION_ROOT_FIELD]?: ObjectFieldMapper;
   [MapperKind.SUBSCRIPTION_ROOT_FIELD]?: ObjectFieldMapper;
   [MapperKind.INTERFACE_FIELD]?: InterfaceFieldMapper;
+  [MapperKind.COMPOSITE_FIELD]?: CompositeFieldMapper;
   [MapperKind.INPUT_OBJECT_FIELD]?: InputObjectFieldMapper;
 }
 
@@ -428,13 +429,19 @@ export type DirectiveMapper = (
   schema: GraphQLSchema
 ) => GraphQLDirective | null | undefined;
 
-export type FieldMapper<
-  F extends GraphQLFieldConfig<any, any> | GraphQLInputFieldConfig,
-  T extends GraphQLObjectType | GraphQLInterfaceType | GraphQLInputObjectType
-> = (fieldConfig: F, fieldName: string, type: T, schema: GraphQLSchema) => F | [string, F] | null | undefined;
+export type GenericFieldMapper<F extends GraphQLFieldConfig<any, any> | GraphQLInputFieldConfig> = (
+  fieldConfig: F,
+  fieldName: string,
+  typeName: string,
+  schema: GraphQLSchema
+) => F | [string, F] | null | undefined;
 
-export type ObjectFieldMapper = FieldMapper<GraphQLFieldConfig<any, any>, GraphQLObjectType>;
+export type FieldMapper = GenericFieldMapper<GraphQLFieldConfig<any, any> | GraphQLInputFieldConfig>;
 
-export type InterfaceFieldMapper = FieldMapper<GraphQLFieldConfig<any, any>, GraphQLInterfaceType>;
+export type ObjectFieldMapper = GenericFieldMapper<GraphQLFieldConfig<any, any>>;
 
-export type InputObjectFieldMapper = FieldMapper<GraphQLInputFieldConfig, GraphQLInputObjectType>;
+export type InterfaceFieldMapper = GenericFieldMapper<GraphQLFieldConfig<any, any>>;
+
+export type CompositeFieldMapper = GenericFieldMapper<GraphQLFieldConfig<any, any>>;
+
+export type InputObjectFieldMapper = GenericFieldMapper<GraphQLInputFieldConfig>;

--- a/packages/utils/src/Interfaces.ts
+++ b/packages/utils/src/Interfaces.ts
@@ -384,14 +384,14 @@ export interface SchemaMapper {
   [MapperKind.MUTATION]?: ObjectTypeMapper;
   [MapperKind.SUBSCRIPTION]?: ObjectTypeMapper;
   [MapperKind.DIRECTIVE]?: DirectiveMapper;
-  [MapperKind.OBJECT_FIELD]?: ObjectFieldMapper;
-  [MapperKind.ROOT_FIELD]?: ObjectFieldMapper;
-  [MapperKind.QUERY_ROOT_FIELD]?: ObjectFieldMapper;
-  [MapperKind.MUTATION_ROOT_FIELD]?: ObjectFieldMapper;
-  [MapperKind.SUBSCRIPTION_ROOT_FIELD]?: ObjectFieldMapper;
-  [MapperKind.INTERFACE_FIELD]?: InterfaceFieldMapper;
-  [MapperKind.COMPOSITE_FIELD]?: CompositeFieldMapper;
-  [MapperKind.INPUT_OBJECT_FIELD]?: InputObjectFieldMapper;
+  [MapperKind.OBJECT_FIELD]?: FieldMapper;
+  [MapperKind.ROOT_FIELD]?: FieldMapper;
+  [MapperKind.QUERY_ROOT_FIELD]?: FieldMapper;
+  [MapperKind.MUTATION_ROOT_FIELD]?: FieldMapper;
+  [MapperKind.SUBSCRIPTION_ROOT_FIELD]?: FieldMapper;
+  [MapperKind.INTERFACE_FIELD]?: FieldMapper;
+  [MapperKind.COMPOSITE_FIELD]?: FieldMapper;
+  [MapperKind.INPUT_OBJECT_FIELD]?: InputFieldMapper;
 }
 
 export type NamedTypeMapper = (type: GraphQLNamedType, schema: GraphQLSchema) => GraphQLNamedType | null | undefined;
@@ -436,12 +436,6 @@ export type GenericFieldMapper<F extends GraphQLFieldConfig<any, any> | GraphQLI
   schema: GraphQLSchema
 ) => F | [string, F] | null | undefined;
 
-export type FieldMapper = GenericFieldMapper<GraphQLFieldConfig<any, any> | GraphQLInputFieldConfig>;
+export type FieldMapper = GenericFieldMapper<GraphQLFieldConfig<any, any>>;
 
-export type ObjectFieldMapper = GenericFieldMapper<GraphQLFieldConfig<any, any>>;
-
-export type InterfaceFieldMapper = GenericFieldMapper<GraphQLFieldConfig<any, any>>;
-
-export type CompositeFieldMapper = GenericFieldMapper<GraphQLFieldConfig<any, any>>;
-
-export type InputObjectFieldMapper = GenericFieldMapper<GraphQLInputFieldConfig>;
+export type InputFieldMapper = GenericFieldMapper<GraphQLInputFieldConfig>;

--- a/packages/utils/src/addTypes.ts
+++ b/packages/utils/src/addTypes.ts
@@ -1,7 +1,7 @@
-// enhanceSchema uses toConfig to create a new schema with a new or replaced
+// addTypes uses toConfig to create a new schema with a new or replaced
 // type or directive. Rewiring is employed so that the replaced type can be
 // reconnected with the existing types.
-// Re
+//
 // Rewiring is employed even for new types or directives as a convenience, so
 // that type references within the new type or directive do not have to be to
 // the identical objects within the original schema.
@@ -36,7 +36,7 @@ import {
 } from 'graphql';
 import { rewireTypes } from './rewire';
 
-export function enhanceSchema(
+export function addTypes(
   schema: GraphQLSchema,
   newTypesOrDirectives: Array<GraphQLNamedType | GraphQLDirective>
 ): GraphQLSchema {

--- a/packages/utils/src/enhanceSchema.ts
+++ b/packages/utils/src/enhanceSchema.ts
@@ -1,0 +1,84 @@
+// enhanceSchema uses toConfig to create a new schema with a new or replaced
+// type or directive. Rewiring is employed so that the replaced type can be
+// reconnected with the existing types.
+// Re
+// Rewiring is employed even for new types or directives as a convenience, so
+// that type references within the new type or directive do not have to be to
+// the identical objects within the original schema.
+//
+// In fact, the type references could even be stub types with entirely different
+// fields, as long as the type references share the same name as the desired
+// type within the original schema's type map.
+//
+// This makes it easy to perform simple schema operations (e.g. adding a new
+// type with a fiew fields removed from an existing type) that could normally be
+// performed by using toConfig directly, but is blocked if any intervening
+// more advanced schema operations have caused the types to be recreated via
+// rewiring.
+//
+// Type recreation happens, for example, with every use of mapSchema, as the
+// types are always rewired. If fields are selected and removed using
+// mapSchema, adding those fields to a new type can no longer be simply done
+// by toConfig, as the types are not the identical Javascript objects, and
+// schema creation will fail with errors referencing multiple types with the
+// same names.
+//
+// enhanceSchema can fill this gap by adding an additional round of rewiring.
+//
+
+import {
+  GraphQLObjectType,
+  GraphQLSchema,
+  GraphQLNamedType,
+  GraphQLDirective,
+  isNamedType,
+  isDirective,
+} from 'graphql';
+import { rewireTypes } from './rewire';
+
+export function enhanceSchema(
+  schema: GraphQLSchema,
+  newTypesOrDirectives: Array<GraphQLNamedType | GraphQLDirective>
+): GraphQLSchema {
+  const queryType = schema.getQueryType();
+  const mutationType = schema.getMutationType();
+  const subscriptionType = schema.getSubscriptionType();
+
+  const queryTypeName = queryType != null ? queryType.name : undefined;
+  const mutationTypeName = mutationType != null ? mutationType.name : undefined;
+  const subscriptionTypeName = subscriptionType != null ? subscriptionType.name : undefined;
+
+  const config = schema.toConfig();
+
+  const originalTypeMap = {};
+  config.types.forEach(type => {
+    originalTypeMap[type.name] = type;
+  });
+
+  const originalDirectiveMap = {};
+  config.directives.forEach(directive => {
+    originalDirectiveMap[directive.name] = directive;
+  });
+
+  newTypesOrDirectives.forEach(newTypeOrDirective => {
+    if (isNamedType(newTypeOrDirective)) {
+      originalTypeMap[newTypeOrDirective.name] = newTypeOrDirective;
+    } else if (isDirective(newTypeOrDirective)) {
+      originalDirectiveMap[newTypeOrDirective.name] = newTypeOrDirective;
+    }
+  });
+
+  const { typeMap, directives } = rewireTypes(
+    originalTypeMap,
+    Object.keys(originalDirectiveMap).map(directiveName => originalDirectiveMap[directiveName])
+  );
+
+  return new GraphQLSchema({
+    ...config,
+    query: queryTypeName ? (typeMap[queryTypeName] as GraphQLObjectType) : undefined,
+    mutation: mutationTypeName ? (typeMap[mutationTypeName] as GraphQLObjectType) : undefined,
+    subscription: subscriptionTypeName != null ? (typeMap[subscriptionTypeName] as GraphQLObjectType) : undefined,
+    types: Object.keys(typeMap).map(typeName => typeMap[typeName]),
+    directives,
+  });
+}

--- a/packages/utils/src/fields.ts
+++ b/packages/utils/src/fields.ts
@@ -1,92 +1,43 @@
 import { GraphQLFieldConfigMap, GraphQLObjectType, GraphQLFieldConfig, GraphQLSchema } from 'graphql';
 import { MapperKind } from './Interfaces';
 import { mapSchema } from './mapSchema';
-import { rewireTypes } from './rewire';
-
-export function modifyFields(
-  schema: GraphQLSchema,
-  {
-    append = [],
-    remove = [],
-  }: {
-    append?: Array<{ typeName: string; additionalFields: GraphQLFieldConfigMap<any, any> }>;
-    remove?: Array<{
-      typeName: string;
-      testFn: (fieldName: string, field: GraphQLFieldConfig<any, any>) => boolean;
-    }>;
-  }
-): GraphQLSchema {
-  const queryType = schema.getQueryType();
-  const mutationType = schema.getMutationType();
-  const subscriptionType = schema.getSubscriptionType();
-
-  const queryTypeName = queryType != null ? queryType.name : undefined;
-  const mutationTypeName = mutationType != null ? mutationType.name : undefined;
-  const subscriptionTypeName = subscriptionType != null ? subscriptionType.name : undefined;
-
-  const config = schema.toConfig();
-
-  const originalTypeMap = {};
-  config.types.forEach(type => {
-    originalTypeMap[type.name] = type;
-  });
-
-  remove.forEach(({ typeName, testFn }) => {
-    const config = (originalTypeMap[typeName] as GraphQLObjectType).toConfig();
-    const originalFieldConfigMap = config.fields;
-    const newFieldConfigMap = {};
-    Object.keys(originalFieldConfigMap).forEach(fieldName => {
-      if (!testFn(fieldName, originalFieldConfigMap[fieldName])) {
-        newFieldConfigMap[fieldName] = originalFieldConfigMap[fieldName];
-      }
-    });
-    originalTypeMap[typeName] = new GraphQLObjectType({
-      ...config,
-      fields: newFieldConfigMap,
-    });
-  });
-
-  append.forEach(({ typeName, additionalFields }) => {
-    if (originalTypeMap[typeName] == null) {
-      originalTypeMap[typeName] = new GraphQLObjectType({
-        name: typeName,
-        fields: additionalFields,
-      });
-    } else {
-      const config = (originalTypeMap[typeName] as GraphQLObjectType).toConfig();
-      const originalFieldConfigMap = config.fields;
-      const newFieldConfigMap = {};
-      Object.keys(originalFieldConfigMap).forEach(fieldName => {
-        newFieldConfigMap[fieldName] = originalFieldConfigMap[fieldName];
-      });
-      Object.keys(additionalFields).forEach(fieldName => {
-        newFieldConfigMap[fieldName] = additionalFields[fieldName];
-      });
-      originalTypeMap[typeName] = new GraphQLObjectType({
-        ...config,
-        fields: newFieldConfigMap,
-      });
-    }
-  });
-
-  const { typeMap, directives } = rewireTypes(originalTypeMap, config.directives);
-
-  return new GraphQLSchema({
-    ...config,
-    query: queryTypeName ? (typeMap[queryTypeName] as GraphQLObjectType) : undefined,
-    mutation: mutationTypeName ? (typeMap[mutationTypeName] as GraphQLObjectType) : undefined,
-    subscription: subscriptionTypeName != null ? (typeMap[subscriptionTypeName] as GraphQLObjectType) : undefined,
-    types: Object.keys(typeMap).map(typeName => typeMap[typeName]),
-    directives,
-  });
-}
+import { enhanceSchema } from './enhanceSchema';
 
 export function appendFields(
   schema: GraphQLSchema,
   typeName: string,
   additionalFields: GraphQLFieldConfigMap<any, any>
 ): GraphQLSchema {
-  return modifyFields(schema, { append: [{ typeName, additionalFields }] });
+  if (schema.getType(typeName) == null) {
+    return enhanceSchema(schema, [
+      new GraphQLObjectType({
+        name: typeName,
+        fields: additionalFields,
+      }),
+    ]);
+  }
+
+  return mapSchema(schema, {
+    [MapperKind.OBJECT_TYPE]: type => {
+      if (type.name === typeName) {
+        const config = type.toConfig();
+        const originalFieldConfigMap = config.fields;
+
+        const newFieldConfigMap = {};
+        Object.keys(originalFieldConfigMap).forEach(fieldName => {
+          newFieldConfigMap[fieldName] = originalFieldConfigMap[fieldName];
+        });
+        Object.keys(additionalFields).forEach(fieldName => {
+          newFieldConfigMap[fieldName] = additionalFields[fieldName];
+        });
+
+        return new GraphQLObjectType({
+          ...config,
+          fields: newFieldConfigMap,
+        });
+      }
+    },
+  });
 }
 
 export function removeFields(
@@ -94,22 +45,8 @@ export function removeFields(
   typeName: string,
   testFn: (fieldName: string, field: GraphQLFieldConfig<any, any>) => boolean
 ): [GraphQLSchema, GraphQLFieldConfigMap<any, any>] {
-  const selectedFields = getFields(schema, typeName, testFn);
-  const selectedFieldNames = Object.keys(selectedFields);
-  const newSchema = modifyFields(schema, {
-    remove: [{ typeName, testFn: fieldName => selectedFieldNames.includes(fieldName) }],
-  });
-
-  return [newSchema, selectedFields];
-}
-
-export function getFields(
-  schema: GraphQLSchema,
-  typeName: string,
-  testFn: (fieldName: string, field: GraphQLFieldConfig<any, any>) => boolean
-): GraphQLFieldConfigMap<any, any> {
-  const selectedFields = {};
-  mapSchema(schema, {
+  const removedFields = {};
+  const newSchema = mapSchema(schema, {
     [MapperKind.OBJECT_TYPE]: type => {
       if (type.name === typeName) {
         const config = type.toConfig();
@@ -118,7 +55,7 @@ export function getFields(
         Object.keys(originalFieldConfigMap).forEach(fieldName => {
           const originalFieldConfig = originalFieldConfigMap[fieldName];
           if (testFn(fieldName, originalFieldConfig)) {
-            selectedFields[fieldName] = originalFieldConfig;
+            removedFields[fieldName] = originalFieldConfig;
           }
         });
       }
@@ -127,5 +64,5 @@ export function getFields(
     },
   });
 
-  return selectedFields;
+  return [newSchema, removedFields];
 }

--- a/packages/utils/src/fields.ts
+++ b/packages/utils/src/fields.ts
@@ -1,15 +1,15 @@
 import { GraphQLFieldConfigMap, GraphQLObjectType, GraphQLFieldConfig, GraphQLSchema } from 'graphql';
 import { MapperKind } from './Interfaces';
 import { mapSchema } from './mapSchema';
-import { enhanceSchema } from './enhanceSchema';
+import { addTypes } from './addTypes';
 
-export function appendFields(
+export function appendObjectFields(
   schema: GraphQLSchema,
   typeName: string,
   additionalFields: GraphQLFieldConfigMap<any, any>
 ): GraphQLSchema {
   if (schema.getType(typeName) == null) {
-    return enhanceSchema(schema, [
+    return addTypes(schema, [
       new GraphQLObjectType({
         name: typeName,
         fields: additionalFields,
@@ -40,7 +40,7 @@ export function appendFields(
   });
 }
 
-export function removeFields(
+export function removeObjectFields(
   schema: GraphQLSchema,
   typeName: string,
   testFn: (fieldName: string, field: GraphQLFieldConfig<any, any>) => boolean

--- a/packages/utils/src/heal.ts
+++ b/packages/utils/src/heal.ts
@@ -22,8 +22,7 @@ import {
 } from 'graphql';
 
 import { isNamedStub, getBuiltInForStub } from './stub';
-
-type NamedTypeMap = Record<string, GraphQLNamedType>;
+import { TypeMap } from './Interfaces';
 
 // Update any references to named schema types that disagree with the named
 // types found in schema.getTypeMap().
@@ -85,7 +84,7 @@ export function healTypes(
     skipPruning: false,
   }
 ) {
-  const actualNamedTypeMap: NamedTypeMap = Object.create(null);
+  const actualNamedTypeMap: TypeMap = Object.create(null);
 
   // If any of the .name properties of the GraphQLNamedType objects in
   // schema.getTypeMap() have changed, the keys of the type map need to

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -26,7 +26,7 @@ export * from './getResolversFromSchema';
 export * from './forEachField';
 export * from './forEachDefaultValue';
 export * from './mapSchema';
-export * from './enhanceSchema';
+export * from './addTypes';
 export * from './rewire';
 export * from './mergeDeep';
 export * from './Interfaces';

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -26,6 +26,7 @@ export * from './getResolversFromSchema';
 export * from './forEachField';
 export * from './forEachDefaultValue';
 export * from './mapSchema';
+export * from './enhanceSchema';
 export * from './rewire';
 export * from './mergeDeep';
 export * from './Interfaces';

--- a/packages/utils/src/mapSchema.ts
+++ b/packages/utils/src/mapSchema.ts
@@ -6,7 +6,6 @@ import {
   GraphQLType,
   isInterfaceType,
   isEnumType,
-  isInputType,
   isObjectType,
   isScalarType,
   isUnionType,
@@ -234,7 +233,7 @@ function getTypeSpecifiers(type: GraphQLType, schema: GraphQLSchema): Array<Mapp
     } else if (type === subscription) {
       specifiers.push(MapperKind.ROOT_OBJECT, MapperKind.SUBSCRIPTION);
     }
-  } else if (isInputType(type)) {
+  } else if (isInputObjectType(type)) {
     specifiers.push(MapperKind.INPUT_OBJECT_TYPE);
   } else if (isInterfaceType(type)) {
     specifiers.push(MapperKind.COMPOSITE_TYPE, MapperKind.ABSTRACT_TYPE, MapperKind.INTERFACE_TYPE);
@@ -279,7 +278,7 @@ function getFieldSpecifiers(type: GraphQLType, schema: GraphQLSchema): Array<Map
     } else if (type === subscription) {
       specifiers.push(MapperKind.ROOT_FIELD, MapperKind.SUBSCRIPTION_ROOT_FIELD);
     }
-  } else if (isInputType(type)) {
+  } else if (isInputObjectType(type)) {
     specifiers.push(MapperKind.INPUT_OBJECT_FIELD);
   } else if (isInterfaceType(type)) {
     specifiers.push(MapperKind.COMPOSITE_FIELD, MapperKind.INTERFACE_FIELD);

--- a/packages/utils/src/mapSchema.ts
+++ b/packages/utils/src/mapSchema.ts
@@ -18,6 +18,11 @@ import {
   GraphQLInterfaceTypeConfig,
   GraphQLInputObjectTypeConfig,
   isLeafType,
+  isListType,
+  isNonNullType,
+  isNamedType,
+  GraphQLList,
+  GraphQLNonNull,
 } from 'graphql';
 
 import {
@@ -26,7 +31,7 @@ import {
   TypeMap,
   NamedTypeMapper,
   DirectiveMapper,
-  FieldMapper,
+  GenericFieldMapper,
   IDefaultValueIteratorFn,
 } from './Interfaces';
 
@@ -35,7 +40,12 @@ import { serializeInputValue, parseInputValue } from './transformInputValue';
 
 export function mapSchema(schema: GraphQLSchema, schemaMapper: SchemaMapper = {}): GraphQLSchema {
   const originalTypeMap = schema.getTypeMap();
-  let newTypeMap = mapTypesConvertingDefaultValues(originalTypeMap, schema, schemaMapper);
+
+  let newTypeMap = mapDefaultValues(originalTypeMap, schema, serializeInputValue);
+  newTypeMap = mapTypes(newTypeMap, schema, schemaMapper, type => isLeafType(type));
+  newTypeMap = mapDefaultValues(newTypeMap, schema, parseInputValue);
+
+  newTypeMap = mapTypes(newTypeMap, schema, schemaMapper, type => !isLeafType(type));
   newTypeMap = mapFields(newTypeMap, schema, schemaMapper);
 
   const originalDirectives = schema.getDirectives();
@@ -72,46 +82,6 @@ export function mapSchema(schema: GraphQLSchema, schemaMapper: SchemaMapper = {}
   });
 }
 
-function mapTypesConvertingDefaultValues(
-  originalTypeMap: TypeMap,
-  schema: GraphQLSchema,
-  schemaMapper: SchemaMapper
-): TypeMap {
-  let newTypeMap = mapDefaultValues(originalTypeMap, schema, serializeInputValue);
-
-  newTypeMap = mapTypes(newTypeMap, schema, schemaMapper, type => isLeafType(type));
-
-  newTypeMap = mapDefaultValues(newTypeMap, schema, parseInputValue);
-
-  return mapTypes(newTypeMap, schema, schemaMapper, type => !isLeafType(type));
-}
-
-function mapDefaultValues(originalTypeMap: TypeMap, schema: GraphQLSchema, fn: IDefaultValueIteratorFn): TypeMap {
-  return mapTypes(originalTypeMap, schema, {
-    [MapperKind.OBJECT_FIELD]: fieldConfig => {
-      const originalArgumentConfigMap = fieldConfig.args;
-      const newArgumentConfigMap = {};
-      Object.keys(originalArgumentConfigMap).forEach(argName => {
-        const originalArgument = originalArgumentConfigMap[argName];
-        newArgumentConfigMap[argName] = {
-          ...originalArgument,
-          defaultValue: fn(originalArgument.type, originalArgument.defaultValue),
-        };
-      });
-      return {
-        ...fieldConfig,
-        args: newArgumentConfigMap,
-      };
-    },
-    [MapperKind.INPUT_OBJECT_FIELD]: (inputFieldConfig, _fieldName, type) => {
-      return {
-        ...inputFieldConfig,
-        defaultValue: fn(type, inputFieldConfig.defaultValue),
-      };
-    },
-  });
-}
-
 function mapTypes(
   originalTypeMap: TypeMap,
   schema: GraphQLSchema,
@@ -124,7 +94,7 @@ function mapTypes(
     if (!typeName.startsWith('__')) {
       const originalType = originalTypeMap[typeName];
       if (originalType != null && testFn(originalType)) {
-        const typeMapper = getTypeMapper(schema, schemaMapper, originalType);
+        const typeMapper = getTypeMapper(schema, schemaMapper, typeName);
 
         if (typeMapper != null) {
           const maybeNewType = typeMapper(originalType, schema);
@@ -141,6 +111,75 @@ function mapTypes(
   return newTypeMap;
 }
 
+function mapDefaultValues(typeMap: TypeMap, schema: GraphQLSchema, fn: IDefaultValueIteratorFn): TypeMap {
+  return mapFields(typeMap, schema, {
+    [MapperKind.OBJECT_FIELD]: fieldConfig => {
+      const originalArgumentConfigMap = fieldConfig.args;
+
+      if (originalArgumentConfigMap == null) {
+        return fieldConfig;
+      }
+
+      const argNames = Object.keys(originalArgumentConfigMap);
+      if (!argNames.length) {
+        return fieldConfig;
+      }
+
+      const newArgumentConfigMap = {};
+      Object.keys(originalArgumentConfigMap).forEach(argName => {
+        const originalArgument = originalArgumentConfigMap[argName];
+        if (originalArgument === undefined) {
+          newArgumentConfigMap[argName] = originalArgument;
+        } else {
+          const maybeNewType = getNewType(typeMap, originalArgument.type);
+          if (maybeNewType == null) {
+            newArgumentConfigMap[argName] = originalArgument;
+          } else {
+            newArgumentConfigMap[argName] = {
+              ...originalArgument,
+              defaultValue: fn(maybeNewType, originalArgument.defaultValue),
+            };
+          }
+        }
+      });
+
+      return {
+        ...fieldConfig,
+        args: newArgumentConfigMap,
+      };
+    },
+    [MapperKind.INPUT_OBJECT_FIELD]: inputFieldConfig => {
+      if (inputFieldConfig.defaultValue === undefined) {
+        return inputFieldConfig;
+      } else {
+        const maybeNewType = getNewType(typeMap, inputFieldConfig.type);
+        if (maybeNewType == null) {
+          return inputFieldConfig;
+        } else {
+          return {
+            ...inputFieldConfig,
+            defaultValue: fn(maybeNewType, inputFieldConfig.defaultValue),
+          };
+        }
+      }
+    },
+  });
+}
+
+function getNewType<T extends GraphQLType>(newTypeMap: TypeMap, type: T): T | null {
+  if (isListType(type)) {
+    const newType = getNewType(newTypeMap, type.ofType);
+    return newType != null ? (new GraphQLList(newType) as T) : null;
+  } else if (isNonNullType(type)) {
+    const newType = getNewType(newTypeMap, type.ofType);
+    return newType != null ? (new GraphQLNonNull(newType) as T) : null;
+  } else if (isNamedType(type)) {
+    const newType = newTypeMap[type.name];
+    return newType != null ? (newType as T) : null;
+  }
+
+  return null;
+}
 function mapFields(originalTypeMap: TypeMap, schema: GraphQLSchema, schemaMapper: SchemaMapper): TypeMap {
   const newTypeMap = {};
 
@@ -153,7 +192,7 @@ function mapFields(originalTypeMap: TypeMap, schema: GraphQLSchema, schemaMapper
         return;
       }
 
-      const fieldMapper = getFieldMapper(schema, schemaMapper, originalType);
+      const fieldMapper = getFieldMapper(schema, schemaMapper, typeName);
       if (fieldMapper == null) {
         newTypeMap[typeName] = originalType;
         return;
@@ -161,19 +200,18 @@ function mapFields(originalTypeMap: TypeMap, schema: GraphQLSchema, schemaMapper
 
       const config = originalType.toConfig();
 
+      const originalFieldConfigMap = config.fields;
       const newFieldConfigMap = {};
-      Object.keys(config.fields).forEach(fieldName => {
-        const originalFieldConfig = config.fields[fieldName];
-        if (fieldMapper != null) {
-          const mappedField = fieldMapper(originalFieldConfig, fieldName, originalType, schema);
-          if (mappedField === undefined) {
-            newFieldConfigMap[fieldName] = originalFieldConfig;
-          } else if (Array.isArray(mappedField)) {
-            const [newFieldName, newFieldConfig] = mappedField;
-            newFieldConfigMap[newFieldName] = newFieldConfig;
-          } else if (mappedField !== null) {
-            newFieldConfigMap[fieldName] = mappedField;
-          }
+      Object.keys(originalFieldConfigMap).forEach(fieldName => {
+        const originalFieldConfig = originalFieldConfigMap[fieldName];
+        const mappedField = fieldMapper(originalFieldConfig, fieldName, typeName, schema);
+        if (mappedField === undefined) {
+          newFieldConfigMap[fieldName] = originalFieldConfig;
+        } else if (Array.isArray(mappedField)) {
+          const [newFieldName, newFieldConfig] = mappedField;
+          newFieldConfigMap[newFieldName] = newFieldConfig;
+        } else if (mappedField !== null) {
+          newFieldConfigMap[fieldName] = mappedField;
         }
       });
 
@@ -219,18 +257,20 @@ function mapDirectives(
   return newDirectives;
 }
 
-function getTypeSpecifiers(type: GraphQLType, schema: GraphQLSchema): Array<MapperKind> {
+function getTypeSpecifiers(schema: GraphQLSchema, typeName: string): Array<MapperKind> {
+  const type = schema.getType(typeName);
   const specifiers = [MapperKind.TYPE];
+
   if (isObjectType(type)) {
     specifiers.push(MapperKind.COMPOSITE_TYPE, MapperKind.OBJECT_TYPE);
     const query = schema.getQueryType();
     const mutation = schema.getMutationType();
     const subscription = schema.getSubscriptionType();
-    if (type === query) {
+    if (query != null && typeName === query.name) {
       specifiers.push(MapperKind.ROOT_OBJECT, MapperKind.QUERY);
-    } else if (type === mutation) {
+    } else if (mutation != null && typeName === mutation.name) {
       specifiers.push(MapperKind.ROOT_OBJECT, MapperKind.MUTATION);
-    } else if (type === subscription) {
+    } else if (subscription != null && typeName === subscription.name) {
       specifiers.push(MapperKind.ROOT_OBJECT, MapperKind.SUBSCRIPTION);
     }
   } else if (isInputObjectType(type)) {
@@ -248,12 +288,8 @@ function getTypeSpecifiers(type: GraphQLType, schema: GraphQLSchema): Array<Mapp
   return specifiers;
 }
 
-function getTypeMapper(
-  schema: GraphQLSchema,
-  schemaMapper: SchemaMapper,
-  type: GraphQLNamedType
-): NamedTypeMapper | null {
-  const specifiers = getTypeSpecifiers(type, schema);
+function getTypeMapper(schema: GraphQLSchema, schemaMapper: SchemaMapper, typeName: string): NamedTypeMapper | null {
+  const specifiers = getTypeSpecifiers(schema, typeName);
   let typeMapper: NamedTypeMapper | undefined;
   const stack = [...specifiers];
   while (!typeMapper && stack.length > 0) {
@@ -264,39 +300,42 @@ function getTypeMapper(
   return typeMapper != null ? typeMapper : null;
 }
 
-function getFieldSpecifiers(type: GraphQLType, schema: GraphQLSchema): Array<MapperKind> {
+function getFieldSpecifiers(schema: GraphQLSchema, typeName: string): Array<MapperKind> {
+  const type = schema.getType(typeName);
   const specifiers = [MapperKind.FIELD];
+
   if (isObjectType(type)) {
     specifiers.push(MapperKind.COMPOSITE_FIELD, MapperKind.OBJECT_FIELD);
     const query = schema.getQueryType();
     const mutation = schema.getMutationType();
     const subscription = schema.getSubscriptionType();
-    if (type === query) {
+    if (query != null && typeName === query.name) {
       specifiers.push(MapperKind.ROOT_FIELD, MapperKind.QUERY_ROOT_FIELD);
-    } else if (type === mutation) {
+    } else if (mutation != null && typeName === mutation.name) {
       specifiers.push(MapperKind.ROOT_FIELD, MapperKind.MUTATION_ROOT_FIELD);
-    } else if (type === subscription) {
+    } else if (subscription != null && typeName === subscription.name) {
       specifiers.push(MapperKind.ROOT_FIELD, MapperKind.SUBSCRIPTION_ROOT_FIELD);
     }
-  } else if (isInputObjectType(type)) {
-    specifiers.push(MapperKind.INPUT_OBJECT_FIELD);
   } else if (isInterfaceType(type)) {
     specifiers.push(MapperKind.COMPOSITE_FIELD, MapperKind.INTERFACE_FIELD);
+  } else if (isInputObjectType(type)) {
+    specifiers.push(MapperKind.INPUT_OBJECT_FIELD);
   }
 
   return specifiers;
 }
 
-function getFieldMapper<
-  F extends GraphQLFieldConfig<any, any> | GraphQLInputFieldConfig,
-  T extends GraphQLObjectType | GraphQLInterfaceType | GraphQLInputObjectType
->(schema: GraphQLSchema, schemaMapper: SchemaMapper, type: T): FieldMapper<F, T> | null {
-  const specifiers = getFieldSpecifiers(type, schema);
-  let fieldMapper: FieldMapper<F, T> | undefined;
+function getFieldMapper<F extends GraphQLFieldConfig<any, any> | GraphQLInputFieldConfig>(
+  schema: GraphQLSchema,
+  schemaMapper: SchemaMapper,
+  typeName: string
+): GenericFieldMapper<F> | null {
+  const specifiers = getFieldSpecifiers(schema, typeName);
+  let fieldMapper: GenericFieldMapper<F> | undefined;
   const stack = [...specifiers];
   while (!fieldMapper && stack.length > 0) {
     const next = stack.pop();
-    fieldMapper = schemaMapper[next] as FieldMapper<F, T>;
+    fieldMapper = schemaMapper[next] as GenericFieldMapper<F>;
   }
 
   return fieldMapper != null ? fieldMapper : null;

--- a/packages/utils/src/mapSchema.ts
+++ b/packages/utils/src/mapSchema.ts
@@ -24,6 +24,7 @@ import {
 import {
   SchemaMapper,
   MapperKind,
+  TypeMap,
   NamedTypeMapper,
   DirectiveMapper,
   FieldMapper,
@@ -73,10 +74,10 @@ export function mapSchema(schema: GraphQLSchema, schemaMapper: SchemaMapper = {}
 }
 
 function mapTypesConvertingDefaultValues(
-  originalTypeMap: Record<string, GraphQLNamedType>,
+  originalTypeMap: TypeMap,
   schema: GraphQLSchema,
   schemaMapper: SchemaMapper
-): Record<string, GraphQLNamedType> {
+): TypeMap {
   let newTypeMap = mapDefaultValues(originalTypeMap, schema, serializeInputValue);
 
   newTypeMap = mapTypes(newTypeMap, schema, schemaMapper, type => isLeafType(type));
@@ -86,11 +87,7 @@ function mapTypesConvertingDefaultValues(
   return mapTypes(newTypeMap, schema, schemaMapper, type => !isLeafType(type));
 }
 
-function mapDefaultValues(
-  originalTypeMap: Record<string, GraphQLNamedType>,
-  schema: GraphQLSchema,
-  fn: IDefaultValueIteratorFn
-): Record<string, GraphQLNamedType> {
+function mapDefaultValues(originalTypeMap: TypeMap, schema: GraphQLSchema, fn: IDefaultValueIteratorFn): TypeMap {
   return mapTypes(originalTypeMap, schema, {
     [MapperKind.OBJECT_FIELD]: fieldConfig => {
       const originalArgumentConfigMap = fieldConfig.args;
@@ -117,11 +114,11 @@ function mapDefaultValues(
 }
 
 function mapTypes(
-  originalTypeMap: Record<string, GraphQLNamedType>,
+  originalTypeMap: TypeMap,
   schema: GraphQLSchema,
   schemaMapper: SchemaMapper,
   testFn: (originalType: GraphQLNamedType) => boolean = () => true
-): Record<string, GraphQLNamedType> {
+): TypeMap {
   const newTypeMap = {};
 
   Object.keys(originalTypeMap).forEach(typeName => {
@@ -145,11 +142,7 @@ function mapTypes(
   return newTypeMap;
 }
 
-function mapFields(
-  originalTypeMap: Record<string, GraphQLNamedType>,
-  schema: GraphQLSchema,
-  schemaMapper: SchemaMapper
-): Record<string, GraphQLNamedType> {
+function mapFields(originalTypeMap: TypeMap, schema: GraphQLSchema, schemaMapper: SchemaMapper): TypeMap {
   const newTypeMap = {};
 
   Object.keys(originalTypeMap).forEach(typeName => {

--- a/packages/utils/src/rewire.ts
+++ b/packages/utils/src/rewire.ts
@@ -26,6 +26,7 @@ import {
 } from 'graphql';
 
 import { getBuiltInForStub, isNamedStub } from './stub';
+import { TypeMap } from './Interfaces';
 
 export function rewireTypes(
   originalTypeMap: Record<string, GraphQLNamedType | null>,
@@ -36,10 +37,10 @@ export function rewireTypes(
     skipPruning: false,
   }
 ): {
-  typeMap: Record<string, GraphQLNamedType>;
+  typeMap: TypeMap;
   directives: Array<GraphQLDirective>;
 } {
-  const newTypeMap: Record<string, GraphQLNamedType> = Object.create(null);
+  const newTypeMap: TypeMap = Object.create(null);
 
   Object.keys(originalTypeMap).forEach(typeName => {
     const namedType = originalTypeMap[typeName];
@@ -199,10 +200,10 @@ export function rewireTypes(
 }
 
 function pruneTypes(
-  typeMap: Record<string, GraphQLNamedType>,
+  typeMap: TypeMap,
   directives: Array<GraphQLDirective>
 ): {
-  typeMap: Record<string, GraphQLNamedType>;
+  typeMap: TypeMap;
   directives: Array<GraphQLDirective>;
 } {
   const newTypeMap = {};

--- a/packages/wrap/src/transforms/HoistField.ts
+++ b/packages/wrap/src/transforms/HoistField.ts
@@ -1,6 +1,13 @@
 import { GraphQLSchema, GraphQLObjectType, getNullableType } from 'graphql';
 
-import { wrapFieldNode, renameFieldNode, appendFields, removeFields, Transform, Request } from '@graphql-tools/utils';
+import {
+  wrapFieldNode,
+  renameFieldNode,
+  appendObjectFields,
+  removeObjectFields,
+  Transform,
+  Request,
+} from '@graphql-tools/utils';
 
 import MapFields from './MapFields';
 import { createMergedResolver } from '@graphql-tools/delegate';
@@ -33,7 +40,7 @@ export default class HoistField implements Transform {
       schema.getType(this.typeName) as GraphQLObjectType
     );
 
-    let [newSchema, targetFieldConfigMap] = removeFields(
+    let [newSchema, targetFieldConfigMap] = removeObjectFields(
       schema,
       innerType.name,
       fieldName => fieldName === this.oldFieldName
@@ -43,7 +50,7 @@ export default class HoistField implements Transform {
 
     const targetType = targetField.type as GraphQLObjectType;
 
-    newSchema = appendFields(newSchema, this.typeName, {
+    newSchema = appendObjectFields(newSchema, this.typeName, {
       [this.newFieldName]: {
         type: targetType,
         resolve: createMergedResolver({ fromPath: this.pathToField }),

--- a/packages/wrap/src/transforms/WrapFields.ts
+++ b/packages/wrap/src/transforms/WrapFields.ts
@@ -1,6 +1,6 @@
 import { GraphQLSchema, GraphQLObjectType } from 'graphql';
 
-import { Transform, Request, hoistFieldNodes, getFields, modifyFields } from '@graphql-tools/utils';
+import { Transform, Request, hoistFieldNodes, removeFields, appendFields } from '@graphql-tools/utils';
 import { createMergedResolver, defaultMergedResolver } from '@graphql-tools/delegate';
 
 import MapFields from './MapFields';
@@ -41,76 +41,38 @@ export default class WrapFields implements Transform {
   }
 
   public transformSchema(schema: GraphQLSchema): GraphQLSchema {
-    let targetFieldConfigMap = getFields(
+    let [newSchema, targetFieldConfigMap] = removeFields(
       schema,
       this.outerTypeName,
       !this.fieldNames ? () => true : fieldName => this.fieldNames.includes(fieldName)
     );
 
-    const innerMostFieldNames = Object.keys(targetFieldConfigMap);
-
-    const remove = [
-      {
-        typeName: this.outerTypeName,
-        testFn: (fieldName: string) => innerMostFieldNames.includes(fieldName),
-      },
-    ];
-
     let wrapIndex = this.numWraps - 1;
+    let wrappingTypeName = this.wrappingTypeNames[wrapIndex];
+    let wrappingFieldName = this.wrappingFieldNames[wrapIndex];
 
-    const innerMostWrappingTypeName = this.wrappingTypeNames[wrapIndex];
-
-    let baseWrappingType = new GraphQLObjectType({
-      name: innerMostWrappingTypeName,
-      fields: targetFieldConfigMap,
-    });
-
-    // Appending is still necessary to support wrapping with a pre-existing type.
-    // modifyFields lets you use the incomplete type within a field config map
-    // as it employes rewiring and will use the correct final type.
-    //
-    // In fact, the baseWrappingType could even be a stub type with no fields
-    // as long as it has the correct name.
-
-    const append = [
-      {
-        typeName: innerMostWrappingTypeName,
-        additionalFields: targetFieldConfigMap,
-      },
-    ];
+    newSchema = appendFields(newSchema, wrappingTypeName, targetFieldConfigMap);
 
     for (wrapIndex--; wrapIndex > -1; wrapIndex--) {
-      targetFieldConfigMap = {
-        [this.wrappingFieldNames[wrapIndex + 1]]: {
-          type: baseWrappingType,
+      const nextWrappingTypeName = this.wrappingTypeNames[wrapIndex];
+
+      newSchema = appendFields(newSchema, nextWrappingTypeName, {
+        [wrappingFieldName]: {
+          type: newSchema.getType(wrappingTypeName) as GraphQLObjectType,
           resolve: defaultMergedResolver,
         },
-      };
-
-      const wrappingTypeName = this.wrappingTypeNames[wrapIndex];
-
-      baseWrappingType = new GraphQLObjectType({
-        name: wrappingTypeName,
-        fields: targetFieldConfigMap,
       });
 
-      append.push({
-        typeName: wrappingTypeName,
-        additionalFields: targetFieldConfigMap,
-      });
+      wrappingTypeName = nextWrappingTypeName;
+      wrappingFieldName = this.wrappingFieldNames[wrapIndex];
     }
 
-    append.push({
-      typeName: this.outerTypeName,
-      additionalFields: {
-        [this.wrappingFieldNames[0]]: {
-          type: baseWrappingType,
-          resolve: createMergedResolver({ dehoist: true }),
-        },
+    newSchema = appendFields(newSchema, this.outerTypeName, {
+      [wrappingFieldName]: {
+        type: newSchema.getType(wrappingTypeName) as GraphQLObjectType,
+        resolve: createMergedResolver({ dehoist: true }),
       },
     });
-
-    const newSchema = modifyFields(schema, { append, remove });
 
     return this.transformer.transformSchema(newSchema);
   }

--- a/packages/wrap/src/transforms/WrapFields.ts
+++ b/packages/wrap/src/transforms/WrapFields.ts
@@ -1,6 +1,6 @@
 import { GraphQLSchema, GraphQLObjectType } from 'graphql';
 
-import { Transform, Request, hoistFieldNodes, removeFields, appendFields } from '@graphql-tools/utils';
+import { Transform, Request, hoistFieldNodes, removeObjectFields, appendObjectFields } from '@graphql-tools/utils';
 import { createMergedResolver, defaultMergedResolver } from '@graphql-tools/delegate';
 
 import MapFields from './MapFields';
@@ -41,7 +41,7 @@ export default class WrapFields implements Transform {
   }
 
   public transformSchema(schema: GraphQLSchema): GraphQLSchema {
-    let [newSchema, targetFieldConfigMap] = removeFields(
+    let [newSchema, targetFieldConfigMap] = removeObjectFields(
       schema,
       this.outerTypeName,
       !this.fieldNames ? () => true : fieldName => this.fieldNames.includes(fieldName)
@@ -51,12 +51,12 @@ export default class WrapFields implements Transform {
     let wrappingTypeName = this.wrappingTypeNames[wrapIndex];
     let wrappingFieldName = this.wrappingFieldNames[wrapIndex];
 
-    newSchema = appendFields(newSchema, wrappingTypeName, targetFieldConfigMap);
+    newSchema = appendObjectFields(newSchema, wrappingTypeName, targetFieldConfigMap);
 
     for (wrapIndex--; wrapIndex > -1; wrapIndex--) {
       const nextWrappingTypeName = this.wrappingTypeNames[wrapIndex];
 
-      newSchema = appendFields(newSchema, nextWrappingTypeName, {
+      newSchema = appendObjectFields(newSchema, nextWrappingTypeName, {
         [wrappingFieldName]: {
           type: newSchema.getType(wrappingTypeName) as GraphQLObjectType,
           resolve: defaultMergedResolver,
@@ -67,7 +67,7 @@ export default class WrapFields implements Transform {
       wrappingFieldName = this.wrappingFieldNames[wrapIndex];
     }
 
-    newSchema = appendFields(newSchema, this.outerTypeName, {
+    newSchema = appendObjectFields(newSchema, this.outerTypeName, {
       [wrappingFieldName]: {
         type: newSchema.getType(wrappingTypeName) as GraphQLObjectType,
         resolve: createMergedResolver({ dehoist: true }),

--- a/packages/wrap/tests/fragmentsAreNotDuplicated.test.ts
+++ b/packages/wrap/tests/fragmentsAreNotDuplicated.test.ts
@@ -6,11 +6,11 @@ import { addMocksToSchema } from '@graphql-tools/mock';
 
 describe('Merging schemas', () => {
   test('should not throw `There can be only one fragment named "FieldName"` errors', async () => {
-    const originalSchema = makeExecutableSchema({
+    let originalSchema = makeExecutableSchema({
       typeDefs: rawSchema,
     });
 
-    addMocksToSchema({ schema: originalSchema });
+    originalSchema = addMocksToSchema({ schema: originalSchema });
 
     const originalResult = await graphql(
       originalSchema,

--- a/packages/wrap/tests/gatsbyTransforms.test.ts
+++ b/packages/wrap/tests/gatsbyTransforms.test.ts
@@ -78,7 +78,7 @@ class StripNonQueryTransform {
 
 describe('Gatsby transforms', () => {
   test('work', async () => {
-    const schema = makeExecutableSchema({
+    let schema = makeExecutableSchema({
       typeDefs: `
       directive @cacheControl(maxAge: Int, scope: CacheControlScope) on FIELD_DEFINITION | OBJECT | INTERFACE
 
@@ -132,7 +132,7 @@ describe('Gatsby transforms', () => {
       `,
     });
 
-    addMocksToSchema({ schema });
+    schema = addMocksToSchema({ schema });
 
     const transformedSchema = wrapSchema(schema, [
       new StripNonQueryTransform(),

--- a/packages/wrap/tests/transforms.test.ts
+++ b/packages/wrap/tests/transforms.test.ts
@@ -223,7 +223,7 @@ describe('transforms', () => {
 
   describe('rename root type', () => {
     test('should work', async () => {
-      const subschema = makeExecutableSchema({
+      let subschema = makeExecutableSchema({
         typeDefs: `
           schema {
             query: QueryRoot
@@ -244,7 +244,7 @@ describe('transforms', () => {
         `,
       });
 
-      addMocksToSchema({ schema: subschema });
+      subschema = addMocksToSchema({ schema: subschema });
 
       const schema = wrapSchema(subschema, [
         new RenameRootTypes((name) => (name === 'QueryRoot' ? 'Query' : name)),

--- a/website/docs/generate-schema.md
+++ b/website/docs/generate-schema.md
@@ -210,7 +210,7 @@ This [GraphQL schema language cheat sheet](https://raw.githubusercontent.com/sog
 
 ### makeExecutableSchema(options)
 
-`makeExecutableSchema` takes a single argument: an object of options. Only the `typeDefs` option is required.
+`makeExecutableSchema` takes a single argument: an object of options. Only the `typeDefs` option is required. It returns a new schema, modified as specified.
 
 ```
 import { makeExecutableSchema } from '@graphql-tools/schema';

--- a/website/docs/mocking.md
+++ b/website/docs/mocking.md
@@ -283,7 +283,7 @@ const schemaWithMocks = addMocksToSchema({
 });
 ```
 
-Given an instance of GraphQLSchema and a mock object, `addMocksToSchema` modifies the schema in place to return mock data for any valid query that is sent to the server. If `mocks` is not passed, the defaults will be used for each of the scalar types. If `preserveResolvers` is set to `true`, existing resolvers will not be overwritten to provide mock data. This can be used to mock some parts of the server and not others.
+Given an instance of GraphQLSchema and a mock object, `addMocksToSchema` returns a new schema that can return mock data for any valid query that is sent to the server. If `mocks` is not passed, the defaults will be used for each of the scalar types. If `preserveResolvers` is set to `true`, existing resolvers will not be overwritten to provide mock data. This can be used to mock some parts of the server and not others.
 
 ### MockList
 

--- a/website/docs/mocking.md
+++ b/website/docs/mocking.md
@@ -25,8 +25,8 @@ const schemaString = `...`;
 // Make a GraphQL schema with no resolvers
 const schema = makeExecutableSchema({ typeDefs: schemaString });
 
-// Add mocks, modifies schema in place
-addMocksToSchema({ schema });
+// Create a new schema with mocks
+const schemaWithMocks = addMocksToSchema({ schema });
 
 const query = `
 query tasksForUser {
@@ -34,7 +34,7 @@ query tasksForUser {
 }
 `;
 
-graphql(schema, query).then((result) => console.log('Got result', result));
+graphql(schemaWithMocks, query).then((result) => console.log('Got result', result));
 ```
 
 > Note: If your schema has custom scalar types, you still need to define the `__serialize`, `__parseValue`, and `__parseLiteral` functions, and pass them inside the second argument to `makeExecutableSchema`.
@@ -104,7 +104,7 @@ Similarly, if you want to mock a **random** value for the Custom Scalar, you can
 The final step is to use the `mocks` object and `schema` to mock the server.
 
 ```js
-import { addMockFunctionsToSchema, mockServer } from '@graphql-tools/mock';
+import { addMocksToSchema, mockServer } from '@graphql-tools/mock';
 // Mock object.
 const mocks = {
   Int: () => 6,
@@ -115,8 +115,8 @@ const mocks = {
 const preserveResolvers = false;
 // Mock the server passing the schema, mocks object and preserverResolvers arguments.
 const server = mockServer(schema, mocks, preserveResolvers);
-// Alternatively, you can call addMockFunctionsToSchema with the same arguments.
-addMockFunctionsToSchema({
+// Alternatively, you can call addMocksToSchema with the same arguments.
+const schemaWithMocks = addMocksToSchema({
   schema,
   mocks,
   preserveResolvers,
@@ -245,10 +245,10 @@ const schema = makeExecutableSchema({
   resolvers
 })
 
-addMocksToSchema({
-    schema,
-    mocks,
-    preserveResolvers: true
+const schemaWithMocks = addMocksToSchema({
+  schema,
+  mocks,
+  preserveResolvers: true
 })
 ```
 
@@ -266,7 +266,7 @@ import * as introspectionResult from 'schema.json';
 
 const schema = buildClientSchema(introspectionResult);
 
-addMocksToSchema({schema});
+const schemaWithMocks = addMocksToSchema({schema});
 ```
 
 ## API
@@ -276,7 +276,7 @@ addMocksToSchema({schema});
 ```js
 import { addMocksToSchema } from '@graphql-tools/mock';
 
-addMocksToSchema({
+const schemaWithMocks = addMocksToSchema({
   schema,
   mocks: {},
   preserveResolvers: false,

--- a/website/docs/resolvers.md
+++ b/website/docs/resolvers.md
@@ -157,7 +157,7 @@ In addition to using a resolver map with `makeExecutableSchema`, you can use it 
 
 ### addResolversToSchema({ schema, resolvers, resolverValidationOptions?, inheritResolversFromInterfaces? })
 
-`addResolversToSchema` takes an options object of `IAddResolveFunctionsToSchemaOptions` and modifies the schema in place by attaching the resolvers to the relevant types.
+`addResolversToSchema` takes an options object of `IAddResolveFunctionsToSchemaOptions` and returns a new schema with resolvers attached to the relevant types.
 
 
 ```js
@@ -173,7 +173,7 @@ const resolvers = {
   },
 };
 
-addResolversToSchema({ schema, resolvers });
+const schemaWithResolvers = addResolversToSchema({ schema, resolvers });
 ```
 
 The `IAddResolveFunctionsToSchemaOptions` object has 4 properties that are described in [`makeExecutableSchema`](/docs/generate-schema/#makeexecutableschemaoptions).
@@ -188,6 +188,6 @@ export interface IAddResolveFunctionsToSchemaOptions {
 
 ### addSchemaLevelResolver(schema, rootResolveFunction)
 
-Some operations, such as authentication, need to be done only once per query. Logically, these operations belong in a schema level resolver field resolver, but unfortunately GraphQL-JS does not let you define one. `addSchemaLevelResolver` solves this by modifying the GraphQLSchema that is passed as the first argument.
+Some operations, such as authentication, need to be done only once per query. Logically, these operations belong in a schema level resolver field resolver, but unfortunately GraphQL-JS does not let you define one. `addSchemaLevelResolver` solves this by returning a new schema with the addition of a root resolve function.
 
 > You can check [Resolvers Composition](/docs/resolvers-composition) to compose resolvers with an authentication layer, and some checking operations etc.

--- a/website/docs/schema-loading.md
+++ b/website/docs/schema-loading.md
@@ -132,7 +132,7 @@ const schema = loadSchemaSync(join(__dirname, './schema.graphql'));
 const resolvers = {};
 
 // Add resolvers to the schema
-addResolversToSchema({
+const schemaWithResolvers = addResolversToSchema({
     schema,
     resolvers,
 });
@@ -141,7 +141,7 @@ const app = express();
 
 app.use(
     graphqlHTTP({
-        schema,
+        schemaWithResolvers,
         graphiql: true,
     })
 );

--- a/website/docs/schema-stitching.md
+++ b/website/docs/schema-stitching.md
@@ -22,7 +22,7 @@ import { stitchSchemas } from '@graphql-tools/stitch';
 // Mocked chirp schema
 // We don't worry about the schema implementation right now since we're just
 // demonstrating schema stitching.
-const chirpSchema = makeExecutableSchema({
+let chirpSchema = makeExecutableSchema({
   typeDefs: `
     type Chirp {
       id: ID!
@@ -37,10 +37,10 @@ const chirpSchema = makeExecutableSchema({
   `
 });
 
-addMocksToSchema({ schema: chirpSchema });
+chirpSchema = addMocksToSchema({ schema: chirpSchema });
 
 // Mocked author schema
-const authorSchema = makeExecutableSchema({
+let authorSchema = makeExecutableSchema({
   typeDefs: `
     type User {
       id: ID!
@@ -53,7 +53,7 @@ const authorSchema = makeExecutableSchema({
   `
 });
 
-addMocksToSchema({ schema: authorSchema });
+authorSchema = addMocksToSchema({ schema: authorSchema });
 
 export const schema = stitchSchemas({
   subschemas: [
@@ -186,7 +186,7 @@ import {
 // Mocked chirp schema; we don't want to worry about the schema
 // implementation right now since we're just demonstrating
 // schema stitching
-const chirpSchema = makeExecutableSchema({
+let chirpSchema = makeExecutableSchema({
   typeDefs: `
     type Chirp {
       id: ID!
@@ -201,7 +201,7 @@ const chirpSchema = makeExecutableSchema({
   `
 });
 
-addMocksToSchema({ schema: chirpSchema });
+chirpSchema = addMocksToSchema({ schema: chirpSchema });
 
 // create transforms
 

--- a/website/docs/schema-transforms.md
+++ b/website/docs/schema-transforms.md
@@ -171,12 +171,12 @@ RenameRootFields(
 
 ### Modifying object fields
 
-* `TransformObjectFields(objectFieldTransformer: ObjectFieldTransformer, fieldNodeTransformer?: FieldNodeTransformer))`: Given an object field transformer, arbitrarily transform fields. The `objectFieldTransformer` can return a `GraphQLFieldConfig` definition, an array with first member being the new field name and second member being the new `GraphQLFieldConfig` definition, `null` to remove the field, or `undefined` to leave the field unchanged. The optional `fieldNodeTransformer`, if specified, is called upon any field of that type in the request; result transformation can be specified by wrapping the field's resolver within the `objectFieldTransformer`. In this way, a field can be fully arbitrarily modified in place.
+* `TransformObjectFields(objectFieldTransformer: FieldTransformer, fieldNodeTransformer?: FieldNodeTransformer))`: Given a field transformer, arbitrarily transform fields. The `objectFieldTransformer` can return a `GraphQLFieldConfig` definition, an array with first member being the new field name and second member being the new `GraphQLFieldConfig` definition, `null` to remove the field, or `undefined` to leave the field unchanged. The optional `fieldNodeTransformer`, if specified, is called upon any field of that type in the request; result transformation can be specified by wrapping the field's resolver within the `objectFieldTransformer`.
 
 ```ts
-TransformObjectFields(objectFieldTransformer: ObjectFieldTransformer, fieldNodeTransformer: FieldNodeTransformer)
+TransformObjectFields(objectFieldTransformer: FieldTransformer, fieldNodeTransformer: FieldNodeTransformer)
 
-type ObjectFieldTransformer = (
+export type FieldTransformer = (
   typeName: string,
   fieldName: string,
   fieldConfig: GraphQLFieldConfig<any, any>,
@@ -184,13 +184,14 @@ type ObjectFieldTransformer = (
   | GraphQLFieldConfig<any, any>
   | [string, GraphQLFieldConfig<any, any>]
   | null
-  | void;
+  | undefined;
 
-type FieldNodeTransformer = (
+export type FieldNodeTransformer = (
   typeName: string,
   fieldName: string,
-  fieldNode: FieldNode
-) => FieldNode;
+  fieldNode: FieldNode,
+  fragments: Record<string, FragmentDefinitionNode>
+) => SelectionNode | Array<SelectionNode>;
 ```
 
 * `FilterObjectFields(filter: ObjectFilter)`: Removes object fields for which the `filter` function returns `false`.


### PR DESCRIPTION
## convert schema package functions to be immutable
- change addResolversToSchema, addCatchUndefinedToSchema, addErrorLoggingToSchema,
addSchemaLevelResolver to all use mapSchema to return a new schema without modifying the passed in schema
- change all internal use of these functions and all tests to use the return value

## bring default value updating into mapSchema
 - changing a leaf type should refresh all default values in composite and input object types

## change FieldMapper type
 - pass typeName instead of a type to field mappers.
 - passing an actual type can be confusing, because the type may be in the process of being mapped and not equivalent to the type in the original schema

## fix mapSchema bug
 - typo between IsInputType and IsInputObjectType was preventing scalar type mapping.

## refactor schema mod helper functions
 - add addTypes function that can add/replace types/directives (see detailed comment within the file with regard to motivation even for simply adding a new type vs just using toConfig)
 - helper functions names are now more specific appendFields => appendObjectFields, removeFIelds => removeObjectFIelds
 - the helper functions take a schema as input and return a fully functionable schema, modified as desired.
 - a more complex modifyFields function is not necessary, empty types can be added and later extended so if multiples types with cross-referencing fields need to be added, the types can be added first without fields, and the fields appended later.

## change WrapFields/HoistFields to use immutable helper functions rather than modifying existing schema
 - healing is no longer necessary.

## next?
 - the visitSchema function and the schema directive classes that use visitSchema are the next (final?) target for mutable => immutable conversion