### PR TITLE
merge-typedefs doc example is missing a equal sign

### DIFF
--- a/website/docs/merge-typedefs.md
+++ b/website/docs/merge-typedefs.md
@@ -112,7 +112,7 @@ const { mergeTypeDefs } = require('@graphql-tools/merge');
 
 const typesArray = loadFiles(path.join(__dirname, './types'));
 
-module.exports mergeTypeDefs(typesArray, { all: true });
+module.exports = mergeTypeDefs(typesArray, { all: true });
 ```
 When using the `loadFiles` function you can also implement your type definitions using `.graphql` or `.gql` or `.graphqls` files.
 


### PR DESCRIPTION
Just missing a equal sign in the example. Just committed a small fix to the docs.