### PR TITLE
fix(stitching): avoid duplicate directives

### DIFF
--- a/packages/stitch/src/typeCandidates.ts
+++ b/packages/stitch/src/typeCandidates.ts
@@ -39,7 +39,7 @@ export function buildTypeCandidates({
   transformedSchemas,
   typeCandidates,
   extensions,
-  directives,
+  directiveMap,
   schemaDefs,
   operationTypeNames,
   mergeDirectives,
@@ -48,7 +48,7 @@ export function buildTypeCandidates({
   transformedSchemas: Map<GraphQLSchema | SubschemaConfig, GraphQLSchema>;
   typeCandidates: Record<string, Array<MergeTypeCandidate>>;
   extensions: Array<DocumentNode>;
-  directives: Array<GraphQLDirective>;
+  directiveMap: Record<string, GraphQLDirective>;
   schemaDefs: {
     schemaDef: SchemaDefinitionNode;
     schemaExtensions: Array<SchemaExtensionNode>;
@@ -96,7 +96,7 @@ export function buildTypeCandidates({
 
       if (mergeDirectives) {
         schema.getDirectives().forEach(directive => {
-          directives.push(directive);
+          directiveMap[directive.name] = directive;
         });
       }
 
@@ -131,7 +131,8 @@ export function buildTypeCandidates({
 
       const directivesDocument = extractDirectiveDefinitions(schemaLikeObject);
       directivesDocument.definitions.forEach(def => {
-        directives.push(typeFromAST(def) as GraphQLDirective);
+        const directive = typeFromAST(def) as GraphQLDirective;
+        directiveMap[directive.name] = directive;
       });
 
       const extensionsDocument = extractTypeExtensionDefinitions(schemaLikeObject);

--- a/packages/utils/src/rewire.ts
+++ b/packages/utils/src/rewire.ts
@@ -23,6 +23,7 @@ import {
   isScalarType,
   isUnionType,
   isSpecifiedScalarType,
+  isSpecifiedDirective,
 } from 'graphql';
 
 import { getBuiltInForStub, isNamedStub } from './stub';
@@ -78,6 +79,9 @@ export function rewireTypes(
     : pruneTypes(newTypeMap, newDirectives);
 
   function rewireDirective(directive: GraphQLDirective): GraphQLDirective {
+    if (isSpecifiedDirective(directive)) {
+      return directive;
+    }
     const directiveConfig = directive.toConfig();
     directiveConfig.args = rewireArgs(directiveConfig.args);
     return new GraphQLDirective(directiveConfig);


### PR DESCRIPTION
Fixes #1656.

Later directives with the same name should override earlier directives rather than causing an error.

Directives with the same names from a later subschema will override an earlier subschema. Directives from typedefs will override both.

Mixing of legacy schemas argument and newer subschemas, typeDefs, and types arguments should respect this same order.

We can consider adding onDirectiveConflict option to match onTypeConflict for customization.