### PR TITLE
Name operations

### DIFF
--- a/packages/delegate/src/Subschema.ts
+++ b/packages/delegate/src/Subschema.ts
@@ -15,7 +15,7 @@ export function setObjectSubschema(result: any, subschema: GraphQLSchema | Subsc
   result[OBJECT_SUBSCHEMA_SYMBOL] = subschema;
 }
 
-export function isSubschemaConfig(value: any): value is SubschemaConfig {
+export function isSubschemaConfig(value: any): value is SubschemaConfig | Subschema {
   return Boolean((value as SubschemaConfig).schema);
 }
 

--- a/packages/delegate/src/createRequest.ts
+++ b/packages/delegate/src/createRequest.ts
@@ -32,6 +32,7 @@ export function getDelegatingOperation(parentType: GraphQLObjectType, schema: Gr
 
 export function createRequestFromInfo({
   info,
+  operationName,
   operation = getDelegatingOperation(info.parentType, info.schema),
   fieldName = info.fieldName,
   selectionSet,
@@ -44,6 +45,7 @@ export function createRequestFromInfo({
     fragments: info.fragments,
     variableDefinitions: info.operation.variableDefinitions,
     variableValues: info.variableValues,
+    targetOperationName: operationName,
     targetOperation: operation,
     targetFieldName: fieldName,
     selectionSet,
@@ -58,6 +60,7 @@ export function createRequest({
   fragments,
   variableDefinitions,
   variableValues,
+  targetOperationName,
   targetOperation,
   targetFieldName,
   selectionSet,
@@ -130,8 +133,16 @@ export function createRequest({
     selectionSet: newSelectionSet,
   };
 
+  const operationName = targetOperationName
+    ? {
+        kind: Kind.NAME,
+        value: targetOperationName,
+      }
+    : undefined;
+
   const operationDefinition: OperationDefinitionNode = {
     kind: Kind.OPERATION_DEFINITION,
+    name: operationName,
     operation: targetOperation,
     variableDefinitions: Object.keys(variableDefinitionMap).map(varName => variableDefinitionMap[varName]),
     selectionSet: {

--- a/packages/delegate/src/delegateToSchema.ts
+++ b/packages/delegate/src/delegateToSchema.ts
@@ -33,6 +33,7 @@ export function delegateToSchema(options: IDelegateToSchemaOptions | GraphQLSche
 
   const {
     info,
+    operationName,
     operation = getDelegatingOperation(info.parentType, info.schema),
     fieldName = info.fieldName,
     returnType = info.returnType,
@@ -46,6 +47,7 @@ export function delegateToSchema(options: IDelegateToSchemaOptions | GraphQLSche
     fieldName,
     selectionSet,
     fieldNodes,
+    operationName,
   });
 
   return delegateRequest({

--- a/packages/delegate/src/types.ts
+++ b/packages/delegate/src/types.ts
@@ -35,6 +35,7 @@ export type DelegationBinding = (delegationContext: DelegationContext) => Array<
 
 export interface IDelegateToSchemaOptions<TContext = Record<string, any>, TArgs = Record<string, any>> {
   schema: GraphQLSchema | SubschemaConfig | Subschema;
+  operationName?: string;
   operation?: Operation;
   fieldName?: string;
   returnType?: GraphQLOutputType;
@@ -58,6 +59,7 @@ export interface IDelegateRequestOptions extends Omit<IDelegateToSchemaOptions, 
 
 export interface ICreateRequestFromInfo {
   info: GraphQLResolveInfo;
+  operationName?: string;
   operation: Operation;
   fieldName: string;
   selectionSet?: SelectionSetNode;
@@ -72,6 +74,7 @@ export interface ICreateRequest {
   variableDefinitions?: ReadonlyArray<VariableDefinitionNode>;
   variableValues?: Record<string, any>;
   targetOperation: Operation;
+  targetOperationName?: string;
   targetFieldName: string;
   selectionSet?: SelectionSetNode;
   fieldNodes?: ReadonlyArray<FieldNode>;


### PR DESCRIPTION
alternative to #1651 

allows specification of operation name when delegating without a default. no need to allow a function as discussed there, as caller will always have access to the existing operation name under the info argument.

you can use the subschema createProxyingResolver option to enable setting the operation for delegation to a subschema when wrapping or stitching subschemas.

you can also just set the operation name in a transform (now that the second argument of a transformRequest function is the delegationContext)

you can also set the operation name within the executor function, now that info argument is passed there.