### PR TITLE
avoid infinite loop

### DIFF
--- a/packages/loaders/url/tests/url-loader.spec.ts
+++ b/packages/loaders/url/tests/url-loader.spec.ts
@@ -11,7 +11,9 @@ describe('Schema URL Loader', () => {
   const loader = new UrlLoader();
 
   const testTypeDefs = /* GraphQL */`
-schema { query: CustomQuery }
+schema {
+  query: CustomQuery
+}
 """Test type comment"""
 type CustomQuery {
   """Test field comment"""

--- a/packages/utils/src/print-schema-with-directives.ts
+++ b/packages/utils/src/print-schema-with-directives.ts
@@ -120,7 +120,7 @@ function correctType<TMap extends { [key: string]: GraphQLNamedType }, TName ext
 }
 
 function getSchemaDefinition(schema: GraphQLSchema) {
-  if (schema.astNode) {
+  if (!Object.getOwnPropertyDescriptor(schema, 'astNode').get && schema.astNode) {
     return print(schema.astNode);
   } else {
     return createSchemaDefinition({


### PR DESCRIPTION
fixSchemaAst fixes the schema ast by adding a getter for the property which lazily calls buildSchema(printSchemaWithDirectives(schema) to rebuild the schema.

printSchemaWithDirectives, however, now checks to see if schema.astNode is defined, and so will end up calling itself. This can be avoided by making sure that the astNode is not defined as a getter.

fixSchemaAst could alternatively be changed to return a new schema ratehr than modifying the original schema.