### PR TITLE
fix(stitchSchemas): subschemas with object inputs and mergeTypes  as true causes crash

### DIFF
--- a/packages/stitch/src/typeCandidates.ts
+++ b/packages/stitch/src/typeCandidates.ts
@@ -16,9 +16,12 @@ import {
   isInterfaceType,
   isUnionType,
   isEnumType,
+  isInputObjectType,
   SchemaDefinitionNode,
   SchemaExtensionNode,
   GraphQLFieldConfigMap,
+  GraphQLInputObjectType,
+  GraphQLInputFieldConfigMap,
 } from 'graphql';
 
 import { wrapSchema } from '@graphql-tools/wrap';
@@ -277,6 +280,22 @@ function merge(typeName: string, candidates: Array<MergeTypeCandidate>): GraphQL
       extensionASTNodes: initialCandidateType.extensionASTNodes,
     };
     return new GraphQLObjectType(config);
+  } else if (isInputObjectType(initialCandidateType)) {
+    const config = {
+      name: typeName,
+      fields: candidates.reduce<GraphQLInputFieldConfigMap>(
+        (acc, candidate) => ({
+          ...acc,
+          ...(candidate.type as GraphQLInputObjectType).toConfig().fields,
+        }),
+        {}
+      ),
+      description: initialCandidateType.description,
+      extensions: initialCandidateType.extensions,
+      astNode: initialCandidateType.astNode,
+      extensionASTNodes: initialCandidateType.extensionASTNodes,
+    };
+    return new GraphQLInputObjectType(config);
   } else if (isInterfaceType(initialCandidateType)) {
     const config = {
       name: typeName,

--- a/packages/stitch/tests/alternateStitchSchemas.test.ts
+++ b/packages/stitch/tests/alternateStitchSchemas.test.ts
@@ -1853,6 +1853,10 @@ describe('mergeTypes', () => {
 
   beforeEach(() => {
     const typeDefs1 = `
+      input ObjectInput {
+        val: String!
+      }
+
       type Query {
         rootField1: Wrapper
         getTest(id: ID): Test
@@ -1981,6 +1985,18 @@ describe('mergeTypes', () => {
         },
       },
     });
+
+    const stitchedSchemaWithMerge = stitchSchemas({
+      subschemas: [subschemaConfig1, subschemaConfig2],
+      mergeTypes: true,
+    })
+
+    const result2 = await graphql(
+      stitchedSchemaWithMerge,
+      `{ rootField1 { test { id } } }`
+    );
+
+    expect(result2).toEqual({ data: { rootField1: { test: { id: '1' } } } })
   });
 });
 


### PR DESCRIPTION
_**NOTE** I've no idea if that fix is sufficient or if support of input object is otherwise supported_

Without the proposed fix in `typeCandidates.ts` the added test case triggers the following error from expected unreachable code:

```
 FAIL  packages/stitch/tests/alternateStitchSchemas.test.ts (11.775 s)
  ● mergeTypes › can merge types

    Type ObjectInput has unknown GraphQL type.

      351 |   } else {
      352 |     // not reachable.
    > 353 |     throw new Error(`Type ${typeName} has unknown GraphQL type.`);
          |           ^
      354 |   }
      355 | }
      356 |

      at merge (packages/stitch/src/typeCandidates.ts:353:11)
      at packages/stitch/src/typeCandidates.ts:222:27
          at Array.forEach (<anonymous>)
      at Object.buildTypeMap (packages/stitch/src/typeCandidates.ts:212:31)
      at Object.stitchSchemas (packages/stitch/src/stitchSchemas.ts:98:19)
      at Object.<anonymous> (packages/stitch/tests/alternateStitchSchemas.test.ts:1989:37)
```