### PR TITLE
Docs (migration-from-import): code-file-loader => graphql-file-loader

### DIFF
--- a/website/docs/migration-from-import.md
+++ b/website/docs/migration-from-import.md
@@ -5,7 +5,7 @@ sidebar_label: From GraphQL Import
 description: Migration from GraphQL Import
 ---
 
-GraphQL Import was an NPM package that allows you import and export definitions using `#import` syntax in `.graphql` files. So this package has been moved under GraphQL Tools monorepo. It is really easy to migrate. You need two different packages `@graphql-tools/load` and `@graphql-tools/code-file-loader`.
+GraphQL Import was an NPM package that allows you import and export definitions using `#import` syntax in `.graphql` files. So this package has been moved under GraphQL Tools monorepo. It is really easy to migrate. You need two different packages `@graphql-tools/load` and `@graphql-tools/graphql-file-loader`.
 
 Before;
 ```ts
@@ -22,7 +22,7 @@ const schema = makeExecutableSchema({ typeDefs, resolvers });
 After;
 ```ts
 import { loadSchemaSync } from '@graphql-tools/load';
-import { GraphQLFileLoader } from '@graphql-tools/code-file-loader';
+import { GraphQLFileLoader } from '@graphql-tools/graphql-file-loader';
 import { addResolversToSchema } from '@graphql-tools/schema';
 
 const schema = loadSchemaSync(join(__dirname, 'schema.graphql'), { loaders: [new GraphQLFileLoader()] });


### PR DESCRIPTION
Hello there,

After reading the [migration from import](https://www.graphql-tools.com/docs/migration-from-import/`) page of the documentation, I noticed the file loader import used in the example wasn't correct, so I took the liberty of changing:
 
`code-file-loader` => `graphql-file-loader` 

Since in the example, we want to load a graphql file.

Let me know if I missed anything

Thank you so much for your work 🙏🏼