### PR TITLE
fix: loadFiles path resolving issue

### DIFF
--- a/packages/load-files/src/index.ts
+++ b/packages/load-files/src/index.ts
@@ -1,7 +1,7 @@
 import globby, { sync as globbySync, GlobbyOptions } from 'globby';
 import unixify from 'unixify';
 import { extname } from 'path';
-import { readFile, stat, statSync, readFileSync } from 'fs-extra';
+import { readFile, statSync, readFileSync } from 'fs-extra';
 
 const DEFAULT_IGNORED_EXTENSIONS = ['spec', 'test', 'd', 'map'];
 const DEFAULT_EXTENSIONS = ['gql', 'graphql', 'graphqls', 'ts', 'js'];
@@ -18,15 +18,6 @@ function asArray<T>(obj: T | T[]): T[] {
 function isDirectorySync(path: string) {
   try {
     const pathStat = statSync(path);
-    return pathStat.isDirectory();
-  } catch (e) {
-    return false;
-  }
-}
-
-async function isDirectory(path: string) {
-  try {
-    const pathStat = await stat(path);
     return pathStat.isDirectory();
   } catch (e) {
     return false;
@@ -195,7 +186,7 @@ export async function loadFiles(
   const execOptions = { ...LoadFilesDefaultOptions, ...options };
   const relevantPaths = await scanForFiles(
     asArray(pattern).map(path =>
-      isDirectory(path)
+      isDirectorySync(path)
         ? buildGlob(unixify(path), execOptions.extensions, execOptions.ignoredExtensions, execOptions.recursive)
         : unixify(path)
     ),

--- a/packages/load-files/tests/file-scanner.spec.ts
+++ b/packages/load-files/tests/file-scanner.spec.ts
@@ -89,11 +89,6 @@ describe('file scanner', function() {
   describe('schema', () => {
     const schemaContent = `type MyType { f: String }`;
     testSchemaDir({
-      path: './test-assets/1/*.graphql',
-      expected: [schemaContent],
-      note: 'minimatch pattern',
-    });
-    testSchemaDir({
       path: './test-assets/1',
       expected: [schemaContent],
       note: 'one file',
@@ -145,14 +140,14 @@ describe('file scanner', function() {
       note: 'should include index by default',
       extensions: ['graphql'],
     });
+    testSchemaDir({
+      path: './test-assets/1/*.graphql',
+      expected: [schemaContent],
+      note: 'non-directory pattern',
+    });
   });
 
   describe('resolvers', () => {
-    testResolversDir({
-      path: './test-assets/6/*.resolvers.js',
-      expected: [{ MyType: { f: 1 } }],
-      note: 'minimatch pattern',
-    });
     testResolversDir({
       path: './test-assets/6',
       expected: [{ MyType: { f: 1 } }],
@@ -214,6 +209,11 @@ describe('file scanner', function() {
       extensions: ['js'],
       compareValue: true,
       ignoreIndex: true,
+    });
+    testResolversDir({
+      path: './test-assets/6/*.resolvers.js',
+      expected: [{ MyType: { f: 1 } }],
+      note: 'non-directory pattern',
     });
   });
 });

--- a/packages/load-files/tests/file-scanner.spec.ts
+++ b/packages/load-files/tests/file-scanner.spec.ts
@@ -89,6 +89,11 @@ describe('file scanner', function() {
   describe('schema', () => {
     const schemaContent = `type MyType { f: String }`;
     testSchemaDir({
+      path: './test-assets/1/*.graphql',
+      expected: [schemaContent],
+      note: 'minimatch pattern',
+    });
+    testSchemaDir({
       path: './test-assets/1',
       expected: [schemaContent],
       note: 'one file',
@@ -143,6 +148,11 @@ describe('file scanner', function() {
   });
 
   describe('resolvers', () => {
+    testResolversDir({
+      path: './test-assets/6/*.resolvers.js',
+      expected: [{ MyType: { f: 1 } }],
+      note: 'minimatch pattern',
+    });
     testResolversDir({
       path: './test-assets/6',
       expected: [{ MyType: { f: 1 } }],


### PR DESCRIPTION
`loadFiles` fails to load file with non-directory `minimatch` patterns. It's using async function `isDirectory` for pattern checking but not waiting for it to finish, hence the result of the ternary is always `exprIfTrue`.

This PR adds `await`.