### PR TITLE
allow MapFields to transform all field nodes

### DIFF
--- a/packages/wrap/src/transforms/MapFields.ts
+++ b/packages/wrap/src/transforms/MapFields.ts
@@ -2,13 +2,13 @@ import { GraphQLSchema } from 'graphql';
 
 import { Transform, Request, FieldNodeMappers } from '@graphql-tools/utils';
 
-import TransformObjectFields from './TransformObjectFields';
+import TransformCompositeFields from './TransformCompositeFields';
 
 export default class MapFields implements Transform {
-  private readonly transformer: TransformObjectFields;
+  private readonly transformer: TransformCompositeFields;
 
   constructor(fieldNodeTransformerMap: FieldNodeMappers) {
-    this.transformer = new TransformObjectFields(
+    this.transformer = new TransformCompositeFields(
       (_typeName, _fieldName, fieldConfig) => fieldConfig,
       (typeName, fieldName, fieldNode, fragments) => {
         const typeTransformers = fieldNodeTransformerMap[typeName];


### PR DESCRIPTION
MapFields (really should be MapFieldNodes, this should be changed in next major release) provides a quick way to modify field nodes for object types by specification of a map of type/field names as opposed to a function.

this backwards-compatible change allows MapFields to work for interfaces and root types.