### PR TITLE
fix(proxiedResults): handle top level errors when using type merging

### DIFF
--- a/packages/delegate/src/proxiedResult.ts
+++ b/packages/delegate/src/proxiedResult.ts
@@ -67,24 +67,23 @@ export function dehoistResult(parent: any, delimeter = '__gqltf__'): any {
   return result;
 }
 
-export function mergeProxiedResults(target: any, ...sources: any[]): any {
-  const errors = target[ERROR_SYMBOL].concat(
-    ...sources.map((source: any) => (source instanceof Error ? source : source[ERROR_SYMBOL]))
-  );
-
-  const filteredSources = sources.filter(source => !(source instanceof Error));
-
-  const fieldSubschemaMap = filteredSources.reduce((acc: Record<any, SubschemaConfig>, source: any) => {
+export function mergeProxiedResults(target: any, ...sources: Array<any>): any {
+  const results = sources.filter(source => !(source instanceof Error));
+  const fieldSubschemaMap = results.reduce((acc: Record<any, SubschemaConfig>, source: any) => {
     const subschema = source[OBJECT_SUBSCHEMA_SYMBOL];
     Object.keys(source).forEach(key => {
       acc[key] = subschema;
     });
     return acc;
   }, {});
-  const result = filteredSources.reduce(mergeDeep, target);
-  result[ERROR_SYMBOL] = errors;
+
+  const result = results.reduce(mergeDeep, target);
   result[FIELD_SUBSCHEMA_MAP_SYMBOL] = target[FIELD_SUBSCHEMA_MAP_SYMBOL]
     ? mergeDeep(target[FIELD_SUBSCHEMA_MAP_SYMBOL], fieldSubschemaMap)
     : fieldSubschemaMap;
+
+  const errors = sources.map((source: any) => (source instanceof Error ? source : source[ERROR_SYMBOL]));
+  result[ERROR_SYMBOL] = target[ERROR_SYMBOL].concat(...errors);
+
   return result;
 }


### PR DESCRIPTION
*_NOTE_*: once again, I've doubts to this being the right fix. maybe errors on query toplevel fields should throw errors instead of merely go through merging, the thing is, yet again, I'm not familiar enough with underlying principles to figure out the right call. But somehow, this fix solves the issue at the right place — on processing subschema results.


If the toplevel query of delegation has failed and reports an error on toplevel, with null as result,
`handleNull()` returns the errors has result, then `mergeProxiedResults()`, concats an error array consisting of `[undefined]`, the errors props not being set on exception (in a previous fix on mergeProxiedResults, it was assumed that sources where always execution results).

I suspect that the real problem is the `handleNull` with `handleResults` logics that mangles errors and values results processing, but I'm not confortable enought to revize that.

The solution here is to twist the assomption that `sources` parameters of `mergeProxiedResults()` only receives results object but also exceptions if any occured, and treat them accordingly:
 - by putting the exception in the errors array
 - by removing the related source from the results merge

without the fix, we would endup with the non-informative following message in query errors, triggered when trying to process the `[undefined]` errors array mentionned above:

```
      TypeError: Cannot read property 'path' of undefined
          at Object.getErrors (graphql-tools/packages/utils/src/errors.ts:52:16)
          at defaultMergedResolver (graphql-tools/packages/delegate/src/defaultMergedResolver.ts:25:18)
          at resolveFieldValueOrError (graphql-tools/node_modules/graphql/execution/execute.js:485:18)
          at resolveField (graphql-tools/node_modules/graphql/execution/execute.js:443:16)
          at executeFields (graphql-tools/node_modules/graphql/execution/execute.js:280:18)
          at collectAndExecuteSubfields (graphql-tools/node_modules/graphql/execution/execute.js:731:10)
          at completeObjectValue (graphql-tools/node_modules/graphql/execution/execute.js:721:10)
          at completeValue (graphql-tools/node_modules/graphql/execution/execute.js:609:12)
          at completeValueCatchingError (graphql-tools/node_modules/graphql/execution/execute.js:513:19)
          at resolveField (graphql-tools/node_modules/graphql/execution/execute.js:444:10) {
        locations: [ [Object] ],
        path: [ 'userById', 'id' ]
```


