### PR TITLE
fix(typeMerging): can't return a list of merged types

### DIFF
--- a/packages/stitch/tests/typeMerging.test.ts
+++ b/packages/stitch/tests/typeMerging.test.ts
@@ -15,6 +15,7 @@ let chirpSchema = makeExecutableSchema({
       id: ID!
       text: String
       author: User
+      coAuthors: [User]
     }
 
     type User {
@@ -79,6 +80,9 @@ describe('merging using type merging', () => {
             id
             textAlias: text
             author {
+              email
+            }
+            coAuthors {
               email
             }
           }


### PR DESCRIPTION
Found a tricky one. I spent several hours trying to figure out exactly what going on, It looks like transparent querying of list / object bites us hard.

Long story short, the fallback [resolve of merge config](https://github.com/nicolas-cherel/graphql-tools/blame/5b7711c657e53338071387f86731e8f2a3e54b86/packages/stitch/src/stitchingInfo.ts#L104-L104) doesn't handle difference between list or non list of queried items. So it goes on quering with provided query field that will just query a single object, while `info.returnType` is a list of object.

So `handleResult()`, reading the `returnType` will call [`handleList()`](https://github.com/nicolas-cherel/graphql-tools/blame/5b7711c657e53338071387f86731e8f2a3e54b86/packages/delegate/src/results/handleResult.ts#L37-L37) while result is an object, and then crash on `list.map`

I suspect a simple negotiation of list / non list on query return type and expected return type should do the trick, but despite my efforts, I couldn't figure out where and how to put it without introducing unwanted variability in resolution logics. I have my suspicions that it'll end up in default resolver of merge config.
