### PR TITLE
fix(merge): add default value for `mergeDirectives`

### DIFF
--- a/packages/merge/src/typedefs-mergers/directives.ts
+++ b/packages/merge/src/typedefs-mergers/directives.ts
@@ -10,7 +10,7 @@ function nameAlreadyExists(name: NameNode, namesArr: ReadonlyArray<NameNode>): b
   return namesArr.some(({ value }) => value === name.value);
 }
 
-function mergeArguments(a1: ArgumentNode[], a2: ArgumentNode[]): ArgumentNode[] {
+function mergeArguments(a1: readonly ArgumentNode[], a2: readonly ArgumentNode[]): ArgumentNode[] {
   const result: ArgumentNode[] = [...a2];
 
   for (const argument of a1) {
@@ -57,8 +57,8 @@ function deduplicateDirectives(directives: ReadonlyArray<DirectiveNode>): Direct
 }
 
 export function mergeDirectives(
-  d1: ReadonlyArray<DirectiveNode>,
-  d2: ReadonlyArray<DirectiveNode>,
+  d1: ReadonlyArray<DirectiveNode> = [],
+  d2: ReadonlyArray<DirectiveNode> = [],
   config?: Config
 ): DirectiveNode[] {
   const reverseOrder: boolean = config && config.reverseDirectives;
@@ -71,8 +71,8 @@ export function mergeDirectives(
       const existingDirectiveIndex = result.findIndex(d => d.name.value === directive.name.value);
       const existingDirective = result[existingDirectiveIndex];
       (result[existingDirectiveIndex] as any).arguments = mergeArguments(
-        directive.arguments as any,
-        existingDirective.arguments as any
+        directive.arguments || [],
+        existingDirective.arguments || []
       );
     } else {
       result.push(directive);


### PR DESCRIPTION
The GraphQL reference implementation treats directives  as optional,
so mergeDirectives needs to handle the `undefined` case, since some
libraries will set `directives` to be undefined instead of an empty list.

see https://github.com/graphql/graphql-js/blob/20a8f555e7eaa5c2fa2fd188abcef83ee8169e7f/src/language/ast.d.ts#L453

<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
