### PR TITLE
Merged types should allow query of `__typename` field without crashing query

### DIFF
--- a/packages/delegate/src/mergeFields.ts
+++ b/packages/delegate/src/mergeFields.ts
@@ -40,6 +40,10 @@ function buildDelegationPlan(
 
   const delegationMap: Map<SubschemaConfig, Array<SelectionNode>> = new Map();
   originalSelections.forEach(selection => {
+    if (selection.name.value === '__typename') {
+      return;
+    }
+
     // 2a. use uniqueFields map to assign fields to subschema if one of possible subschemas
 
     const uniqueSubschema: SubschemaConfig = uniqueFields[selection.name.value];

--- a/packages/stitch/tests/typeMerging.test.ts
+++ b/packages/stitch/tests/typeMerging.test.ts
@@ -89,6 +89,7 @@ describe('merging using type merging', () => {
     const result = await graphql(stitchedSchema, query);
 
     expect(result.errors).toBeUndefined();
+    expect(result.data.userById.__typename).toBe('User');
     expect(result.data.userById.chirps[1].id).not.toBe(null);
     expect(result.data.userById.chirps[1].text).not.toBe(null);
     expect(result.data.userById.chirps[1].author.email).not.toBe(null);

--- a/packages/stitch/tests/typeMerging.test.ts
+++ b/packages/stitch/tests/typeMerging.test.ts
@@ -74,6 +74,7 @@ describe('merging using type merging', () => {
     const query = `
       query {
         userById(id: 5) {
+          __typename
           chirps {
             id
             textAlias: text


### PR DESCRIPTION
Just creating a PR with an updated test to trigger issue