### PR TITLE
Replace schemaDirectives argument in docs

### DIFF
--- a/website/docs/schema-directives.md
+++ b/website/docs/schema-directives.md
@@ -31,7 +31,7 @@ Earlier versions of `graphql-tools` provides a class-based mechanism for directi
 
 Most of this document is concerned with _implementing_ schema directives, and some of the examples may seem quite complicated. No matter how many tools and best practices you have at your disposal, it can be difficult to implement a non-trivial schema directive in a reliable, reusable way. Exhaustive testing is essential, and using a typed language like TypeScript is recommended, because there are so many different schema types to worry about.
 
-However, the API we provide for _using_ a schema directive is extremely simple. Just import the implementation of the directive, then pass it to `makeExecutableSchema` via the `schemaDirectives` argument, which is an object that maps directive names to directive implementations:
+However, the API we provide for _using_ a schema directive is extremely simple. Just import the implementation of the directive, then pass it to `makeExecutableSchema` via the `schemaTransforms` argument, which is an array of schema transformation functions:
 
 ```js
 import { makeExecutableSchema } from "@graphql-tools/schema";


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

Old `schemaDirectives` is mentioned in the docs while example already has `schemaTransforms`.
