### PR TITLE
transforms should always pass along unmodified parts of originalRequest

### DIFF
--- a/packages/delegate/src/transforms/AddArgumentsAsVariables.ts
+++ b/packages/delegate/src/transforms/AddArgumentsAsVariables.ts
@@ -30,11 +30,12 @@ export default class AddArgumentsAsVariables implements Transform {
   }
 
   public transformRequest(originalRequest: Request): Request {
-    const { document, newVariables } = addVariablesToRootField(this.targetSchema, originalRequest, this.args);
+    const { document, variables } = addVariablesToRootField(this.targetSchema, originalRequest, this.args);
 
     return {
+      ...originalRequest,
       document,
-      variables: newVariables,
+      variables,
     };
   }
 }
@@ -45,7 +46,7 @@ function addVariablesToRootField(
   args: Record<string, any>
 ): {
   document: DocumentNode;
-  newVariables: Record<string, any>;
+  variables: Record<string, any>;
 } {
   const document = originalRequest.document;
   const variableValues = originalRequest.variables;
@@ -118,7 +119,7 @@ function addVariablesToRootField(
       ...document,
       definitions: [...newOperations, ...fragments],
     },
-    newVariables: variableValues,
+    variables: variableValues,
   };
 }
 

--- a/packages/wrap/src/transforms/ExtractField.ts
+++ b/packages/wrap/src/transforms/ExtractField.ts
@@ -32,7 +32,7 @@ export default class ExtractField implements Transform {
     });
 
     fieldPath = [];
-    const newDocument = visit(originalRequest.document, {
+    const document = visit(originalRequest.document, {
       [Kind.FIELD]: {
         enter: (node: FieldNode) => {
           fieldPath.push(node.name.value);
@@ -48,9 +48,10 @@ export default class ExtractField implements Transform {
         },
       },
     });
+
     return {
       ...originalRequest,
-      document: newDocument,
+      document,
     };
   }
 }

--- a/packages/wrap/src/transforms/RenameRootTypes.ts
+++ b/packages/wrap/src/transforms/RenameRootTypes.ts
@@ -31,7 +31,7 @@ export default class RenameRootTypes implements Transform {
   }
 
   public transformRequest(originalRequest: Request): Request {
-    const newDocument = visit(originalRequest.document, {
+    const document = visit(originalRequest.document, {
       [Kind.NAMED_TYPE]: (node: NamedTypeNode) => {
         const name = node.name.value;
         if (name in this.reverseMap) {
@@ -46,8 +46,8 @@ export default class RenameRootTypes implements Transform {
       },
     });
     return {
-      document: newDocument,
-      variables: originalRequest.variables,
+      ...originalRequest,
+      document,
     };
   }
 

--- a/packages/wrap/src/transforms/RenameTypes.ts
+++ b/packages/wrap/src/transforms/RenameTypes.ts
@@ -95,7 +95,7 @@ export default class RenameTypes implements Transform {
   }
 
   public transformRequest(originalRequest: Request): Request {
-    const newDocument = visit(originalRequest.document, {
+    const document = visit(originalRequest.document, {
       [Kind.NAMED_TYPE]: (node: NamedTypeNode) => {
         const name = node.name.value;
         if (name in this.reverseMap) {
@@ -109,9 +109,10 @@ export default class RenameTypes implements Transform {
         }
       },
     });
+
     return {
-      document: newDocument,
-      variables: originalRequest.variables,
+      ...originalRequest,
+      document,
     };
   }
 

--- a/packages/wrap/src/transforms/TransformQuery.ts
+++ b/packages/wrap/src/transforms/TransformQuery.ts
@@ -39,11 +39,9 @@ export default class TransformQuery implements Transform {
   }
 
   public transformRequest(originalRequest: Request): Request {
-    const document = originalRequest.document;
-
     const pathLength = this.path.length;
     let index = 0;
-    const newDocument = visit(document, {
+    const document = visit(originalRequest.document, {
       [Kind.FIELD]: {
         enter: node => {
           if (index === pathLength || node.name.value !== this.path[index]) {
@@ -66,9 +64,10 @@ export default class TransformQuery implements Transform {
         },
       },
     });
+
     return {
       ...originalRequest,
-      document: newDocument,
+      document,
     };
   }
 

--- a/packages/wrap/src/transforms/WrapQuery.ts
+++ b/packages/wrap/src/transforms/WrapQuery.ts
@@ -16,10 +16,9 @@ export default class WrapQuery implements Transform {
   }
 
   public transformRequest(originalRequest: Request): Request {
-    const document = originalRequest.document;
     const fieldPath: Array<string> = [];
     const ourPath = JSON.stringify(this.path);
-    const newDocument = visit(document, {
+    const document = visit(originalRequest.document, {
       [Kind.FIELD]: {
         enter: (node: FieldNode) => {
           fieldPath.push(node.name.value);
@@ -49,7 +48,7 @@ export default class WrapQuery implements Transform {
     });
     return {
       ...originalRequest,
-      document: newDocument,
+      document,
     };
   }
 


### PR DESCRIPTION
so as not to lose extensions, for example

motivation: https://github.com/gatsbyjs/gatsby/issues/23552#issuecomment-641928334