### PR TITLE
fix by getting underlying type prior to delegation

### DIFF
--- a/packages/stitch/src/stitchingInfo.ts
+++ b/packages/stitch/src/stitchingInfo.ts
@@ -6,6 +6,8 @@ import {
   SelectionSetNode,
   isObjectType,
   isScalarType,
+  getNamedType,
+  GraphQLOutputType,
 } from 'graphql';
 
 import {
@@ -106,6 +108,7 @@ function createMergedTypes(
                 schema: subschema,
                 operation: 'query',
                 fieldName: mergedTypeConfig.fieldName,
+                returnType: getNamedType(info.returnType) as GraphQLOutputType,
                 args: mergedTypeConfig.args(originalResult),
                 selectionSet,
                 context,

--- a/packages/stitch/tests/typeMerging.test.ts
+++ b/packages/stitch/tests/typeMerging.test.ts
@@ -16,6 +16,7 @@ let chirpSchema = makeExecutableSchema({
       text: String
       author: User
       coAuthors: [User]
+      authorGroups: [[User]]
     }
 
     type User {
@@ -83,6 +84,9 @@ describe('merging using type merging', () => {
               email
             }
             coAuthors {
+              email
+            }
+            authorGroups {
               email
             }
           }


### PR DESCRIPTION
This possibly should be added as an argument to the resolver for
performance reasons.

In general, the next version of type merging will require a lot of
refactoring to improve performance.