### PR TITLE
stitching should automatically update path of subschema errors

### DIFF
--- a/packages/delegate/src/defaultMergedResolver.ts
+++ b/packages/delegate/src/defaultMergedResolver.ts
@@ -1,6 +1,6 @@
 import { defaultFieldResolver, GraphQLResolveInfo } from 'graphql';
 
-import { getResponseKeyFromInfo, getErrors } from '@graphql-tools/utils';
+import { getResponseKeyFromInfo, getErrors, getDepth } from '@graphql-tools/utils';
 
 import { handleResult } from './results/handleResult';
 import { getSubschema } from './Subschema';
@@ -32,6 +32,7 @@ export function defaultMergedResolver(
 
   const result = parent[responseKey];
   const subschema = getSubschema(parent, responseKey);
+  const depth = getDepth(parent);
 
-  return handleResult(result, errors, subschema, context, info);
+  return handleResult(result, errors, depth, subschema, context, info);
 }

--- a/packages/delegate/src/results/handleNull.ts
+++ b/packages/delegate/src/results/handleNull.ts
@@ -1,36 +1,13 @@
 import { GraphQLError } from 'graphql';
-
 import AggregateError from 'aggregate-error';
-import { getErrorsByPathSegment, relocatedError } from '@graphql-tools/utils';
 
-export function handleNull(errors: ReadonlyArray<GraphQLError>) {
+export function handleNull(errors: Array<GraphQLError>) {
   if (errors.length) {
-    if (errors.some(error => !error.path || error.path.length < 2)) {
-      if (errors.length > 1) {
-        const combinedError = new AggregateError(errors);
-        return combinedError;
-      }
-      const error = errors[0];
-      return error.originalError || relocatedError(error, null);
-    } else if (errors.some(error => typeof error.path[1] === 'string')) {
-      const childErrors = getErrorsByPathSegment(errors);
-
-      const result = {};
-      Object.keys(childErrors).forEach(pathSegment => {
-        result[pathSegment] = handleNull(childErrors[pathSegment]);
-      });
-
-      return result;
+    if (errors.length > 1) {
+      return new AggregateError(errors);
     }
 
-    const childErrors = getErrorsByPathSegment(errors);
-
-    const result: Array<any> = [];
-    Object.keys(childErrors).forEach(pathSegment => {
-      result.push(handleNull(childErrors[pathSegment]));
-    });
-
-    return result;
+    return errors[0];
   }
 
   return null;

--- a/packages/delegate/src/results/handleResult.ts
+++ b/packages/delegate/src/results/handleResult.ts
@@ -16,7 +16,8 @@ import { handleList } from './handleList';
 
 export function handleResult(
   result: any,
-  errors: ReadonlyArray<GraphQLError>,
+  errors: Array<GraphQLError>,
+  depth: number,
   subschema: GraphQLSchema | SubschemaConfig,
   context: Record<string, any>,
   info: GraphQLResolveInfo,
@@ -32,8 +33,8 @@ export function handleResult(
   if (isLeafType(type)) {
     return type.parseValue(result);
   } else if (isCompositeType(type)) {
-    return handleObject(type, result, errors, subschema, context, info, skipTypeMerging);
+    return handleObject(type, result, errors, depth, subschema, context, info, skipTypeMerging);
   } else if (isListType(type)) {
-    return handleList(type, result, errors, subschema, context, info, skipTypeMerging);
+    return handleList(type, result, errors, depth, subschema, context, info, skipTypeMerging);
   }
 }

--- a/packages/delegate/src/transforms/CheckResultAndHandleErrors.ts
+++ b/packages/delegate/src/transforms/CheckResultAndHandleErrors.ts
@@ -1,6 +1,6 @@
-import { GraphQLResolveInfo, ExecutionResult, GraphQLOutputType, GraphQLSchema } from 'graphql';
+import { GraphQLResolveInfo, ExecutionResult, GraphQLOutputType, GraphQLSchema, responsePathAsArray } from 'graphql';
 
-import { Transform, getResponseKeyFromInfo } from '@graphql-tools/utils';
+import { Transform, getResponseKeyFromInfo, toGraphQLErrors } from '@graphql-tools/utils';
 import { handleResult } from '../results/handleResult';
 import { SubschemaConfig } from '../types';
 
@@ -50,8 +50,9 @@ export function checkResultAndHandleErrors(
   returnType: GraphQLOutputType = info.returnType,
   skipTypeMerging?: boolean
 ): any {
-  const errors = result.errors != null ? result.errors : [];
+  const sourcePath = info != null ? responsePathAsArray(info.path) : [];
+  const errors = result.errors != null ? toGraphQLErrors(result.errors, sourcePath) : [];
   const data = result.data != null ? result.data[responseKey] : undefined;
 
-  return handleResult(data, errors, subschema, context, info, returnType, skipTypeMerging);
+  return handleResult(data, errors, sourcePath.length - 1, subschema, context, info, returnType, skipTypeMerging);
 }

--- a/packages/stitch/tests/errors.test.ts
+++ b/packages/stitch/tests/errors.test.ts
@@ -38,6 +38,7 @@ describe('passes along errors for missing fields on list', () => {
     const originalResult = await graphql(schema, query);
     const stitchedResult = await graphql(stitchedSchema, query);
     expect(stitchedResult).toEqual(originalResult);
+    expect(stitchedResult.errors[0].path).toEqual(originalResult.errors[0].path);
   });
 
   test('even if nullable', async () => {
@@ -72,6 +73,7 @@ describe('passes along errors for missing fields on list', () => {
     const originalResult = await graphql(schema, query);
     const stitchedResult = await graphql(stitchedSchema, query);
     expect(stitchedResult).toEqual(originalResult);
+    expect(stitchedResult.errors[0].path).toEqual(originalResult.errors[0].path);
   });
 });
 
@@ -108,6 +110,7 @@ describe('passes along errors when list field errors', () => {
     const originalResult = await graphql(schema, query);
     const stitchedResult = await graphql(stitchedSchema, query);
     expect(stitchedResult).toEqual(originalResult);
+    expect(stitchedResult.errors[0].path).toEqual(originalResult.errors[0].path);
   });
 
   test('even if nullable', async () => {
@@ -142,6 +145,38 @@ describe('passes along errors when list field errors', () => {
     const originalResult = await graphql(schema, query);
     const stitchedResult = await graphql(stitchedSchema, query);
     expect(stitchedResult).toEqual(originalResult);
+    expect(stitchedResult.errors[0].path).toEqual(originalResult.errors[0].path);
+  });
+
+  describe('passes along correct error when there are two non-null fields', () => {
+    test('should work', async () => {
+      const schema = makeExecutableSchema({
+        typeDefs: `
+          type Query {
+            getBoth: Both
+          }
+          type Both {
+            mandatoryField1: String!
+            mandatoryField2: String!
+          }
+        `,
+        resolvers: {
+          Query: {
+            getBoth: () => ({ mandatoryField1: 'test' }),
+          },
+        },
+      });
+
+      const stitchedSchema = stitchSchemas({
+        subschemas: [schema],
+      });
+
+      const query = '{ getBoth { mandatoryField1 mandatoryField2 } }';
+      const originalResult = await graphql(schema, query);
+      const stitchedResult = await graphql(stitchedSchema, query);
+      expect(stitchedResult).toEqual(originalResult);
+      expect(stitchedResult.errors[0].path).toEqual(originalResult.errors[0].path);
+    });
   });
 });
 

--- a/packages/wrap/src/generateProxyingResolvers.ts
+++ b/packages/wrap/src/generateProxyingResolvers.ts
@@ -1,6 +1,13 @@
 import { GraphQLSchema, GraphQLFieldResolver, GraphQLObjectType, GraphQLResolveInfo } from 'graphql';
 
-import { Transform, Operation, getResponseKeyFromInfo, getErrors, applySchemaTransforms } from '@graphql-tools/utils';
+import {
+  Transform,
+  Operation,
+  getResponseKeyFromInfo,
+  getErrors,
+  applySchemaTransforms,
+  getDepth,
+} from '@graphql-tools/utils';
 import {
   delegateToSchema,
   getSubschema,
@@ -91,12 +98,13 @@ function createPossiblyNestedProxyingResolver(
       // Check to see if the parent contains a proxied result
       if (errors != null) {
         const subschema = getSubschema(parent, responseKey);
+        const depth = getDepth(parent);
 
         // If there is a proxied result from this subschema, return it
         // This can happen even for a root field when the root type ia
         // also nested as a field within a different type.
         if (subschemaOrSubschemaConfig === subschema && parent[responseKey] !== undefined) {
-          return handleResult(parent[responseKey], errors, subschema, context, info);
+          return handleResult(parent[responseKey], errors, depth, subschema, context, info);
         }
       }
     }

--- a/packages/wrap/tests/errors.test.ts
+++ b/packages/wrap/tests/errors.test.ts
@@ -30,13 +30,18 @@ describe('Errors', () => {
       const error = {
         message: 'Test error without path',
       };
+      const relativeError = {
+        graphQLError: error,
+      };
       const mockErrors: any = {
-        responseKey: '',
-        [ERROR_SYMBOL]: [error],
+        responseKey: null,
+        [ERROR_SYMBOL]: {
+          'responseKey': [relativeError],
+        },
       };
 
       expect(getErrors(mockErrors, 'responseKey')).toEqual([
-        mockErrors[ERROR_SYMBOL][0],
+        mockErrors[ERROR_SYMBOL].responseKey[0],
       ]);
     });
   });


### PR DESCRIPTION
Currently, the path is just dropped, and so we rely on upstream graphql putting in the correct path when the error is reported, but this causes problems because field resolution may not occur in the desired order, and the wrong path may be reported. 

This fix for #1047 includes multiple changes to error proxying, some now exposed to users.

= no longer relying on graphql-js to automatically set path of stitched error
= now relying on graphql-js not modifying path of resolver-returned error even if references a path different from resolver
= streamlines object error annotations to represent a map of errors by the field name
= introduces depth property for proxied results that must be updated during proxied result traversal for properly searching the error arrays
= requires updating of advanced wrapping/hoisting resolvers