### PR TITLE
Fix stitchSchemas for when empty array of typeDefs are passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix visitEnumValue to allow modifying the enum value <br/>
   [@danielrearden](https://github.com/danielrearden) in [#1003](https://github.com/ardatan/graphql-tools/pull/1391)
 - Export `generateProxyingResolvers` from `@graphql-tools/wrap`.
+- Fix `stitchSchemas` from `@graphql-tools/stitch` from the case there the typeDefs array is empty. [#1575](https://github.com/ardatan/graphql-tools/pull/1575)
 
 ### 5.0.0
 

--- a/packages/stitch/src/stitchSchemas.ts
+++ b/packages/stitch/src/stitchSchemas.ts
@@ -51,7 +51,7 @@ export function stitchSchemas({
   }
 
   let schemaLikeObjects: Array<GraphQLSchema | SubschemaConfig | DocumentNode | GraphQLNamedType> = [...subschemas];
-  if (typeDefs) {
+  if ((typeDefs && !Array.isArray(typeDefs)) || (Array.isArray(typeDefs) && typeDefs.length)) {
     schemaLikeObjects.push(buildDocumentFromTypeDefinitions(typeDefs, parseOptions));
   }
   if (types != null) {

--- a/packages/stitch/tests/stitchSchemas.test.ts
+++ b/packages/stitch/tests/stitchSchemas.test.ts
@@ -2982,6 +2982,36 @@ fragment BookingFragment on Booking {
     });
   });
 
+  describe('empty typeDefs array', () => {
+    test('works', async () => {
+      const typeDefs = `
+      type Query {
+        book: Book
+      }
+      type Book {
+        category: String!
+      }
+    `;
+      let schema = makeExecutableSchema({ typeDefs });
+
+      const resolvers = {
+        Query: {
+          book: () => ({ category: 'Test' }),
+        },
+      };
+
+      schema = stitchSchemas({
+        schemas: [schema],
+        resolvers,
+        typeDefs: [],
+      });
+
+      const result = await graphql(schema, '{ book { cat: category } }');
+
+      expect(result.data.book.cat).toBe('Test');
+    });
+  });
+
   describe('new root type name', () => {
     test('works', async () => {
       let bookSchema = makeExecutableSchema({


### PR DESCRIPTION
If an empty array is passed, the GraphQL parser fails, because the
source is empty. Switch the typeDef check to check for length as well,
since an empty array is truthy.

<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
- [x] Update CHANGELOG.md with your change. Include a description of your change, link to PR (always) and issue (if applicable). Add your CHANGELOG entry under vNEXT. Do not create a new version number for your change yourself.

