### PR TITLE
docs(schema-directives): fix REST API example = field.resolve => fiel…

### DIFF
--- a/website/docs/schema-directives.md
+++ b/website/docs/schema-directives.md
@@ -193,7 +193,7 @@ function restDirective(directiveName: string) {
         const directiveArgumentMap = directives[directiveName];
         if (directiveArgumentMap) {
           const { url } = directiveArgumentMap;
-          field.resolve = () => fetch(url);
+          fieldConfig.resolve = () => fetch(url);
           return fieldConfig;
         }
       }


### PR DESCRIPTION
…dConfig.resolve

`field` is not defined in this context, but `fieldConfig` is. Did we mean `fieldConfig`? 

<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

