### PR TITLE
Fix: resolve correct data if schema is wrapped

### DIFF
--- a/packages/delegate/src/delegateToSchema.ts
+++ b/packages/delegate/src/delegateToSchema.ts
@@ -288,6 +288,5 @@ function createDefaultSubscriber(schema: GraphQLSchema, rootValue: Record<string
       contextValue: context,
       variableValues: variables,
       rootValue: rootValue ?? info?.rootValue,
-      subscribeFieldResolver: payload => payload,
     }) as any;
 }

--- a/packages/delegate/src/delegateToSchema.ts
+++ b/packages/delegate/src/delegateToSchema.ts
@@ -271,10 +271,23 @@ export function delegateRequest({
 
 function createDefaultExecutor(schema: GraphQLSchema, rootValue: Record<string, any>) {
   return ({ document, context, variables, info }: ExecutionParams) =>
-    execute(schema, document, rootValue ?? info?.rootValue, context, variables);
+    execute({
+      schema,
+      document,
+      contextValue: context,
+      variableValues: variables,
+      rootValue: rootValue ?? info?.rootValue,
+    });
 }
 
 function createDefaultSubscriber(schema: GraphQLSchema, rootValue: Record<string, any>) {
   return ({ document, context, variables, info }: ExecutionParams) =>
-    subscribe(schema, document, rootValue ?? info?.rootValue, context, variables) as any;
+    subscribe({
+      schema,
+      document,
+      contextValue: context,
+      variableValues: variables,
+      rootValue: rootValue ?? info?.rootValue,
+      subscribeFieldResolver: payload => payload,
+    }) as any;
 }

--- a/packages/wrap/src/generateProxyingResolvers.ts
+++ b/packages/wrap/src/generateProxyingResolvers.ts
@@ -44,8 +44,6 @@ export function generateProxyingResolvers(
 
   const resolvers = {};
   Object.keys(operationTypes).forEach((operation: Operation) => {
-    const resolveField = operation === 'subscription' ? 'subscribe' : 'resolve';
-
     const rootType = operationTypes[operation];
     if (rootType != null) {
       const typeName = rootType.name;
@@ -63,9 +61,16 @@ export function generateProxyingResolvers(
 
         const finalResolver = createPossiblyNestedProxyingResolver(subschemaOrSubschemaConfig, proxyingResolver);
 
-        resolvers[typeName][fieldName] = {
-          [resolveField]: finalResolver,
-        };
+        if (operation === 'subscription') {
+          resolvers[typeName][fieldName] = {
+            subscribe: finalResolver,
+            resolve: (payload: any) => payload[fieldName],
+          };
+        } else {
+          resolvers[typeName][fieldName] = {
+            resolve: finalResolver,
+          };
+        }
       });
     }
   });

--- a/packages/wrap/src/generateProxyingResolvers.ts
+++ b/packages/wrap/src/generateProxyingResolvers.ts
@@ -1,4 +1,4 @@
-import { GraphQLSchema, GraphQLFieldResolver, GraphQLObjectType } from 'graphql';
+import { GraphQLSchema, GraphQLFieldResolver, GraphQLObjectType, GraphQLResolveInfo } from 'graphql';
 
 import { Transform, Operation, getResponseKeyFromInfo, getErrors, applySchemaTransforms } from '@graphql-tools/utils';
 import {
@@ -64,7 +64,8 @@ export function generateProxyingResolvers(
         if (operation === 'subscription') {
           resolvers[typeName][fieldName] = {
             subscribe: finalResolver,
-            resolve: (payload: any) => payload[fieldName],
+            resolve: (payload: any, _: never, __: never, { fieldName: targetFieldName }: GraphQLResolveInfo) =>
+              payload[targetFieldName],
           };
         } else {
           resolvers[typeName][fieldName] = {


### PR DESCRIPTION
If a subschema has the subscription resolvers like below;
```js
{
   Subscription: {
      foo: {
         subscribe: () => someAsyncIteratorReturnsNumber, // not an object with fieldName like { foo: 2 }
         resolve: payload => payload, // << this function gets an object { foo: 2 } if the schema is wrapped, so GraphQL Request fails because returned value here should be a string.
      }
   }
}
```

So this PR adds additional `resolve` field to proxy resolvers. It resolves `payload[fieldName]` by overwriting subschema's `resolve` method.