### PR TITLE
refactor application of transforms

### DIFF
--- a/packages/delegate/src/Transformer.ts
+++ b/packages/delegate/src/Transformer.ts
@@ -1,0 +1,45 @@
+import { Transform, Request, ExecutionResult } from '@graphql-tools/utils';
+
+import { DelegationContext, DelegationBinding } from './types';
+
+import { defaultDelegationBinding } from './delegationBindings';
+
+interface Transformation {
+  transform: Transform;
+  context: Record<string, any>;
+}
+
+export class Transformer {
+  private transformations: Array<Transformation> = [];
+  private delegationContext: DelegationContext;
+
+  constructor(context: DelegationContext, binding: DelegationBinding = defaultDelegationBinding) {
+    this.delegationContext = context;
+    const delegationTransforms: Array<Transform> = binding(this.delegationContext);
+    delegationTransforms.forEach(transform => this.addTransform(transform, {}));
+  }
+
+  private addTransform(transform: Transform, context = {}) {
+    this.transformations.push({ transform, context });
+  }
+
+  public transformRequest(originalRequest: Request) {
+    return this.transformations.reduce(
+      (request: Request, transformation: Transformation) =>
+        transformation.transform.transformRequest != null
+          ? transformation.transform.transformRequest(request, this.delegationContext, transformation.context)
+          : request,
+      originalRequest
+    );
+  }
+
+  public transformResult(originalResult: ExecutionResult) {
+    return this.transformations.reduceRight(
+      (result: ExecutionResult, transformation: Transformation) =>
+        transformation.transform.transformResult != null
+          ? transformation.transform.transformResult(result, this.delegationContext, transformation.context)
+          : result,
+      originalResult
+    );
+  }
+}

--- a/packages/delegate/src/delegationBindings.ts
+++ b/packages/delegate/src/delegationBindings.ts
@@ -1,0 +1,72 @@
+import { Transform } from '@graphql-tools/utils';
+
+import { StitchingInfo, DelegationContext } from './types';
+
+import ExpandAbstractTypes from './transforms/ExpandAbstractTypes';
+import WrapConcreteTypes from './transforms/WrapConcreteTypes';
+import FilterToSchema from './transforms/FilterToSchema';
+import AddFragmentsByField from './transforms/AddFragmentsByField';
+import AddSelectionSetsByField from './transforms/AddSelectionSetsByField';
+import AddSelectionSetsByType from './transforms/AddSelectionSetsByType';
+import AddTypenameToAbstract from './transforms/AddTypenameToAbstract';
+import CheckResultAndHandleErrors from './transforms/CheckResultAndHandleErrors';
+import AddArgumentsAsVariables from './transforms/AddArgumentsAsVariables';
+
+export function defaultDelegationBinding(delegationContext: DelegationContext): Array<Transform> {
+  const {
+    subschema: schemaOrSubschemaConfig,
+    targetSchema,
+    fieldName,
+    args,
+    context,
+    info,
+    returnType,
+    transforms = [],
+    skipTypeMerging,
+  } = delegationContext;
+  const stitchingInfo: StitchingInfo = info?.schema.extensions?.stitchingInfo;
+
+  let transformedSchema = stitchingInfo?.transformedSchemas.get(schemaOrSubschemaConfig);
+  if (transformedSchema != null) {
+    delegationContext.transformedSchema = transformedSchema;
+  } else {
+    transformedSchema = delegationContext.transformedSchema;
+  }
+
+  let delegationTransforms: Array<Transform> = [
+    new CheckResultAndHandleErrors(info, fieldName, schemaOrSubschemaConfig, context, returnType, skipTypeMerging),
+  ];
+
+  if (stitchingInfo != null) {
+    delegationTransforms = delegationTransforms.concat([
+      new AddSelectionSetsByField(info.schema, stitchingInfo.selectionSetsByField),
+      new AddSelectionSetsByType(info.schema, stitchingInfo.selectionSetsByType),
+      new WrapConcreteTypes(returnType, transformedSchema),
+      new ExpandAbstractTypes(info.schema, transformedSchema),
+    ]);
+  } else if (info != null) {
+    delegationTransforms = delegationTransforms.concat([
+      new WrapConcreteTypes(returnType, transformedSchema),
+      new ExpandAbstractTypes(info.schema, transformedSchema),
+    ]);
+  } else {
+    delegationTransforms.push(new WrapConcreteTypes(returnType, transformedSchema));
+  }
+
+  delegationTransforms = delegationTransforms.concat(transforms.slice().reverse());
+
+  if (stitchingInfo != null) {
+    delegationTransforms.push(new AddFragmentsByField(targetSchema, stitchingInfo.fragmentsByField));
+  }
+
+  if (args != null) {
+    delegationTransforms.push(new AddArgumentsAsVariables(targetSchema, args));
+  }
+
+  delegationTransforms = delegationTransforms.concat([
+    new FilterToSchema(targetSchema),
+    new AddTypenameToAbstract(targetSchema),
+  ]);
+
+  return delegationTransforms;
+}

--- a/packages/delegate/src/index.ts
+++ b/packages/delegate/src/index.ts
@@ -5,6 +5,6 @@ export { createMergedResolver } from './createMergedResolver';
 export { handleResult } from './results/handleResult';
 export { Subschema, isSubschema, isSubschemaConfig, getSubschema } from './Subschema';
 
+export * from './delegationBindings';
 export * from './transforms';
-
 export * from './types';

--- a/packages/delegate/src/types.ts
+++ b/packages/delegate/src/types.ts
@@ -10,10 +10,28 @@ import {
   FragmentDefinitionNode,
   GraphQLObjectType,
   VariableDefinitionNode,
+  OperationTypeNode,
 } from 'graphql';
+
 import { Operation, Transform, Request, TypeMap, ExecutionResult } from '@graphql-tools/utils';
 
 import { Subschema } from './Subschema';
+
+export interface DelegationContext {
+  subschema: GraphQLSchema | SubschemaConfig;
+  targetSchema: GraphQLSchema;
+  operation: OperationTypeNode;
+  fieldName: string;
+  args: Record<string, any>;
+  context: Record<string, any>;
+  info: GraphQLResolveInfo;
+  returnType: GraphQLOutputType;
+  transforms: Array<Transform>;
+  transformedSchema: GraphQLSchema;
+  skipTypeMerging: boolean;
+}
+
+export type DelegationBinding = (delegationContext: DelegationContext) => Array<Transform>;
 
 export interface IDelegateToSchemaOptions<TContext = Record<string, any>, TArgs = Record<string, any>> {
   schema: GraphQLSchema | SubschemaConfig | Subschema;
@@ -30,6 +48,7 @@ export interface IDelegateToSchemaOptions<TContext = Record<string, any>, TArgs 
   transformedSchema?: GraphQLSchema;
   skipValidation?: boolean;
   skipTypeMerging?: boolean;
+  binding?: DelegationBinding;
 }
 
 export interface IDelegateRequestOptions extends Omit<IDelegateToSchemaOptions, 'info'> {

--- a/packages/utils/src/Interfaces.ts
+++ b/packages/utils/src/Interfaces.ts
@@ -134,8 +134,16 @@ export interface IFieldResolverOptions<TSource = any, TContext = any, TArgs = an
 }
 
 export type SchemaTransform = (originalSchema: GraphQLSchema) => GraphQLSchema;
-export type RequestTransform = (originalRequest: Request) => Request;
-export type ResultTransform = (originalResult: ExecutionResult) => ExecutionResult;
+export type RequestTransform = (
+  originalRequest: Request,
+  delegationContext?: Record<string, any>,
+  transformationContext?: Record<string, any>
+) => Request;
+export type ResultTransform = (
+  originalResult: ExecutionResult,
+  delegationContext?: Record<string, any>,
+  transformationContext?: Record<string, any>
+) => ExecutionResult;
 
 export interface Transform {
   transformSchema?: SchemaTransform;


### PR DESCRIPTION
= provide binding option to delegateToSchema

A Binding is a function that takes a delegationContext (just the relevant subset of options passed to delegateSchema) and produces the set of transforms used to actually delegate (i.e. that "binds" the fieldNodes from the sourceSchema to that of the targetSchema), this provides library users ability to completely customize delegation behavior, even on a per field level. These delegation transforms are the specified schema transforms, but also the additional delegation transforms that reduce friction between the source and target schemas, see below.

= export defaultBinding that enables:

(a) setting arguments after schema transformation = AddArgumentsAsVariables
(b) conversion of original result into object annotated with errors for easy return and use with defaultMergedResolver = CheckResultAndHandleErrors
(c) addition of required selectionSets for use when stitching = AddSelectionSetsByField/Type, AddFragmentsByField
(d) automatic filtering of fields not in target schema, useful for stitching and many other scenarios = FilterToSchema
(e) delegation from concrete types in source schema to abstract types in target schema = WrapConcreteTypes
(f) delegation from new abstract types in source schema (not found in target schema) to implementations within target schemas = ExpandAbstractTypes

= addition of internal Transformer class responsible for applying transforms

The Transformer class is constructed with a delegationContext and a binding function and uses them to produces the delegating transforms. The Transformer creates an individual transformationContext for each transform (for easy sharing of state between the transformRequest and transformResult methods, a new feature) and exposes transformRequest and transformResult methods that performs the individual transformations with arguments of the original request/result, the delegationContext, and the individual transformationContext, which gives the transformRequest and transformResult methods access to the overall state, including the original graphql context, as well as any additional state they want to set up. These additional arguments may help enable advanced transforms such as specifying input fields in target schema not present or filtered from the source schema, see #1551.