### PR TITLE
fix removeObjectFields helper

### DIFF
--- a/packages/utils/src/fields.ts
+++ b/packages/utils/src/fields.ts
@@ -52,15 +52,87 @@ export function removeObjectFields(
         const config = type.toConfig();
         const originalFieldConfigMap = config.fields;
 
+        const newFieldConfigMap = {};
         Object.keys(originalFieldConfigMap).forEach(fieldName => {
           const originalFieldConfig = originalFieldConfigMap[fieldName];
           if (testFn(fieldName, originalFieldConfig)) {
             removedFields[fieldName] = originalFieldConfig;
+          } else {
+            newFieldConfigMap[fieldName] = originalFieldConfig;
+          }
+        });
+
+        return new GraphQLObjectType({
+          ...config,
+          fields: newFieldConfigMap,
+        });
+      }
+    },
+  });
+
+  return [newSchema, removedFields];
+}
+
+export function selectObjectFields(
+  schema: GraphQLSchema,
+  typeName: string,
+  testFn: (fieldName: string, field: GraphQLFieldConfig<any, any>) => boolean
+): GraphQLFieldConfigMap<any, any> {
+  const selectedFields = {};
+  mapSchema(schema, {
+    [MapperKind.OBJECT_TYPE]: type => {
+      if (type.name === typeName) {
+        const config = type.toConfig();
+        const originalFieldConfigMap = config.fields;
+
+        Object.keys(originalFieldConfigMap).forEach(fieldName => {
+          const originalFieldConfig = originalFieldConfigMap[fieldName];
+          if (testFn(fieldName, originalFieldConfig)) {
+            selectedFields[fieldName] = originalFieldConfig;
           }
         });
       }
 
       return undefined;
+    },
+  });
+
+  return selectedFields;
+}
+
+export function modifyObjectFields(
+  schema: GraphQLSchema,
+  typeName: string,
+  testFn: (fieldName: string, field: GraphQLFieldConfig<any, any>) => boolean,
+  newFields: GraphQLFieldConfigMap<any, any>
+): [GraphQLSchema, GraphQLFieldConfigMap<any, any>] {
+  const removedFields = {};
+  const newSchema = mapSchema(schema, {
+    [MapperKind.OBJECT_TYPE]: type => {
+      if (type.name === typeName) {
+        const config = type.toConfig();
+        const originalFieldConfigMap = config.fields;
+
+        const newFieldConfigMap = {};
+        Object.keys(originalFieldConfigMap).forEach(fieldName => {
+          const originalFieldConfig = originalFieldConfigMap[fieldName];
+          if (testFn(fieldName, originalFieldConfig)) {
+            removedFields[fieldName] = originalFieldConfig;
+          } else {
+            newFieldConfigMap[fieldName] = originalFieldConfig;
+          }
+        });
+
+        Object.keys(newFields).forEach(fieldName => {
+          const fieldConfig = newFields[fieldName];
+          newFieldConfigMap[fieldName] = fieldConfig;
+        });
+
+        return new GraphQLObjectType({
+          ...config,
+          fields: newFieldConfigMap,
+        });
+      }
     },
   });
 


### PR DESCRIPTION
it was selecting, not helping!

it turns out that removing all object fields leads to automatic type pruning -- this could be optionally disabled, but easier for users to just add a selectObjectFields helper and a modifyObjectFields helper that can remove and add fields in a single step