### PR TITLE
support regenerating schema, type and directive object annotations

### DIFF
--- a/packages/utils/src/mapSchema.ts
+++ b/packages/utils/src/mapSchema.ts
@@ -40,6 +40,7 @@ import {
 
 import { rewireTypes } from './rewire';
 import { serializeInputValue, parseInputValue } from './transformInputValue';
+import { reannotateObject } from './reannotateObject';
 
 export function mapSchema(schema: GraphQLSchema, schemaMapper: SchemaMapper = {}): GraphQLSchema {
   const originalTypeMap = schema.getTypeMap();
@@ -77,14 +78,18 @@ export function mapSchema(schema: GraphQLSchema, schemaMapper: SchemaMapper = {}
 
   const { typeMap, directives } = rewireTypes(newTypeMap, newDirectives);
 
-  return new GraphQLSchema({
-    ...schema.toConfig(),
-    query: newQueryTypeName ? (typeMap[newQueryTypeName] as GraphQLObjectType) : undefined,
-    mutation: newMutationTypeName ? (typeMap[newMutationTypeName] as GraphQLObjectType) : undefined,
-    subscription: newSubscriptionTypeName != null ? (typeMap[newSubscriptionTypeName] as GraphQLObjectType) : undefined,
-    types: Object.keys(typeMap).map(typeName => typeMap[typeName]),
-    directives,
-  });
+  return reannotateObject(
+    new GraphQLSchema({
+      ...schema.toConfig(),
+      query: newQueryTypeName ? (typeMap[newQueryTypeName] as GraphQLObjectType) : undefined,
+      mutation: newMutationTypeName ? (typeMap[newMutationTypeName] as GraphQLObjectType) : undefined,
+      subscription:
+        newSubscriptionTypeName != null ? (typeMap[newSubscriptionTypeName] as GraphQLObjectType) : undefined,
+      types: Object.keys(typeMap).map(typeName => typeMap[typeName]),
+      directives,
+    }),
+    schema
+  );
 }
 
 function mapTypes(
@@ -98,18 +103,27 @@ function mapTypes(
   Object.keys(originalTypeMap).forEach(typeName => {
     if (!typeName.startsWith('__')) {
       const originalType = originalTypeMap[typeName];
-      if (originalType != null && testFn(originalType)) {
-        const typeMapper = getTypeMapper(schema, schemaMapper, typeName);
 
-        if (typeMapper != null) {
-          const maybeNewType = typeMapper(originalType, schema);
-          newTypeMap[typeName] = maybeNewType !== undefined ? maybeNewType : originalType;
-        } else {
-          newTypeMap[typeName] = originalType;
-        }
-      } else {
+      if (originalType == null || !testFn(originalType)) {
         newTypeMap[typeName] = originalType;
+        return;
       }
+
+      const typeMapper = getTypeMapper(schema, schemaMapper, typeName);
+
+      if (typeMapper == null) {
+        newTypeMap[typeName] = originalType;
+        return;
+      }
+
+      const maybeNewType = typeMapper(originalType, schema);
+
+      if (maybeNewType === undefined) {
+        newTypeMap[typeName] = originalType;
+        return;
+      }
+
+      newTypeMap[typeName] = reannotateObject(maybeNewType, originalType);
     }
   });
 
@@ -237,10 +251,13 @@ function mapFields(originalTypeMap: TypeMap, schema: GraphQLSchema, schemaMapper
       });
 
       if (isObjectType(originalType)) {
-        newTypeMap[typeName] = new GraphQLObjectType({
-          ...((config as unknown) as GraphQLObjectTypeConfig<any, any>),
-          fields: newFieldConfigMap,
-        });
+        newTypeMap[typeName] = reannotateObject(
+          new GraphQLObjectType({
+            ...((config as unknown) as GraphQLObjectTypeConfig<any, any>),
+            fields: newFieldConfigMap,
+          }),
+          originalType
+        );
       } else if (isInterfaceType(originalType)) {
         newTypeMap[typeName] = new GraphQLInterfaceType({
           ...((config as unknown) as GraphQLInterfaceTypeConfig<any, any>),
@@ -319,10 +336,13 @@ function mapArguments(originalTypeMap: TypeMap, schema: GraphQLSchema, schemaMap
       });
 
       if (isObjectType(originalType)) {
-        newTypeMap[typeName] = new GraphQLObjectType({
-          ...((config as unknown) as GraphQLObjectTypeConfig<any, any>),
-          fields: newFieldConfigMap,
-        });
+        newTypeMap[typeName] = reannotateObject(
+          new GraphQLObjectType({
+            ...((config as unknown) as GraphQLObjectTypeConfig<any, any>),
+            fields: newFieldConfigMap,
+          }),
+          originalType
+        );
       } else if (isInterfaceType(originalType)) {
         newTypeMap[typeName] = new GraphQLInterfaceType({
           ...((config as unknown) as GraphQLInterfaceTypeConfig<any, any>),
@@ -357,7 +377,7 @@ function mapDirectives(
     if (mappedDirective === undefined) {
       newDirectives.push(directive);
     } else if (mappedDirective !== null) {
-      newDirectives.push(mappedDirective);
+      newDirectives.push(reannotateObject(mappedDirective, directive));
     }
   });
 

--- a/packages/utils/src/reannotateObject.ts
+++ b/packages/utils/src/reannotateObject.ts
@@ -1,0 +1,20 @@
+export function reannotateObject<T extends object>(newObject: T, oldObject: T): T {
+  if (newObject == null) {
+    return newObject;
+  }
+
+  const symbols = Object.getOwnPropertySymbols(oldObject);
+  symbols.forEach(symbol => {
+    if (!(symbol in newObject)) {
+      newObject[symbol] = oldObject[symbol];
+    }
+  });
+
+  const names = Object.getOwnPropertyNames(oldObject);
+  names.forEach(name => {
+    if (!(name in newObject)) {
+      newObject[name] = oldObject[name];
+    }
+  });
+  return newObject;
+}

--- a/packages/utils/src/rewire.ts
+++ b/packages/utils/src/rewire.ts
@@ -27,6 +27,7 @@ import {
 
 import { getBuiltInForStub, isNamedStub } from './stub';
 import { TypeMap } from './Interfaces';
+import { reannotateObject } from './reannotateObject';
 
 export function rewireTypes(
   originalTypeMap: Record<string, GraphQLNamedType | null>,
@@ -62,7 +63,7 @@ export function rewireTypes(
   });
 
   Object.keys(newTypeMap).forEach(typeName => {
-    newTypeMap[typeName] = rewireNamedType(newTypeMap[typeName]);
+    newTypeMap[typeName] = reannotateObject(rewireNamedType(newTypeMap[typeName]), newTypeMap[typeName]);
   });
 
   const newDirectives = directives.map(directive => rewireDirective(directive));

--- a/packages/utils/tests/mapSchema.test.ts
+++ b/packages/utils/tests/mapSchema.test.ts
@@ -1,4 +1,4 @@
-import { GraphQLObjectType, GraphQLSchema, graphqlSync } from 'graphql';
+import { GraphQLObjectType, GraphQLSchema, graphqlSync, GraphQLString } from 'graphql';
 
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { MapperKind, mapSchema } from '@graphql-tools/utils';
@@ -59,5 +59,46 @@ describe('mapSchema', () => {
 
     expect(newSchema).toBeInstanceOf(GraphQLSchema);
     expect(newSchema.getQueryType().name).toBe('RootQuery');
+  });
+
+  test('can copy nonstandard properties', () => {
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          'test': {
+            type: GraphQLString
+          }
+        }
+      })
+    });
+
+    const symbol = Symbol('symbol');
+
+    Object.defineProperty(
+      schema.getQueryType(),
+      symbol,
+      {
+        enumerable: false,
+        configurable: false,
+        value: symbol,
+      }
+    );
+
+    Object.defineProperty(
+      schema.getQueryType(),
+      'value',
+      {
+        enumerable: false,
+        configurable: false,
+        value: 'value',
+      }
+    );
+
+    const newSchema = mapSchema(schema, {});
+
+    expect(newSchema).toBeInstanceOf(GraphQLSchema);
+    expect((newSchema.getQueryType() as unknown as { symbol: symbol })[symbol]).toBe(symbol);
+    expect((newSchema.getQueryType() as unknown as { value: string }).value).toBe('value');
   });
 });


### PR DESCRIPTION
within the graphql ecosystem, many users still annotate schemas, types, and
possibly directives with custom properties instead of using the
newer extensions property.

mapSchema should copy all custom properties when creating graphql
objects as possible.