### PR TITLE
Fix bare request delegation

### DIFF
--- a/packages/delegate/src/createRequest.ts
+++ b/packages/delegate/src/createRequest.ts
@@ -35,7 +35,7 @@ export function createRequestFromInfo({
   operation = getDelegatingOperation(info.parentType, info.schema),
   fieldName = info.fieldName,
   selectionSet,
-  fieldNodes,
+  fieldNodes = info.fieldNodes,
 }: ICreateRequestFromInfo): Request {
   return createRequest({
     sourceSchema: info.schema,
@@ -47,7 +47,7 @@ export function createRequestFromInfo({
     targetOperation: operation,
     targetFieldName: fieldName,
     selectionSet,
-    fieldNodes: selectionSet != null ? undefined : fieldNodes != null ? fieldNodes : info.fieldNodes,
+    fieldNodes,
   });
 }
 
@@ -66,7 +66,7 @@ export function createRequest({
   let newSelectionSet: SelectionSetNode = selectionSet;
   let argumentNodeMap: Record<string, ArgumentNode>;
 
-  if (selectionSet != null && fieldNodes == null) {
+  if (fieldNodes == null) {
     argumentNodeMap = Object.create(null);
   } else {
     const selections: Array<SelectionNode> = fieldNodes.reduce(

--- a/packages/delegate/src/types.ts
+++ b/packages/delegate/src/types.ts
@@ -30,8 +30,9 @@ export interface IDelegateToSchemaOptions<TContext = Record<string, any>, TArgs 
   skipTypeMerging?: boolean;
 }
 
-export interface IDelegateRequestOptions extends IDelegateToSchemaOptions {
+export interface IDelegateRequestOptions extends Omit<IDelegateToSchemaOptions, 'info'> {
   request: Request;
+  info?: GraphQLResolveInfo;
 }
 
 export interface ICreateRequestFromInfo {

--- a/packages/delegate/tests/createRequest.test.ts
+++ b/packages/delegate/tests/createRequest.test.ts
@@ -29,6 +29,72 @@ describe('bare requests', () => {
         Query: {
           delegate: (_root, args) => {
             const request = createRequest({
+              fieldNodes: [{
+                kind: Kind.FIELD,
+                name: {
+                  kind: Kind.NAME,
+                  value: 'delegate',
+                },
+                arguments: [{
+                  kind: Kind.ARGUMENT,
+                  name: {
+                    kind: Kind.NAME,
+                    value: 'input',
+                  },
+                  value: {
+                    kind: Kind.STRING,
+                    value: args.input,
+                  }
+                }]
+              }],
+              targetOperation: 'query',
+              targetFieldName: 'test',
+            });
+            return delegateRequest({
+              request,
+              schema: innerSchema,
+            });
+          },
+        },
+      },
+    });
+
+    const result = await graphql(
+      outerSchema,
+      `
+        query {
+          delegate(input: "test")
+        }
+      `,
+    );
+
+    expect(result.data.delegate).toEqual('test');
+  });
+
+  test('should work with adding args on delegation', async () => {
+    const innerSchema = makeExecutableSchema({
+      typeDefs: `
+        type Query {
+          test(input: String): String
+        }
+      `,
+      resolvers: {
+        Query: {
+          test: (_root, args) => args.input
+        },
+      },
+    });
+
+    const outerSchema = makeExecutableSchema({
+      typeDefs: `
+        type Query {
+          delegate(input: String): String
+        }
+      `,
+      resolvers: {
+        Query: {
+          delegate: (_root, args) => {
+            const request = createRequest({
               targetOperation: 'query',
               targetFieldName: 'test',
             });

--- a/packages/delegate/tests/createRequest.test.ts
+++ b/packages/delegate/tests/createRequest.test.ts
@@ -1,0 +1,59 @@
+import { graphql } from 'graphql';
+
+import { createRequest } from '../src/createRequest';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { delegateRequest } from '../src/delegateToSchema';
+
+describe('bare requests', () => {
+  test('should work', async () => {
+    const innerSchema = makeExecutableSchema({
+      typeDefs: `
+        type Query {
+          test(input: String): String
+        }
+      `,
+      resolvers: {
+        Query: {
+          test: (_root, args) => args.input
+        },
+      },
+    });
+
+    const outerSchema = makeExecutableSchema({
+      typeDefs: `
+        type Query {
+          delegate(input: String): String
+        }
+      `,
+      resolvers: {
+        Query: {
+          delegate: (_root, args, context, info) => {
+            const request = createRequest({
+              targetOperation: 'query',
+              targetFieldName: 'test',
+            });
+            return delegateRequest({
+              request,
+              schema: innerSchema,
+              fieldName: 'test',
+              args,
+              context,
+              info
+            });
+          },
+        },
+      },
+    });
+
+    const result = await graphql(
+      outerSchema,
+      `
+        query {
+          delegate(input: "test")
+        }
+      `,
+    );
+
+    expect(result.data.delegate).toEqual('test');
+  });
+});

--- a/packages/delegate/tests/createRequest.test.ts
+++ b/packages/delegate/tests/createRequest.test.ts
@@ -1,4 +1,4 @@
-import { graphql } from 'graphql';
+import { graphql, Kind } from 'graphql';
 
 import { createRequest } from '../src/createRequest';
 import { makeExecutableSchema } from '@graphql-tools/schema';
@@ -27,7 +27,7 @@ describe('bare requests', () => {
       `,
       resolvers: {
         Query: {
-          delegate: (_root, args, context, info) => {
+          delegate: (_root, args) => {
             const request = createRequest({
               targetOperation: 'query',
               targetFieldName: 'test',
@@ -35,10 +35,7 @@ describe('bare requests', () => {
             return delegateRequest({
               request,
               schema: innerSchema,
-              fieldName: 'test',
               args,
-              context,
-              info
             });
           },
         },

--- a/packages/delegate/tests/delegateToSchema.test..ts
+++ b/packages/delegate/tests/delegateToSchema.test..ts
@@ -1,0 +1,149 @@
+import { graphql } from 'graphql';
+
+import { delegateToSchema } from '../src/delegateToSchema';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+
+describe('delegateToSchema', () => {
+  test('should work', async () => {
+    const innerSchema = makeExecutableSchema({
+      typeDefs: `
+        type Query {
+          test(input: String): String
+        }
+      `,
+      resolvers: {
+        Query: {
+          test: (_root, args) => args.input
+        },
+      },
+    });
+
+    const outerSchema = makeExecutableSchema({
+      typeDefs: `
+        type Query {
+          delegateToSchema(input: String): String
+        }
+      `,
+      resolvers: {
+        Query: {
+          delegateToSchema: (_root, args, context, info) => delegateToSchema({
+            schema: innerSchema,
+            operation: 'query',
+            fieldName: 'test',
+            args,
+            context,
+            info,
+          }),
+        },
+      },
+    });
+
+    const result = await graphql(
+      outerSchema,
+      `
+        query {
+          delegateToSchema(input: "test")
+        }
+      `,
+    );
+
+    expect(result.data.delegateToSchema).toEqual('test');
+  });
+
+  test('should work even where there are default fields', async () => {
+    const innerSchema = makeExecutableSchema({
+      typeDefs: `
+        type Query {
+          test(input: String = "test"): String
+        }
+      `,
+      resolvers: {
+        Query: {
+          test: (_root, args) => args.input
+        },
+      },
+    });
+
+    const outerSchema = makeExecutableSchema({
+      typeDefs: `
+        type Query {
+          delegateToSchema(input: String = "test"): String
+        }
+      `,
+      resolvers: {
+        Query: {
+          delegateToSchema: (_root, args, context, info) => delegateToSchema({
+            schema: innerSchema,
+            operation: 'query',
+            fieldName: 'test',
+            args,
+            context,
+            info,
+          }),
+        },
+      },
+    });
+
+    const result = await graphql(
+      outerSchema,
+      `
+        query {
+          delegateToSchema
+        }
+      `,
+    );
+
+    expect(result.data.delegateToSchema).toEqual('test');
+  });
+
+  test('should work even when there are variables', async () => {
+    const innerSchema = makeExecutableSchema({
+      typeDefs: `
+        type Query {
+          test(input: String): String
+        }
+      `,
+      resolvers: {
+        Query: {
+          test: (_root, args) => args.input
+        },
+      },
+    });
+
+    const outerSchema = makeExecutableSchema({
+      typeDefs: `
+        type Query {
+          delegateToSchema(input: String): String
+        }
+      `,
+      resolvers: {
+        Query: {
+          delegateToSchema: (_root, args, context, info) => delegateToSchema({
+            schema: innerSchema,
+            operation: 'query',
+            fieldName: 'test',
+            args,
+            context,
+            info,
+          }),
+        },
+      },
+    });
+
+    const result = await graphql(
+      outerSchema,
+      `
+        query($input: String) {
+          delegateToSchema(input: $input)
+        }
+      `,
+      undefined,
+      undefined,
+      {
+        input: 'test',
+      },
+    );
+
+    expect(result.data.delegateToSchema).toEqual('test');
+  });
+});

--- a/packages/stitch/tests/fragments.test.ts
+++ b/packages/stitch/tests/fragments.test.ts
@@ -1,8 +1,6 @@
 import { GraphQLSchema, graphql } from 'graphql';
 
 import { delegateToSchema } from '@graphql-tools/delegate';
-import { wrapSchema } from '@graphql-tools/wrap';
-import { makeExecutableSchema } from '@graphql-tools/schema';
 import { IResolvers } from '@graphql-tools/utils';
 
 import { stitchSchemas } from '../src/stitchSchemas';
@@ -104,100 +102,6 @@ describe('stitching', () => {
           },
         },
       });
-    });
-  });
-});
-
-describe('schema delegation', () => {
-  test('should work even when there are default fields', async () => {
-    const schema = makeExecutableSchema({
-      typeDefs: `
-        scalar JSON
-        type Data {
-          json(input: JSON = "test"): JSON
-        }
-        type Query {
-          data: Data
-        }
-      `,
-      resolvers: {
-        Query: {
-          data: () => ({}),
-        },
-        Data: {
-          json: (_root, args, context, info) =>
-            delegateToSchema({
-              schema: propertySchema,
-              fieldName: 'jsonTest',
-              args,
-              context,
-              info,
-            }),
-        },
-      },
-    });
-
-    const result = await graphql(
-      schema,
-      `
-        query {
-          data {
-            json
-          }
-        }
-      `,
-    );
-
-    expect(result).toEqual({
-      data: {
-        data: {
-          json: 'test',
-        },
-      },
-    });
-  });
-
-  test('should work even with variables', async () => {
-    const innerSchema = makeExecutableSchema({
-      typeDefs: `
-        type User {
-          id(show: Boolean): ID
-        }
-        type Query {
-          user: User
-        }
-      `,
-      resolvers: {
-        Query: {
-          user: () => ({}),
-        },
-        User: {
-          id: () => '123',
-        },
-      },
-    });
-    const schema = wrapSchema(innerSchema);
-
-    const result = await graphql(
-      schema,
-      `
-        query($show: Boolean) {
-          user {
-            id(show: $show)
-          }
-        }
-      `,
-      null,
-      null,
-      { show: true },
-    );
-
-    expect(result).toEqual({
-      data: {
-        user: {
-          id: '123',
-        },
-      },
     });
   });
 });


### PR DESCRIPTION
delegateRequest should work without passing info argument to delegateRequest.

details about the request to be delegated (operation, fieldName, returnType) should be calculated from the request (if not provided).