### PR TITLE
Introduce result visiting

### DIFF
--- a/packages/utils/src/Interfaces.ts
+++ b/packages/utils/src/Interfaces.ts
@@ -153,7 +153,8 @@ export interface Transform {
 
 export type FieldNodeMapper = (
   fieldNode: FieldNode,
-  fragments: Record<string, FragmentDefinitionNode>
+  fragments: Record<string, FragmentDefinitionNode>,
+  context: Record<string, any>
 ) => SelectionNode | Array<SelectionNode>;
 
 export type FieldNodeMappers = Record<string, Record<string, FieldNodeMapper>>;

--- a/packages/utils/src/Interfaces.ts
+++ b/packages/utils/src/Interfaces.ts
@@ -154,7 +154,7 @@ export interface Transform {
 export type FieldNodeMapper = (
   fieldNode: FieldNode,
   fragments: Record<string, FragmentDefinitionNode>,
-  context: Record<string, any>
+  transformationContext: Record<string, any>
 ) => SelectionNode | Array<SelectionNode>;
 
 export type FieldNodeMappers = Record<string, Record<string, FieldNodeMapper>>;

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -46,3 +46,4 @@ export * from './implementsAbstractType';
 export * from './errors';
 export * from './toConfig';
 export * from './observableToAsyncIterable';
+export * from './visitResult';

--- a/packages/utils/src/visitResult.ts
+++ b/packages/utils/src/visitResult.ts
@@ -1,0 +1,393 @@
+import {
+  GraphQLSchema,
+  getOperationRootType,
+  getOperationAST,
+  Kind,
+  GraphQLObjectType,
+  FieldNode,
+  GraphQLOutputType,
+  isListType,
+  getNullableType,
+  isAbstractType,
+  isObjectType,
+  OperationDefinitionNode,
+  GraphQLError,
+} from 'graphql';
+
+import { Request, GraphQLExecutionContext, ExecutionResult } from './Interfaces';
+import { collectFields } from './collectFields';
+
+export type ValueVisitor = (value: any) => any;
+
+export type ObjectValueVisitor = {
+  __enter?: ValueVisitor;
+  __leave?: ValueVisitor;
+} & Record<string, ValueVisitor>;
+
+export type ResultVisitorMap = Record<string, ValueVisitor | ObjectValueVisitor>;
+
+export type ErrorVisitor = (error: GraphQLError, pathIndex: number) => GraphQLError;
+
+export type ErrorVisitorMap = Record<string, Record<string, ErrorVisitor>>;
+
+interface SegmentInfo {
+  type: GraphQLObjectType;
+  fieldName: string;
+  pathIndex: number;
+}
+
+interface ErrorInfo {
+  segmentInfoMap: Map<GraphQLError, Array<SegmentInfo>>;
+  unpathedErrors: Array<GraphQLError>;
+}
+
+interface SortedErrors {
+  errorMap: Record<string, Array<GraphQLError>>;
+  unpathedErrors: Array<GraphQLError>;
+}
+
+export function visitData(data: any, enter?: ValueVisitor, leave?: ValueVisitor): any {
+  if (Array.isArray(data)) {
+    return data.map(value => visitData(value, enter, leave));
+  } else if (typeof data === 'object') {
+    const newData = enter != null ? enter(data) : data;
+
+    if (newData != null) {
+      Object.keys(newData).forEach(key => {
+        const value = newData[key];
+        newData[key] = visitData(value, enter, leave);
+      });
+    }
+
+    return leave != null ? leave(newData) : newData;
+  }
+
+  return data;
+}
+
+export function visitErrors(
+  errors: ReadonlyArray<GraphQLError>,
+  visitor: (error: GraphQLError) => GraphQLError
+): Array<GraphQLError> {
+  return errors.map(error => visitor(error));
+}
+export function visitResult(
+  result: ExecutionResult,
+  request: Request,
+  schema: GraphQLSchema,
+  resultVisitorMap?: ResultVisitorMap,
+  errorVisitorMap?: ErrorVisitorMap
+): any {
+  const partialExecutionContext = {
+    schema,
+    fragments: request.document.definitions.reduce((acc, def) => {
+      if (def.kind === Kind.FRAGMENT_DEFINITION) {
+        acc[def.name.value] = def;
+      }
+      return acc;
+    }, {}),
+    variableValues: request.variables,
+  } as GraphQLExecutionContext;
+
+  const errorInfo: ErrorInfo = {
+    segmentInfoMap: new Map<GraphQLError, Array<SegmentInfo>>(),
+    unpathedErrors: [],
+  };
+
+  const data = result.data;
+  const errors = result.errors;
+  const visitingErrors = errors != null && errorVisitorMap != null;
+
+  if (data != null) {
+    result.data = visitRoot(
+      data,
+      getOperationAST(request.document, undefined),
+      partialExecutionContext,
+      resultVisitorMap,
+      visitingErrors ? errors : undefined,
+      errorInfo
+    );
+  }
+
+  if (visitingErrors) {
+    result.errors = visitErrorsByType(errors, errorVisitorMap, errorInfo);
+  }
+
+  return result;
+}
+
+function visitErrorsByType(
+  errors: ReadonlyArray<GraphQLError>,
+  errorVisitorMap: ErrorVisitorMap,
+  errorInfo: ErrorInfo
+): Array<GraphQLError> {
+  return errors.map(error => {
+    const pathSegmentsInfo = errorInfo.segmentInfoMap.get(error);
+    if (pathSegmentsInfo == null) {
+      return error;
+    }
+    return pathSegmentsInfo.reduceRight((acc, segmentInfo) => {
+      const typeName = segmentInfo.type.name;
+      const typeVisitorMap = errorVisitorMap[typeName];
+      if (typeVisitorMap == null) {
+        return acc;
+      }
+      const errorVisitor = typeVisitorMap[segmentInfo.fieldName];
+      return errorVisitor == null ? acc : errorVisitor(acc as GraphQLError, segmentInfo.pathIndex);
+    }, error) as GraphQLError;
+  });
+}
+
+function visitRoot(
+  root: any,
+  operation: OperationDefinitionNode,
+  exeContext: GraphQLExecutionContext,
+  resultVisitorMap: ResultVisitorMap,
+  errors: ReadonlyArray<GraphQLError>,
+  errorInfo: ErrorInfo
+): any {
+  const operationRootType = getOperationRootType(exeContext.schema, operation);
+  const collectedFields = collectFields(
+    exeContext,
+    operationRootType,
+    operation.selectionSet,
+    Object.create(null),
+    Object.create(null)
+  );
+
+  return visitObjectValue(root, operationRootType, collectedFields, exeContext, resultVisitorMap, 0, errors, errorInfo);
+}
+
+function visitObjectValue(
+  object: Record<string, any>,
+  type: GraphQLObjectType,
+  fieldNodeMap: Record<string, Array<FieldNode>>,
+  exeContext: GraphQLExecutionContext,
+  resultVisitorMap: ResultVisitorMap,
+  pathIndex: number,
+  errors: ReadonlyArray<GraphQLError>,
+  errorInfo: ErrorInfo
+): Record<string, any> {
+  const fieldMap = type.getFields();
+  const typeVisitorMap = resultVisitorMap?.[type.name] as ObjectValueVisitor;
+
+  const enterObject = typeVisitorMap?.__enter as ValueVisitor;
+  const newObject = enterObject != null ? enterObject(object) : object;
+
+  let sortedErrors: SortedErrors;
+  let errorMap: Record<string, Array<GraphQLError>>;
+  if (errors != null) {
+    sortedErrors = sortErrorsByPathSegment(errors, pathIndex);
+    errorMap = sortedErrors.errorMap;
+    errorInfo.unpathedErrors = errorInfo.unpathedErrors.concat(sortedErrors.unpathedErrors);
+  }
+
+  Object.keys(fieldNodeMap).forEach(responseKey => {
+    const subFieldNodes = fieldNodeMap[responseKey];
+    const fieldName = subFieldNodes[0].name.value;
+    const fieldType = fieldMap[fieldName].type;
+
+    const newPathIndex = pathIndex + 1;
+
+    let fieldErrors: Array<GraphQLError>;
+    if (errors != null) {
+      fieldErrors = errorMap[responseKey];
+      if (fieldErrors != null) {
+        delete errorMap[responseKey];
+      }
+      addPathSegmentInfo(type, fieldName, newPathIndex, fieldErrors, errorInfo);
+    }
+
+    const newValue = visitFieldValue(
+      object[responseKey],
+      fieldType,
+      subFieldNodes,
+      exeContext,
+      resultVisitorMap,
+      newPathIndex,
+      fieldErrors,
+      errorInfo
+    );
+
+    updateObject(newObject, responseKey, newValue, typeVisitorMap, fieldName);
+  });
+
+  const oldTypename = newObject.__typename;
+  if (oldTypename != null) {
+    updateObject(newObject, '__typename', oldTypename, typeVisitorMap, '__typename');
+  }
+
+  if (errors != null) {
+    Object.keys(errorMap).forEach(unknownResponseKey => {
+      errorInfo.unpathedErrors = errorInfo.unpathedErrors.concat(errorMap[unknownResponseKey]);
+    });
+  }
+
+  const leaveObject = typeVisitorMap?.__leave as ValueVisitor;
+
+  return leaveObject != null ? leaveObject(newObject) : newObject;
+}
+
+function updateObject(
+  object: Record<string, any>,
+  responseKey: string,
+  newValue: any,
+  typeVisitorMap: ObjectValueVisitor,
+  fieldName: string
+): void {
+  if (typeVisitorMap == null) {
+    object[responseKey] = newValue;
+    return;
+  }
+
+  const fieldVisitor = typeVisitorMap[fieldName];
+  if (fieldVisitor == null) {
+    object[responseKey] = newValue;
+    return;
+  }
+
+  const visitedValue = fieldVisitor(newValue);
+  if (visitedValue === undefined) {
+    delete object[responseKey];
+    return;
+  }
+
+  object[responseKey] = visitedValue;
+}
+
+function visitListValue(
+  list: Array<any>,
+  returnType: GraphQLOutputType,
+  fieldNodes: Array<FieldNode>,
+  exeContext: GraphQLExecutionContext,
+  resultVisitorMap: ResultVisitorMap,
+  pathIndex: number,
+  errors: ReadonlyArray<GraphQLError>,
+  errorInfo: ErrorInfo
+): Array<any> {
+  return list.map(listMember =>
+    visitFieldValue(listMember, returnType, fieldNodes, exeContext, resultVisitorMap, pathIndex + 1, errors, errorInfo)
+  );
+}
+
+function visitFieldValue(
+  value: any,
+  returnType: GraphQLOutputType,
+  fieldNodes: Array<FieldNode>,
+  exeContext: GraphQLExecutionContext,
+  resultVisitorMap: ResultVisitorMap,
+  pathIndex: number,
+  errors: ReadonlyArray<GraphQLError> = [],
+  errorInfo: ErrorInfo
+): any {
+  if (value == null) {
+    return value;
+  }
+
+  const nullableType = getNullableType(returnType);
+  if (isListType(nullableType)) {
+    return visitListValue(
+      value as Array<any>,
+      nullableType.ofType,
+      fieldNodes,
+      exeContext,
+      resultVisitorMap,
+      pathIndex,
+      errors,
+      errorInfo
+    );
+  } else if (isAbstractType(nullableType)) {
+    const finalType = exeContext.schema.getType(value.__typename) as GraphQLObjectType;
+    const collectedFields = collectSubFields(exeContext, finalType, fieldNodes);
+    return visitObjectValue(
+      value,
+      finalType,
+      collectedFields,
+      exeContext,
+      resultVisitorMap,
+      pathIndex,
+      errors,
+      errorInfo
+    );
+  } else if (isObjectType(nullableType)) {
+    const collectedFields = collectSubFields(exeContext, nullableType, fieldNodes);
+    return visitObjectValue(
+      value,
+      nullableType,
+      collectedFields,
+      exeContext,
+      resultVisitorMap,
+      pathIndex,
+      errors,
+      errorInfo
+    );
+  }
+
+  const typeVisitorMap = resultVisitorMap?.[nullableType.name] as ValueVisitor;
+  if (typeVisitorMap == null) {
+    return value;
+  }
+
+  const visitedValue = typeVisitorMap(value);
+  return visitedValue === undefined ? value : visitedValue;
+}
+
+function sortErrorsByPathSegment(errors: ReadonlyArray<GraphQLError>, pathIndex: number): SortedErrors {
+  const errorMap = Object.create(null);
+  const unpathedErrors: Array<GraphQLError> = [];
+  errors.forEach(error => {
+    const pathSegment = error.path?.[pathIndex];
+    if (pathSegment == null) {
+      unpathedErrors.push(error);
+      return;
+    }
+
+    if (pathSegment in errorMap) {
+      errorMap[pathSegment].push(error);
+    } else {
+      errorMap[pathSegment] = [error];
+    }
+  });
+
+  return {
+    errorMap,
+    unpathedErrors,
+  };
+}
+
+function addPathSegmentInfo(
+  type: GraphQLObjectType,
+  fieldName: string,
+  pathIndex: number,
+  errors: ReadonlyArray<GraphQLError> = [],
+  errorInfo: ErrorInfo
+) {
+  errors.forEach(error => {
+    const segmentInfo = {
+      type,
+      fieldName,
+      pathIndex,
+    };
+    const pathSegmentsInfo = errorInfo.segmentInfoMap.get(error);
+    if (pathSegmentsInfo == null) {
+      errorInfo.segmentInfoMap.set(error, [segmentInfo]);
+    } else {
+      pathSegmentsInfo.push(segmentInfo);
+    }
+  });
+}
+
+function collectSubFields(
+  exeContext: GraphQLExecutionContext,
+  type: GraphQLObjectType,
+  fieldNodes: Array<FieldNode>
+): Record<string, Array<FieldNode>> {
+  let subFieldNodes: Record<string, Array<FieldNode>> = Object.create(null);
+  const visitedFragmentNames = Object.create(null);
+
+  fieldNodes.forEach(fieldNode => {
+    subFieldNodes = collectFields(exeContext, type, fieldNode.selectionSet, subFieldNodes, visitedFragmentNames);
+  });
+
+  return subFieldNodes;
+}

--- a/packages/utils/tests/visitResult.test.ts
+++ b/packages/utils/tests/visitResult.test.ts
@@ -1,0 +1,385 @@
+import { buildSchema, parse, GraphQLError } from 'graphql';
+
+import { ExecutionResult } from '@graphql-tools/utils';
+
+import { relocatedError } from '../src/errors';
+
+import { visitResult } from '../src/visitResult';
+
+describe('visiting results', () => {
+  const schema = buildSchema(`
+    interface TestInterface {
+      field: String
+    }
+    type Test {
+      field: String
+    }
+    type Query {
+      test: TestInterface
+    }
+  `);
+
+  const request = {
+    document: parse('{ test { field } }'),
+    variables: {},
+  };
+
+  it('should visit without throwing', async () => {
+    expect(() => visitResult({}, request, schema, undefined)).not.toThrow();
+  });
+
+  it('should allow visiting without a resultVisitorMap', async () => {
+    const result = {
+      data: {
+        test: {
+          __typename: 'Test',
+          field: 'test',
+        },
+      },
+    };
+
+    const visitedResult = visitResult(result, request, schema, undefined);
+    expect(visitedResult).toEqual(result);
+  });
+
+  it('should successfully modify the result using an object type result visitor', async () => {
+    const result = {
+      data: {
+        test: {
+          __typename: 'Test',
+          field: 'test',
+        },
+      },
+    };
+
+    const visitedResult = visitResult(result, request, schema, {
+      Test: {
+        field: () => 'success',
+      },
+    });
+
+    const expectedResult = {
+      data: {
+        test: {
+          __typename: 'Test',
+          field: 'success',
+        },
+      },
+    };
+
+    expect(visitedResult).toEqual(expectedResult);
+  });
+
+  it('should successfully modify the result using a leaf type result visitor', async () => {
+    const result = {
+      data: {
+        test: {
+          __typename: 'Test',
+          field: 'test',
+        },
+      },
+    };
+
+    const visitedResult = visitResult(result, request, schema, {
+      String: () => 'success',
+    });
+
+    const expectedResult = {
+      data: {
+        test: {
+          __typename: 'Test',
+          field: 'success',
+        },
+      },
+    };
+
+    expect(visitedResult).toEqual(expectedResult);
+  });
+
+  it('should successfully modify the result using both leaf type and object type visitors', async () => {
+    const result = {
+      data: {
+        test: {
+          __typename: 'Test',
+          field: 'test',
+        },
+      },
+    };
+
+    const visitedResult = visitResult(result, request, schema, {
+      Test: {
+        // leaf type visitors fire first.
+        field: (value) => value === 'intermediate' ? 'success' : 'failure',
+      },
+      String: () => 'intermediate',
+    });
+
+    const expectedResult = {
+      data: {
+        test: {
+          __typename: 'Test',
+          field: 'success',
+        },
+      },
+    };
+
+    expect(visitedResult).toEqual(expectedResult);
+  });
+
+  it('should successfully modify the __typename field of an object', async () => {
+    const result = {
+      data: {
+        test: {
+          __typename: 'Test',
+          field: 'test',
+        },
+      },
+    };
+
+    const visitedResult = visitResult(result, request, schema, {
+      Test: {
+        __typename: () => 'Success',
+      },
+    });
+
+    const expectedResult = {
+      data: {
+        test: {
+          __typename: 'Success',
+          field: 'test',
+        },
+      },
+    };
+
+    expect(visitedResult).toEqual(expectedResult);
+  });
+
+  it('should successfully modify the object directly using the __leave field of an object type result visitor', async () => {
+    const result = {
+      data: {
+        test: {
+          __typename: 'Test',
+          field: 'test',
+        },
+      },
+    };
+
+    const visitedResult = visitResult(result, request, schema, {
+      Test: {
+        __leave: (object) => ({
+          ...object,
+          __typename: 'Success',
+        }),
+      },
+    });
+
+    const expectedResult = {
+      data: {
+        test: {
+          __typename: 'Success',
+          field: 'test',
+        },
+      },
+    };
+
+    expect(visitedResult).toEqual(expectedResult);
+  });
+});
+
+describe('visiting nested results', () => {
+  const schema = buildSchema(`
+    type User {
+      name: String
+    }
+    type UserGroup {
+      name: String
+      subGroupedUsers: [[User]]
+    }
+    type Query {
+      userGroups: [UserGroup]
+    }
+  `);
+
+  const request = {
+    document: parse(`{
+      userGroups {
+        name
+        subGroupedUsers {
+          name
+        }
+      }
+    }`),
+    variables: {},
+  };
+
+  it('should work', async () => {
+    const result: ExecutionResult = {
+      data: {
+        userGroups: [{
+          name: 'Group A',
+          subGroupedUsers: [[
+            {
+              name: 'User A',
+            }
+          ]]
+        }],
+      },
+    };
+
+    const visitedResult = visitResult(result, request, schema, {});
+    expect(visitedResult).toEqual(result);
+  });
+
+  it('should work when the parent is null', async () => {
+    const result: ExecutionResult = {
+      data: {
+        userGroups: null,
+      },
+    };
+
+    const visitedResult = visitResult(result, request, schema, {});
+    expect(visitedResult).toEqual(result);
+  });
+
+  it('should work when the parent is an empty list', async () => {
+    const result: ExecutionResult = {
+      data: {
+        userGroups: [],
+      },
+    };
+
+    const visitedResult = visitResult(result, request, schema, {});
+    expect(visitedResult).toEqual(result);
+  });
+});
+
+describe('visiting nested results', () => {
+  const schema = buildSchema(`
+    type User {
+      name: String
+    }
+    type UserGroup {
+      name: String
+      subGroupedUsers: [[User]]
+    }
+    type Query {
+      userGroups: [UserGroup]
+    }
+  `);
+
+  const request = {
+    document: parse(`{
+      userGroups {
+        name
+        subGroupedUsers {
+          name
+        }
+      }
+    }`),
+    variables: {},
+  };
+
+  it('should work', async () => {
+    const result: ExecutionResult = {
+      data: {
+        userGroups: [{
+          name: 'Group A',
+          subGroupedUsers: [[
+            {
+              name: 'User A',
+            }
+          ]]
+        }],
+      },
+    };
+
+    const visitedResult = visitResult(result, request, schema, {});
+    expect(visitedResult).toEqual(result);
+  });
+
+  it('should work when the parent is null', async () => {
+    const result: ExecutionResult = {
+      data: {
+        userGroups: null,
+      },
+    };
+
+    const visitedResult = visitResult(result, request, schema, {});
+    expect(visitedResult).toEqual(result);
+  });
+
+  it('should work when the parent is an empty list', async () => {
+    const result: ExecutionResult = {
+      data: {
+        userGroups: [],
+      },
+    };
+
+    const visitedResult = visitResult(result, request, schema, {});
+    expect(visitedResult).toEqual(result);
+  });
+});
+
+describe('visiting errors', () => {
+  const schema = buildSchema(`
+    interface TestInterface {
+      field: String
+    }
+    type Test {
+      field: String
+    }
+    type Query {
+      test: TestInterface
+    }
+  `);
+
+  const request = {
+    document: parse('{ test { field } }'),
+    variables: {},
+  };
+
+  it('should allow visiting without an errorVisitor', async () => {
+    const result: ExecutionResult = {
+      data: {
+        test: {
+          __typename: 'Test',
+          field: null,
+        },
+      },
+      errors: [
+        new GraphQLError('unpathed error'),
+        new GraphQLError('pathed error', undefined, undefined, undefined, ['test', 'field']),
+      ]
+    };
+
+    const visitedResult = visitResult(result, request, schema, undefined, undefined);
+    expect(visitedResult).toEqual(result);
+  });
+
+  it('should allow visiting with an errorVisitorMap', async () => {
+    const result: ExecutionResult = {
+      data: {
+        test: {
+          __typename: 'Test',
+          field: null,
+        },
+      },
+      errors: [
+        new GraphQLError('unpathed error'),
+        new GraphQLError('pathed error', undefined, undefined, undefined, ['test', 'field']),
+      ]
+    };
+
+    const visitedResult = visitResult(result, request, schema, undefined, {
+      Query: {
+        test: (error, pathIndex) => {
+          const oldPath = error.path;
+          const newPath = [...oldPath.slice(0, pathIndex), 'inserted', ...oldPath.slice(pathIndex)];
+          return relocatedError(error, newPath);
+        },
+      },
+    });
+
+    expect(visitedResult.errors[1].path).toEqual(['test', 'inserted', 'field']);
+  });
+});

--- a/packages/wrap/src/transforms/HoistField.ts
+++ b/packages/wrap/src/transforms/HoistField.ts
@@ -1,37 +1,46 @@
-import { GraphQLSchema, GraphQLObjectType, getNullableType } from 'graphql';
+import { GraphQLSchema, GraphQLObjectType, getNullableType, FieldNode, Kind, GraphQLError } from 'graphql';
 
 import {
-  wrapFieldNode,
   renameFieldNode,
   appendObjectFields,
   removeObjectFields,
   Transform,
   Request,
+  ExecutionResult,
+  relocatedError,
 } from '@graphql-tools/utils';
 
+import { defaultMergedResolver } from '@graphql-tools/delegate';
+
 import MapFields from './MapFields';
-import { createMergedResolver } from '@graphql-tools/delegate';
 
 export default class HoistField implements Transform {
   private readonly typeName: string;
-  private readonly path: Array<string>;
   private readonly newFieldName: string;
   private readonly pathToField: Array<string>;
   private readonly oldFieldName: string;
   private readonly transformer: Transform;
 
-  constructor(typeName: string, path: Array<string>, newFieldName: string) {
+  constructor(typeName: string, path: Array<string>, newFieldName: string, alias = '__gqtlw__') {
     this.typeName = typeName;
-    this.path = path;
     this.newFieldName = newFieldName;
 
-    this.pathToField = this.path.slice();
-    this.oldFieldName = this.pathToField.pop();
-    this.transformer = new MapFields({
-      [typeName]: {
-        [newFieldName]: fieldNode => wrapFieldNode(renameFieldNode(fieldNode, this.oldFieldName), this.pathToField),
+    const pathToField = path.slice();
+    const oldFieldName = pathToField.pop();
+
+    this.oldFieldName = oldFieldName;
+    this.pathToField = pathToField;
+    this.transformer = new MapFields(
+      {
+        [typeName]: {
+          [newFieldName]: fieldNode => wrapFieldNode(renameFieldNode(fieldNode, oldFieldName), pathToField, alias),
+        },
       },
-    });
+      {
+        [typeName]: value => unwrapValue(value, alias),
+      },
+      errors => unwrapErrors(errors, alias)
+    );
   }
 
   public transformSchema(schema: GraphQLSchema): GraphQLSchema {
@@ -53,14 +62,81 @@ export default class HoistField implements Transform {
     newSchema = appendObjectFields(newSchema, this.typeName, {
       [this.newFieldName]: {
         type: targetType,
-        resolve: createMergedResolver({ fromPath: this.pathToField }),
+        resolve: defaultMergedResolver,
       },
     });
 
     return this.transformer.transformSchema(newSchema);
   }
 
-  public transformRequest(originalRequest: Request): Request {
-    return this.transformer.transformRequest(originalRequest);
+  public transformRequest(
+    originalRequest: Request,
+    delegationContext?: Record<string, any>,
+    transformationContext?: Record<string, any>
+  ): Request {
+    return this.transformer.transformRequest(originalRequest, delegationContext, transformationContext);
   }
+
+  public transformResult(
+    originalResult: ExecutionResult,
+    delegationContext?: Record<string, any>,
+    transformationContext?: Record<string, any>
+  ): ExecutionResult {
+    return this.transformer.transformResult(originalResult, delegationContext, transformationContext);
+  }
+}
+
+export function wrapFieldNode(fieldNode: FieldNode, path: Array<string>, alias: string): FieldNode {
+  let newFieldNode = fieldNode;
+  path.forEach(fieldName => {
+    newFieldNode = {
+      kind: Kind.FIELD,
+      alias: {
+        kind: Kind.NAME,
+        value: alias,
+      },
+      name: {
+        kind: Kind.NAME,
+        value: fieldName,
+      },
+      selectionSet: {
+        kind: Kind.SELECTION_SET,
+        selections: [fieldNode],
+      },
+    };
+  });
+
+  return newFieldNode;
+}
+
+export function unwrapValue(originalValue: any, alias: string): any {
+  let newValue = originalValue;
+
+  let object = newValue[alias];
+  while (object != null) {
+    newValue = object;
+    object = newValue[alias];
+  }
+
+  delete originalValue[alias];
+  Object.assign(originalValue, newValue);
+
+  return originalValue;
+}
+
+function unwrapErrors(errors: ReadonlyArray<GraphQLError>, alias: string): Array<GraphQLError> {
+  if (errors === undefined) {
+    return undefined;
+  }
+
+  return errors.map(error => {
+    const originalPath = error.path;
+    if (originalPath == null) {
+      return error;
+    }
+
+    const newPath = originalPath.filter(pathSegment => pathSegment !== alias);
+
+    return relocatedError(error, newPath);
+  });
 }

--- a/packages/wrap/src/transforms/MapFields.ts
+++ b/packages/wrap/src/transforms/MapFields.ts
@@ -16,7 +16,7 @@ export default class MapFields implements Transform {
   ) {
     this.transformer = new TransformCompositeFields(
       (_typeName, _fieldName, fieldConfig) => fieldConfig,
-      (typeName, fieldName, fieldNode, fragments, context) => {
+      (typeName, fieldName, fieldNode, fragments, transformationContext) => {
         const typeTransformers = fieldNodeTransformerMap[typeName];
         if (typeTransformers == null) {
           return undefined;
@@ -27,10 +27,10 @@ export default class MapFields implements Transform {
           return undefined;
         }
 
-        return fieldNodeTransformer(fieldNode, fragments, context);
+        return fieldNodeTransformer(fieldNode, fragments, transformationContext);
       },
       objectValueTransformerMap != null
-        ? (data, context) => {
+        ? (data, transformationContext) => {
             if (data == null) {
               return data;
             }
@@ -45,7 +45,7 @@ export default class MapFields implements Transform {
               return data;
             }
 
-            return transformer(data, context);
+            return transformer(data, transformationContext);
           }
         : undefined,
       errorsTransformer != null ? errorsTransformer : undefined

--- a/packages/wrap/src/transforms/MapFields.ts
+++ b/packages/wrap/src/transforms/MapFields.ts
@@ -1,28 +1,54 @@
 import { GraphQLSchema } from 'graphql';
 
-import { Transform, Request, FieldNodeMappers } from '@graphql-tools/utils';
+import { Transform, Request, FieldNodeMappers, ExecutionResult } from '@graphql-tools/utils';
 
 import TransformCompositeFields from './TransformCompositeFields';
+
+import { ObjectValueTransformerMap, ErrorsTransformer } from '../types';
 
 export default class MapFields implements Transform {
   private readonly transformer: TransformCompositeFields;
 
-  constructor(fieldNodeTransformerMap: FieldNodeMappers) {
+  constructor(
+    fieldNodeTransformerMap: FieldNodeMappers,
+    objectValueTransformerMap?: ObjectValueTransformerMap,
+    errorsTransformer?: ErrorsTransformer
+  ) {
     this.transformer = new TransformCompositeFields(
       (_typeName, _fieldName, fieldConfig) => fieldConfig,
-      (typeName, fieldName, fieldNode, fragments) => {
+      (typeName, fieldName, fieldNode, fragments, context) => {
         const typeTransformers = fieldNodeTransformerMap[typeName];
         if (typeTransformers == null) {
-          return fieldNode;
+          return undefined;
         }
 
         const fieldNodeTransformer = typeTransformers[fieldName];
         if (fieldNodeTransformer == null) {
-          return fieldNode;
+          return undefined;
         }
 
-        return fieldNodeTransformer(fieldNode, fragments);
-      }
+        return fieldNodeTransformer(fieldNode, fragments, context);
+      },
+      objectValueTransformerMap != null
+        ? (data, context) => {
+            if (data == null) {
+              return data;
+            }
+
+            const typeName = data.__typename;
+            if (typeName == null) {
+              return data;
+            }
+
+            const transformer = objectValueTransformerMap[typeName];
+            if (transformer == null) {
+              return data;
+            }
+
+            return transformer(data, context);
+          }
+        : undefined,
+      errorsTransformer != null ? errorsTransformer : undefined
     );
   }
 
@@ -30,7 +56,19 @@ export default class MapFields implements Transform {
     return this.transformer.transformSchema(schema);
   }
 
-  public transformRequest(request: Request): Request {
-    return this.transformer.transformRequest(request);
+  public transformRequest(
+    originalRequest: Request,
+    delegationContext?: Record<string, any>,
+    transformationContext?: Record<string, any>
+  ): Request {
+    return this.transformer.transformRequest(originalRequest, delegationContext, transformationContext);
+  }
+
+  public transformResult(
+    originalResult: ExecutionResult,
+    delegationContext?: Record<string, any>,
+    transformationContext?: Record<string, any>
+  ): ExecutionResult {
+    return this.transformer.transformResult(originalResult, delegationContext, transformationContext);
   }
 }

--- a/packages/wrap/src/transforms/TransformCompositeFields.ts
+++ b/packages/wrap/src/transforms/TransformCompositeFields.ts
@@ -41,20 +41,14 @@ export default class TransformCompositeFields implements Transform {
 
   public transformRequest(originalRequest: Request): Request {
     const fragments = Object.create(null);
-    originalRequest.document.definitions
-      .filter(def => def.kind === Kind.FRAGMENT_DEFINITION)
-      .forEach(def => {
-        fragments[(def as FragmentDefinitionNode).name.value] = def;
-      });
-    const document = this.transformDocument(
-      originalRequest.document,
-      this.mapping,
-      this.fieldNodeTransformer,
-      fragments
-    );
+    originalRequest.document.definitions.forEach(def => {
+      if (def.kind === Kind.FRAGMENT_DEFINITION) {
+        fragments[def.name.value] = def;
+      }
+    });
     return {
       ...originalRequest,
-      document,
+      document: this.transformDocument(originalRequest.document, fragments),
     };
   }
 
@@ -110,8 +104,6 @@ export default class TransformCompositeFields implements Transform {
 
   private transformDocument(
     document: DocumentNode,
-    mapping: Record<string, Record<string, string>>,
-    fieldNodeTransformer?: FieldNodeTransformer,
     fragments: Record<string, FragmentDefinitionNode> = {}
   ): DocumentNode {
     const typeInfo = new TypeInfo(this.transformedSchema);
@@ -119,69 +111,77 @@ export default class TransformCompositeFields implements Transform {
       document,
       visitWithTypeInfo(typeInfo, {
         leave: {
-          [Kind.SELECTION_SET]: (node: SelectionSetNode): SelectionSetNode => {
-            const parentType: GraphQLType = typeInfo.getParentType();
-            if (parentType != null) {
-              const parentTypeName = parentType.name;
-              let newSelections: Array<SelectionNode> = [];
-
-              node.selections.forEach(selection => {
-                if (selection.kind !== Kind.FIELD) {
-                  newSelections.push(selection);
-                  return;
-                }
-
-                const newName = selection.name.value;
-
-                const transformedSelection =
-                  fieldNodeTransformer != null
-                    ? fieldNodeTransformer(parentTypeName, newName, selection, fragments)
-                    : selection;
-
-                if (Array.isArray(transformedSelection)) {
-                  newSelections = newSelections.concat(transformedSelection);
-                  return;
-                }
-
-                if (transformedSelection.kind !== Kind.FIELD) {
-                  newSelections.push(transformedSelection);
-                  return;
-                }
-
-                const typeMapping = mapping[parentTypeName];
-                if (typeMapping == null) {
-                  newSelections.push(transformedSelection);
-                  return;
-                }
-
-                const oldName = mapping[parentTypeName][newName];
-                if (oldName == null) {
-                  newSelections.push(transformedSelection);
-                  return;
-                }
-
-                newSelections.push({
-                  ...transformedSelection,
-                  name: {
-                    kind: Kind.NAME,
-                    value: oldName,
-                  },
-                  alias: {
-                    kind: Kind.NAME,
-                    value: newName,
-                  },
-                });
-              });
-
-              return {
-                ...node,
-                selections: newSelections,
-              };
-            }
-          },
+          [Kind.SELECTION_SET]: node => this.transformSelectionSet(node, typeInfo, fragments),
         },
       })
     );
     return newDocument;
+  }
+
+  private transformSelectionSet(
+    node: SelectionSetNode,
+    typeInfo: TypeInfo,
+    fragments: Record<string, FragmentDefinitionNode> = {}
+  ): SelectionSetNode {
+    const parentType: GraphQLType = typeInfo.getParentType();
+    if (parentType == null) {
+      return undefined;
+    }
+
+    const parentTypeName = parentType.name;
+    let newSelections: Array<SelectionNode> = [];
+
+    node.selections.forEach(selection => {
+      if (selection.kind !== Kind.FIELD) {
+        newSelections.push(selection);
+        return;
+      }
+
+      const newName = selection.name.value;
+
+      const transformedSelection =
+        this.fieldNodeTransformer != null
+          ? this.fieldNodeTransformer(parentTypeName, newName, selection, fragments)
+          : selection;
+
+      if (Array.isArray(transformedSelection)) {
+        newSelections = newSelections.concat(transformedSelection);
+        return;
+      }
+
+      if (transformedSelection.kind !== Kind.FIELD) {
+        newSelections.push(transformedSelection);
+        return;
+      }
+
+      const typeMapping = this.mapping[parentTypeName];
+      if (typeMapping == null) {
+        newSelections.push(transformedSelection);
+        return;
+      }
+
+      const oldName = this.mapping[parentTypeName][newName];
+      if (oldName == null) {
+        newSelections.push(transformedSelection);
+        return;
+      }
+
+      newSelections.push({
+        ...transformedSelection,
+        name: {
+          kind: Kind.NAME,
+          value: oldName,
+        },
+        alias: {
+          kind: Kind.NAME,
+          value: newName,
+        },
+      });
+    });
+
+    return {
+      ...node,
+      selections: newSelections,
+    };
   }
 }

--- a/packages/wrap/src/transforms/TransformInterfaceFields.ts
+++ b/packages/wrap/src/transforms/TransformInterfaceFields.ts
@@ -1,6 +1,6 @@
 import { GraphQLSchema, isInterfaceType, GraphQLFieldConfig } from 'graphql';
 
-import { Transform, Request } from '@graphql-tools/utils';
+import { Transform, Request, ExecutionResult } from '@graphql-tools/utils';
 import { FieldTransformer, FieldNodeTransformer } from '../types';
 
 import TransformCompositeFields from './TransformCompositeFields';
@@ -33,7 +33,19 @@ export default class TransformInterfaceFields implements Transform {
     return this.transformer.transformSchema(originalSchema);
   }
 
-  public transformRequest(originalRequest: Request): Request {
-    return this.transformer.transformRequest(originalRequest);
+  public transformRequest(
+    originalRequest: Request,
+    delegationContext?: Record<string, any>,
+    transformationContext?: Record<string, any>
+  ): Request {
+    return this.transformer.transformRequest(originalRequest, delegationContext, transformationContext);
+  }
+
+  public transformResult(
+    originalResult: ExecutionResult,
+    delegationContext?: Record<string, any>,
+    transformationContext?: Record<string, any>
+  ): ExecutionResult {
+    return this.transformer.transformResult(originalResult, delegationContext, transformationContext);
   }
 }

--- a/packages/wrap/src/transforms/TransformObjectFields.ts
+++ b/packages/wrap/src/transforms/TransformObjectFields.ts
@@ -1,6 +1,6 @@
 import { GraphQLSchema, isObjectType, GraphQLFieldConfig } from 'graphql';
 
-import { Transform, Request } from '@graphql-tools/utils';
+import { Transform, Request, ExecutionResult } from '@graphql-tools/utils';
 import { FieldTransformer, FieldNodeTransformer } from '../types';
 
 import TransformCompositeFields from './TransformCompositeFields';
@@ -33,7 +33,19 @@ export default class TransformObjectFields implements Transform {
     return this.transformer.transformSchema(originalSchema);
   }
 
-  public transformRequest(originalRequest: Request): Request {
-    return this.transformer.transformRequest(originalRequest);
+  public transformRequest(
+    originalRequest: Request,
+    delegationContext?: Record<string, any>,
+    transformationContext?: Record<string, any>
+  ): Request {
+    return this.transformer.transformRequest(originalRequest, delegationContext, transformationContext);
+  }
+
+  public transformResult(
+    originalResult: ExecutionResult,
+    delegationContext?: Record<string, any>,
+    transformationContext?: Record<string, any>
+  ): ExecutionResult {
+    return this.transformer.transformResult(originalResult, delegationContext, transformationContext);
   }
 }

--- a/packages/wrap/src/transforms/TransformRootFields.ts
+++ b/packages/wrap/src/transforms/TransformRootFields.ts
@@ -1,6 +1,6 @@
 import { GraphQLSchema, GraphQLFieldConfig } from 'graphql';
 
-import { Transform, Request } from '@graphql-tools/utils';
+import { Transform, Request, ExecutionResult } from '@graphql-tools/utils';
 
 import TransformObjectFields from './TransformObjectFields';
 import { RootFieldTransformer, FieldNodeTransformer } from '../types';
@@ -45,7 +45,19 @@ export default class TransformRootFields implements Transform {
     return this.transformer.transformSchema(originalSchema);
   }
 
-  public transformRequest(originalRequest: Request): Request {
-    return this.transformer.transformRequest(originalRequest);
+  public transformRequest(
+    originalRequest: Request,
+    delegationContext?: Record<string, any>,
+    transformationContext?: Record<string, any>
+  ): Request {
+    return this.transformer.transformRequest(originalRequest, delegationContext, transformationContext);
+  }
+
+  public transformResult(
+    originalResult: ExecutionResult,
+    delegationContext?: Record<string, any>,
+    transformationContext?: Record<string, any>
+  ): ExecutionResult {
+    return this.transformer.transformResult(originalResult, delegationContext, transformationContext);
   }
 }

--- a/packages/wrap/src/transforms/WrapFields.ts
+++ b/packages/wrap/src/transforms/WrapFields.ts
@@ -1,16 +1,46 @@
-import { GraphQLSchema, GraphQLObjectType } from 'graphql';
+import {
+  GraphQLSchema,
+  GraphQLObjectType,
+  GraphQLResolveInfo,
+  GraphQLFieldResolver,
+  GraphQLError,
+  FieldNode,
+  FragmentDefinitionNode,
+  SelectionSetNode,
+  Kind,
+} from 'graphql';
 
 import {
   Transform,
   Request,
-  hoistFieldNodes,
   appendObjectFields,
   selectObjectFields,
   modifyObjectFields,
+  ExecutionResult,
+  relocatedError,
 } from '@graphql-tools/utils';
-import { createMergedResolver, defaultMergedResolver } from '@graphql-tools/delegate';
+
+import { defaultMergedResolver } from '@graphql-tools/delegate';
 
 import MapFields from './MapFields';
+
+interface WrapFieldsTransformationContext {
+  nextIndex: number;
+  paths: Record<string, { pathToField: Array<string>; alias: string }>;
+}
+
+function defaultWrappingResolver(
+  parent: any,
+  args: Record<string, any>,
+  context: Record<string, any>,
+  info: GraphQLResolveInfo
+): any {
+  if (!parent) {
+    return {};
+  }
+
+  return defaultMergedResolver(parent, args, context, info);
+}
 
 export default class WrapFields implements Transform {
   private readonly outerTypeName: string;
@@ -18,33 +48,45 @@ export default class WrapFields implements Transform {
   private readonly wrappingTypeNames: Array<string>;
   private readonly numWraps: number;
   private readonly fieldNames: Array<string>;
+  private readonly wrappingResolver: GraphQLFieldResolver<any, any>;
   private readonly transformer: Transform;
 
   constructor(
     outerTypeName: string,
     wrappingFieldNames: Array<string>,
     wrappingTypeNames: Array<string>,
-    fieldNames?: Array<string>
+    fieldNames?: Array<string>,
+    wrappingResolver: GraphQLFieldResolver<any, any> = defaultWrappingResolver,
+    prefix = 'gqtld'
   ) {
     this.outerTypeName = outerTypeName;
     this.wrappingFieldNames = wrappingFieldNames;
     this.wrappingTypeNames = wrappingTypeNames;
     this.numWraps = wrappingFieldNames.length;
     this.fieldNames = fieldNames;
+    this.wrappingResolver = wrappingResolver;
 
     const remainingWrappingFieldNames = this.wrappingFieldNames.slice();
     const outerMostWrappingFieldName = remainingWrappingFieldNames.shift();
-    this.transformer = new MapFields({
-      [outerTypeName]: {
-        [outerMostWrappingFieldName]: (fieldNode, fragments) =>
-          hoistFieldNodes({
-            fieldNode,
-            path: remainingWrappingFieldNames,
-            fieldNames: this.fieldNames,
-            fragments,
-          }),
+    this.transformer = new MapFields(
+      {
+        [outerTypeName]: {
+          [outerMostWrappingFieldName]: (fieldNode, fragments, context: WrapFieldsTransformationContext) =>
+            hoistFieldNodes({
+              fieldNode,
+              path: remainingWrappingFieldNames,
+              fieldNames,
+              fragments,
+              context,
+              prefix,
+            }),
+        },
       },
-    });
+      {
+        [outerTypeName]: (value, context: WrapFieldsTransformationContext) => dehoistValue(value, context),
+      },
+      (errors, context: WrapFieldsTransformationContext) => dehoistErrors(errors, context)
+    );
   }
 
   public transformSchema(schema: GraphQLSchema): GraphQLSchema {
@@ -66,7 +108,7 @@ export default class WrapFields implements Transform {
       newSchema = appendObjectFields(newSchema, nextWrappingTypeName, {
         [wrappingFieldName]: {
           type: newSchema.getType(wrappingTypeName) as GraphQLObjectType,
-          resolve: defaultMergedResolver,
+          resolve: this.wrappingResolver,
         },
       });
 
@@ -82,7 +124,7 @@ export default class WrapFields implements Transform {
       {
         [wrappingFieldName]: {
           type: newSchema.getType(wrappingTypeName) as GraphQLObjectType,
-          resolve: createMergedResolver({ dehoist: true }),
+          resolve: this.wrappingResolver,
         },
       }
     );
@@ -90,7 +132,186 @@ export default class WrapFields implements Transform {
     return this.transformer.transformSchema(newSchema);
   }
 
-  public transformRequest(originalRequest: Request): Request {
-    return this.transformer.transformRequest(originalRequest);
+  public transformRequest(
+    originalRequest: Request,
+    delegationContext: Record<string, any>,
+    transformationContext: WrapFieldsTransformationContext
+  ): Request {
+    transformationContext.nextIndex = 0;
+    transformationContext.paths = Object.create(null);
+    return this.transformer.transformRequest(originalRequest, delegationContext, transformationContext);
   }
+
+  public transformResult(
+    originalResult: ExecutionResult,
+    delegationContext: Record<string, any>,
+    transformationContext: WrapFieldsTransformationContext
+  ): ExecutionResult {
+    return this.transformer.transformResult(originalResult, delegationContext, transformationContext);
+  }
+}
+
+function collectFields(
+  selectionSet: SelectionSetNode,
+  fragments: Record<string, FragmentDefinitionNode>,
+  fields: Array<FieldNode> = [],
+  visitedFragmentNames = {}
+): Array<FieldNode> {
+  if (selectionSet != null) {
+    selectionSet.selections.forEach(selection => {
+      switch (selection.kind) {
+        case Kind.FIELD:
+          fields.push(selection);
+          break;
+        case Kind.INLINE_FRAGMENT:
+          collectFields(selection.selectionSet, fragments, fields, visitedFragmentNames);
+          break;
+        case Kind.FRAGMENT_SPREAD: {
+          const fragmentName = selection.name.value;
+          if (!visitedFragmentNames[fragmentName]) {
+            visitedFragmentNames[fragmentName] = true;
+            collectFields(fragments[fragmentName].selectionSet, fragments, fields, visitedFragmentNames);
+          }
+          break;
+        }
+        default:
+          // unreachable
+          break;
+      }
+    });
+  }
+
+  return fields;
+}
+
+function aliasFieldNode(fieldNode: FieldNode, str: string): FieldNode {
+  return {
+    ...fieldNode,
+    alias: {
+      kind: Kind.NAME,
+      value: str,
+    },
+  };
+}
+
+function hoistFieldNodes({
+  fieldNode,
+  fieldNames,
+  path,
+  fragments,
+  context,
+  prefix,
+  index = 0,
+  wrappingPath = [],
+}: {
+  fieldNode: FieldNode;
+  fieldNames?: Array<string>;
+  path: Array<string>;
+  fragments: Record<string, FragmentDefinitionNode>;
+  context: WrapFieldsTransformationContext;
+  prefix: string;
+  index?: number;
+  wrappingPath?: ReadonlyArray<string>;
+}): Array<FieldNode> {
+  const alias = fieldNode.alias != null ? fieldNode.alias.value : fieldNode.name.value;
+
+  let newFieldNodes: Array<FieldNode> = [];
+
+  if (index < path.length) {
+    const pathSegment = path[index];
+    collectFields(fieldNode.selectionSet, fragments).forEach((possibleFieldNode: FieldNode) => {
+      if (possibleFieldNode.name.value === pathSegment) {
+        const newWrappingPath = wrappingPath.concat([alias]);
+
+        newFieldNodes = newFieldNodes.concat(
+          hoistFieldNodes({
+            fieldNode: possibleFieldNode,
+            fieldNames,
+            path,
+            fragments,
+            context,
+            prefix,
+            index: index + 1,
+            wrappingPath: newWrappingPath,
+          })
+        );
+      }
+    });
+  } else {
+    collectFields(fieldNode.selectionSet, fragments).forEach((possibleFieldNode: FieldNode) => {
+      if (!fieldNames || fieldNames.includes(possibleFieldNode.name.value)) {
+        const nextIndex = context.nextIndex;
+        context.nextIndex++;
+        const indexingAlias = `__${prefix}${nextIndex}__`;
+        context.paths[indexingAlias] = {
+          pathToField: wrappingPath.concat([alias]),
+          alias: possibleFieldNode.alias != null ? possibleFieldNode.alias.value : possibleFieldNode.name.value,
+        };
+        newFieldNodes.push(aliasFieldNode(possibleFieldNode, indexingAlias));
+      }
+    });
+  }
+
+  return newFieldNodes;
+}
+
+export function dehoistValue(originalValue: any, context: WrapFieldsTransformationContext): any {
+  if (originalValue == null) {
+    return originalValue;
+  }
+
+  const newValue = Object.create(null);
+
+  Object.keys(originalValue).forEach(alias => {
+    let obj = newValue;
+
+    const path = context.paths[alias];
+    if (path == null) {
+      newValue[alias] = originalValue[alias];
+      return;
+    }
+
+    const pathToField = path.pathToField;
+    const fieldAlias = path.alias;
+    pathToField.forEach(key => {
+      obj = obj[key] = obj[key] || Object.create(null);
+    });
+    obj[fieldAlias] = originalValue[alias];
+  });
+
+  return newValue;
+}
+
+function dehoistErrors(
+  errors: ReadonlyArray<GraphQLError>,
+  context: WrapFieldsTransformationContext
+): Array<GraphQLError> {
+  if (errors === undefined) {
+    return undefined;
+  }
+
+  return errors.map(error => {
+    const originalPath = error.path;
+    if (originalPath == null) {
+      return error;
+    }
+
+    let newPath: Array<string | number> = [];
+    originalPath.forEach(pathSegment => {
+      if (typeof pathSegment !== 'string') {
+        newPath.push(pathSegment);
+        return;
+      }
+
+      const path = context.paths[pathSegment];
+      if (path == null) {
+        newPath.push(pathSegment);
+        return;
+      }
+
+      newPath = newPath.concat(path.pathToField, [path.alias]);
+    });
+
+    return relocatedError(error, newPath);
+  });
 }

--- a/packages/wrap/src/transforms/WrapFields.ts
+++ b/packages/wrap/src/transforms/WrapFields.ts
@@ -71,13 +71,17 @@ export default class WrapFields implements Transform {
     this.transformer = new MapFields(
       {
         [outerTypeName]: {
-          [outerMostWrappingFieldName]: (fieldNode, fragments, context: WrapFieldsTransformationContext) =>
+          [outerMostWrappingFieldName]: (
+            fieldNode,
+            fragments,
+            transformationContext: WrapFieldsTransformationContext
+          ) =>
             hoistFieldNodes({
               fieldNode,
               path: remainingWrappingFieldNames,
               fieldNames,
               fragments,
-              context,
+              transformationContext,
               prefix,
             }),
         },
@@ -199,7 +203,7 @@ function hoistFieldNodes({
   fieldNames,
   path,
   fragments,
-  context,
+  transformationContext,
   prefix,
   index = 0,
   wrappingPath = [],
@@ -208,7 +212,7 @@ function hoistFieldNodes({
   fieldNames?: Array<string>;
   path: Array<string>;
   fragments: Record<string, FragmentDefinitionNode>;
-  context: WrapFieldsTransformationContext;
+  transformationContext: WrapFieldsTransformationContext;
   prefix: string;
   index?: number;
   wrappingPath?: ReadonlyArray<string>;
@@ -229,7 +233,7 @@ function hoistFieldNodes({
             fieldNames,
             path,
             fragments,
-            context,
+            transformationContext,
             prefix,
             index: index + 1,
             wrappingPath: newWrappingPath,
@@ -240,10 +244,10 @@ function hoistFieldNodes({
   } else {
     collectFields(fieldNode.selectionSet, fragments).forEach((possibleFieldNode: FieldNode) => {
       if (!fieldNames || fieldNames.includes(possibleFieldNode.name.value)) {
-        const nextIndex = context.nextIndex;
-        context.nextIndex++;
+        const nextIndex = transformationContext.nextIndex;
+        transformationContext.nextIndex++;
         const indexingAlias = `__${prefix}${nextIndex}__`;
-        context.paths[indexingAlias] = {
+        transformationContext.paths[indexingAlias] = {
           pathToField: wrappingPath.concat([alias]),
           alias: possibleFieldNode.alias != null ? possibleFieldNode.alias.value : possibleFieldNode.name.value,
         };

--- a/packages/wrap/src/transforms/WrapType.ts
+++ b/packages/wrap/src/transforms/WrapType.ts
@@ -1,6 +1,6 @@
 import { GraphQLSchema } from 'graphql';
 
-import { Transform, Request } from '@graphql-tools/utils';
+import { Transform, Request, ExecutionResult } from '@graphql-tools/utils';
 
 import WrapFields from './WrapFields';
 
@@ -8,14 +8,26 @@ export default class WrapType implements Transform {
   private readonly transformer: Transform;
 
   constructor(outerTypeName: string, innerTypeName: string, fieldName: string) {
-    this.transformer = new WrapFields(outerTypeName, [fieldName], [innerTypeName], undefined);
+    this.transformer = new WrapFields(outerTypeName, [fieldName], [innerTypeName]);
   }
 
   public transformSchema(schema: GraphQLSchema): GraphQLSchema {
     return this.transformer.transformSchema(schema);
   }
 
-  public transformRequest(originalRequest: Request): Request {
-    return this.transformer.transformRequest(originalRequest);
+  public transformRequest(
+    originalRequest: Request,
+    delegationContext: Record<string, any>,
+    transformationContext: Record<string, any>
+  ): Request {
+    return this.transformer.transformRequest(originalRequest, delegationContext, transformationContext);
+  }
+
+  public transformResult(
+    originalResult: ExecutionResult,
+    delegationContext: Record<string, any>,
+    transformationContext: Record<string, any>
+  ): ExecutionResult {
+    return this.transformer.transformResult(originalResult, delegationContext, transformationContext);
   }
 }

--- a/packages/wrap/src/types.ts
+++ b/packages/wrap/src/types.ts
@@ -9,6 +9,7 @@ import {
   SelectionNode,
   ObjectFieldNode,
   ObjectValueNode,
+  GraphQLError,
 } from 'graphql';
 import { Executor, Subscriber, DelegationContext } from '@graphql-tools/delegate';
 import { Request } from '@graphql-tools/utils';
@@ -58,5 +59,15 @@ export type FieldNodeTransformer = (
   typeName: string,
   fieldName: string,
   fieldNode: FieldNode,
-  fragments: Record<string, FragmentDefinitionNode>
+  fragments: Record<string, FragmentDefinitionNode>,
+  context: Record<string, any>
 ) => SelectionNode | Array<SelectionNode>;
+
+export type DataTransformer = (value: any, context?: Record<string, any>) => any;
+
+export type ObjectValueTransformerMap = Record<string, DataTransformer>;
+
+export type ErrorsTransformer = (
+  errors: ReadonlyArray<GraphQLError>,
+  context: Record<string, any>
+) => Array<GraphQLError>;

--- a/packages/wrap/src/types.ts
+++ b/packages/wrap/src/types.ts
@@ -60,14 +60,14 @@ export type FieldNodeTransformer = (
   fieldName: string,
   fieldNode: FieldNode,
   fragments: Record<string, FragmentDefinitionNode>,
-  context: Record<string, any>
+  transformationContext: Record<string, any>
 ) => SelectionNode | Array<SelectionNode>;
 
-export type DataTransformer = (value: any, context?: Record<string, any>) => any;
+export type DataTransformer = (value: any, transformationContext?: Record<string, any>) => any;
 
 export type ObjectValueTransformerMap = Record<string, DataTransformer>;
 
 export type ErrorsTransformer = (
   errors: ReadonlyArray<GraphQLError>,
-  context: Record<string, any>
+  transformationContext: Record<string, any>
 ) => Array<GraphQLError>;


### PR DESCRIPTION
When transforming a delegating schema (i.e. utilizing the transformSchema method within transforms passed to wrapSchema), one technique for result transformation is to defer the work until field resolution time, i.e. by wrapping the resolve method for the appropriate field within the delegating schema.

This approach saves a round of result tree traversal., but, unfortunately, causes several issues:

= return type inconsistencies that affect using these fields for stitching (see: #1725, https://github.com/yaacovCR/graphql-tools-fork/issues/35)
= type merging issues when fields are wrapped only in some subschemas

WrapType, WrapFields, HoistField, ExtendSchema transformers have been converted to utilize their transformResult methods to visit the result. 

This PR embraces that result visiting as an independent step when required and introduces some generic utility functions to make that easier.

To do, in separate future PRs:
= use result visiting to implement leaf value conversion #1634
= use result visiting to convert errors from subschemas to full paths, a la #1650 to solve #1047. This set of changes is now a breaking change because getErrors is exported, and likely should be deferred until the next major release, which probably (?) should coincide with the next major release of upstream graphql-js.  