### PR TITLE
allow mutation type wrapping

### DIFF
--- a/packages/stitch/tests/alternateStitchSchemas.test.ts
+++ b/packages/stitch/tests/alternateStitchSchemas.test.ts
@@ -969,11 +969,11 @@ describe('rename nested object fields with interfaces', () => {
 
 describe('WrapType query transform', () => {
   test('should work', async () => {
-    const transformedPropertySchema = wrapSchema(bookingSchema, [
+    const transformedBookingSchema = wrapSchema(bookingSchema, [
       new WrapType('Query', 'Namespace_Query', 'namespace'),
     ]);
     const result = await graphql(
-      transformedPropertySchema,
+      transformedBookingSchema,
       `
         query($bid: ID!) {
           namespace {
@@ -1024,11 +1024,11 @@ describe('WrapType query transform', () => {
 
 describe('WrapType mutation transform', () => {
   test('should work', async () => {
-    const transformedPropertySchema = wrapSchema(bookingSchema, [
+    const transformedBookingSchema = wrapSchema(bookingSchema, [
       new WrapType('Mutation', 'Namespace_Mutation', 'namespace'),
     ]);
     const result = await graphql(
-      transformedPropertySchema,
+      transformedBookingSchema,
       `
         mutation($bi: BookingInput!) {
           namespace {
@@ -1070,8 +1070,8 @@ describe('WrapType mutation transform', () => {
         {
           locations: [
             {
-              column: 13,
-              line: 8,
+              column: 15,
+              line: 9,
             },
           ],
           message: 'Booking.error error',

--- a/packages/wrap/src/generateProxyingResolvers.ts
+++ b/packages/wrap/src/generateProxyingResolvers.ts
@@ -107,12 +107,14 @@ function createPossiblyNestedProxyingResolver(
 
 export function defaultCreateProxyingResolver({
   schema,
+  operation,
   transforms,
   transformedSchema,
 }: ICreateProxyingResolverOptions): GraphQLFieldResolver<any, any> {
   return (_parent, _args, context, info) =>
     delegateToSchema({
       schema,
+      operation,
       context,
       info,
       transforms,

--- a/website/docs/remote-schemas.md
+++ b/website/docs/remote-schemas.md
@@ -201,17 +201,19 @@ export interface ICreateProxyingResolverOptions {
 };
 ```
 
-You may not need all the options to accomplish what you need. For example, the default proxying resolver creator just uses a subset of the passed arguments:
+You may not need all the options to accomplish what you need. For example, the default proxying resolver creator just uses a subset of the passed arguments, with the fieldName inferred:
 
 ```ts
 export function defaultCreateProxyingResolver({
   schemaOrSubschemaConfig,
+  operation,
   transforms,
   transformedSchema,
 }: ICreateProxyingResolverOptions): GraphQLFieldResolver<any, any> {
   return (_parent, _args, context, info) =>
     delegateToSchema({
       schema: schemaOrSubschemaConfig,
+      operation,
       context,
       info,
       transforms,


### PR DESCRIPTION
the blocker for this was that the default createProxyingResolverFn was changed to no longer hardcode the operation, but to rather infer it from the root type being stitched from.

This was in parallel to a similar change with the target fieldName which was helpful when making the RenameRootField transformer just a special case of the RenameObjectField transformer, but messes up the wrapping of mutations, because when the root fields in the wrapping subschema are the ones that actually do the proxying, and wrapping them with another type causes them to default to the query operation.

So, the default createProxyingResolverFn now hardcodes the operation, and all is well.

Addresses #1708