### PR TITLE
Add default Apollo Engine endpoint

### DIFF
--- a/packages/loaders/apollo-engine/src/index.ts
+++ b/packages/loaders/apollo-engine/src/index.ts
@@ -4,13 +4,15 @@ import { buildClientSchema } from 'graphql';
 
 export interface ApolloEngineOptions extends SingleFileOptions {
   engine: {
-    endpoint: string;
+    endpoint?: string;
     apiKey: string;
   };
   graph: string;
   variant: string;
   headers?: Record<string, string>;
 }
+
+const DEFAULT_APOLLO_ENDPOINT = 'https://engine-graphql.apollographql.com/api/graphql';
 
 export class ApolloEngineLoader implements SchemaLoader<ApolloEngineOptions> {
   loaderId() {
@@ -26,7 +28,7 @@ export class ApolloEngineLoader implements SchemaLoader<ApolloEngineOptions> {
   }
 
   async load(_: 'apollo-engine', options: ApolloEngineOptions): Promise<Source> {
-    const response = await fetch(options.engine.endpoint, {
+    const response = await fetch(options.engine.endpoint || DEFAULT_APOLLO_ENDPOINT, {
       method: 'POST',
       headers: {
         'x-api-key': options.engine.apiKey,


### PR DESCRIPTION
Generally, users are not going to provide a custom endpoint for fetching from the Apollo Engine, so make it optional and add a sensible default value.

<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
- [ ] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

