### PR TITLE
Feature: Add `generateProxyingResolvers` to public API for v6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ### Next
 
-- Fix visitEnumValue to allow modifying the enum value  <br/>
+- Fix visitEnumValue to allow modifying the enum value <br/>
   [@danielrearden](https://github.com/danielrearden) in [#1003](https://github.com/ardatan/graphql-tools/pull/1391)
+- Export `generateProxyingResolvers` from `@graphql-tools/wrap`.
 
 ### 5.0.0
 

--- a/packages/wrap/src/index.ts
+++ b/packages/wrap/src/index.ts
@@ -1,5 +1,5 @@
 export { wrapSchema } from './wrapSchema';
-export { defaultCreateProxyingResolver } from './generateProxyingResolvers';
+export { defaultCreateProxyingResolver, generateProxyingResolvers } from './generateProxyingResolvers';
 
 export * from './transforms/index';
 


### PR DESCRIPTION
As mentioned in #1568, this PR adds `createProxyingResolver` to the public API to quickly create a ResolverMap without having to create a schema.

(While I'm here, thank you a ton to @yaacovCR for all the hard work that must've gone into moving this library from v4 to v5.)
