### PR TITLE
bugfix: adding the missing operation name

### DIFF
--- a/packages/delegate/src/createRequest.ts
+++ b/packages/delegate/src/createRequest.ts
@@ -48,6 +48,7 @@ export function createRequestFromInfo({
     targetFieldName: fieldName,
     selectionSet,
     fieldNodes,
+    operationName: info.operation.name,
   });
 }
 
@@ -62,6 +63,7 @@ export function createRequest({
   targetFieldName,
   selectionSet,
   fieldNodes,
+  operationName,
 }: ICreateRequest): Request {
   let newSelectionSet: SelectionSetNode = selectionSet;
   let argumentNodeMap: Record<string, ArgumentNode>;
@@ -138,6 +140,7 @@ export function createRequest({
       kind: Kind.SELECTION_SET,
       selections: [rootfieldNode],
     },
+    name: operationName,
   };
 
   let definitions: Array<DefinitionNode> = [operationDefinition];

--- a/packages/delegate/src/types.ts
+++ b/packages/delegate/src/types.ts
@@ -11,6 +11,7 @@ import {
   GraphQLObjectType,
   VariableDefinitionNode,
   OperationTypeNode,
+  NameNode,
 } from 'graphql';
 
 import { Operation, Transform, Request, TypeMap, ExecutionResult } from '@graphql-tools/utils';
@@ -75,6 +76,7 @@ export interface ICreateRequest {
   targetFieldName: string;
   selectionSet?: SelectionSetNode;
   fieldNodes?: ReadonlyArray<FieldNode>;
+  operationName?: NameNode;
 }
 
 export interface MergedTypeInfo {


### PR DESCRIPTION

This is related to an old issue that cropped up in version 5.
https://github.com/ardatan/graphql-tools/issues/522
