### PR TITLE
docs(loaders): UrlFileLoader => UrlLoader + fix url ref to remote-schemas

### DIFF
--- a/website/docs/loaders.md
+++ b/website/docs/loaders.md
@@ -125,7 +125,7 @@ This loader generates (a fully executable remote schema using @graphql-tools/wra
 ```ts
 const schema = await loadSchema('http://localhost:3000/graphql', {
   loaders: [
-    new UrlFileLoader(),
+    new UrlLoader(),
   ]
 });
 ```
@@ -135,7 +135,7 @@ You can provide custom headers, HTTP method and custom W3C fetch method.
 ```ts
 const schema = await loadSchema('http://localhost:3000/graphql', {
   loaders: [
-    new UrlFileLoader(),
+    new UrlLoader(),
   ],
   headers: {
     Accept: 'application/json',
@@ -151,7 +151,7 @@ In browser this remote schema can be called using vanilla GraphQL-js and act lik
 ```ts
 const schema = await loadSchema('http://localhost:3000/graphql', {
   loaders: [
-    new UrlFileLoader(),
+    new UrlLoader(),
   ]
 });
 

--- a/website/docs/loaders.md
+++ b/website/docs/loaders.md
@@ -120,7 +120,7 @@ export const schema = new GraphQLSchema(...);
 > This loader only supports Node environment because it relies on File System of your platform.
 
 ### URL Loader
-This loader generates (a fully executable remote schema using @graphql-tools/wrap)[/docs/remote-schema] from a URL endpoint.
+This loader generates [(a fully executable remote schema using @graphql-tools/wrap)](/docs/remote-schemas) from a URL endpoint.
 
 ```ts
 const schema = await loadSchema('http://localhost:3000/graphql', {


### PR DESCRIPTION
1. UrlFileLoader => UrlLoader
https://www.graphql-tools.com/docs/schema-loading/ uses `UrlLoader`, the code is called UrlLoader

https://github.com/ardatan/graphql-tools/blob/bd17df5795fec065fca9b502a862dc4f20862829/packages/loaders/url/src/index.ts#L29-L42

This fixes the typos.

2. the url ref to remote-schemas is broken, I have updated it commit no 2.