### PR TITLE
docs(attachDirectiveResolvers): fix import statement; attachDirective…

### DIFF
--- a/website/docs/directive-resolvers.md
+++ b/website/docs/directive-resolvers.md
@@ -163,7 +163,7 @@ const schema = makeExecutableSchema({
 ### attachDirectiveResolvers
 
 ```js
-import { attachDirectiveResolvers } from '@graphql-tools/utils';
+import { attachDirectiveResolvers } from '@graphql-tools/schema';
 
 const directiveResolvers = {
   // directive resolvers implement


### PR DESCRIPTION
…Resolvers in schema, not utils

<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.


I noticed the import statement in the docs was incorrect, it was pointing to `@graphql-tools/utils`, but `@graphql-tools/schema` has the function.