### PR TITLE
standardize ExecutionResult

### DIFF
--- a/packages/delegate/src/delegateToSchema.ts
+++ b/packages/delegate/src/delegateToSchema.ts
@@ -3,7 +3,6 @@ import {
   execute,
   validate,
   GraphQLSchema,
-  ExecutionResult,
   isSchema,
   FieldDefinitionNode,
   getOperationAST,
@@ -14,7 +13,7 @@ import {
   GraphQLObjectType,
 } from 'graphql';
 
-import { mapAsyncIterator, Transform } from '@graphql-tools/utils';
+import { mapAsyncIterator, Transform, ExecutionResult } from '@graphql-tools/utils';
 
 import { IDelegateToSchemaOptions, IDelegateRequestOptions, SubschemaConfig, ExecutionParams } from './types';
 

--- a/packages/delegate/src/transforms/CheckResultAndHandleErrors.ts
+++ b/packages/delegate/src/transforms/CheckResultAndHandleErrors.ts
@@ -1,6 +1,6 @@
-import { GraphQLResolveInfo, ExecutionResult, GraphQLOutputType, GraphQLSchema } from 'graphql';
+import { GraphQLResolveInfo, GraphQLOutputType, GraphQLSchema } from 'graphql';
 
-import { Transform, getResponseKeyFromInfo } from '@graphql-tools/utils';
+import { Transform, getResponseKeyFromInfo, ExecutionResult } from '@graphql-tools/utils';
 import { handleResult } from '../results/handleResult';
 import { SubschemaConfig } from '../types';
 

--- a/packages/mock/src/types.ts
+++ b/packages/mock/src/types.ts
@@ -1,4 +1,6 @@
-import { GraphQLFieldResolver, GraphQLType, GraphQLSchema, ExecutionResult } from 'graphql';
+import { GraphQLFieldResolver, GraphQLType, GraphQLSchema } from 'graphql';
+
+import { ExecutionResult } from '@graphql-tools/utils';
 
 /* XXX on mocks, args are optional, Not sure if a bug. */
 export type IMockFn = GraphQLFieldResolver<any, any>;

--- a/packages/schema/tests/resolution.test.ts
+++ b/packages/schema/tests/resolution.test.ts
@@ -3,12 +3,13 @@ import {
   parse,
   graphql,
   subscribe,
-  ExecutionResult,
   graphqlSync,
 } from 'graphql';
 import { PubSub } from 'graphql-subscriptions';
 
 import { makeExecutableSchema, addSchemaLevelResolver } from '@graphql-tools/schema';
+
+import { ExecutionResult } from '@graphql-tools/utils';
 
 import { forAwaitEach } from './forAwaitEach';
 

--- a/packages/schema/tests/schemaGenerator.test.ts
+++ b/packages/schema/tests/schemaGenerator.test.ts
@@ -13,7 +13,6 @@ import {
   Kind,
   IntValueNode,
   parse,
-  ExecutionResult,
   GraphQLError,
   GraphQLEnumType,
   execute,
@@ -42,7 +41,8 @@ import {
   NextResolverFn,
   VisitSchemaKind,
   ITypeDefinitions,
-  visitSchema
+  visitSchema,
+  ExecutionResult
 } from '@graphql-tools/utils';
 
 import TypeA from './fixtures/circularSchemaA';

--- a/packages/stitch/tests/alternateStitchSchemas.test.ts
+++ b/packages/stitch/tests/alternateStitchSchemas.test.ts
@@ -1,7 +1,6 @@
 import {
   graphql,
   GraphQLSchema,
-  ExecutionResult,
   subscribe,
   parse,
   GraphQLScalarType,
@@ -40,7 +39,9 @@ import { makeExecutableSchema } from '@graphql-tools/schema';
 import {
   wrapFieldNode,
   renameFieldNode,
-  hoistFieldNodes, filterSchema
+  hoistFieldNodes,
+  filterSchema,
+  ExecutionResult,
 } from '@graphql-tools/utils';
 
 import { stitchSchemas } from '../src/stitchSchemas';

--- a/packages/stitch/tests/stitchSchemas.test.ts
+++ b/packages/stitch/tests/stitchSchemas.test.ts
@@ -6,7 +6,6 @@ import {
   GraphQLScalarType,
   subscribe,
   parse,
-  ExecutionResult,
   defaultFieldResolver,
   findDeprecatedUsages,
   printSchema,
@@ -20,6 +19,7 @@ import {
   getResolversFromSchema,
   SchemaDirectiveVisitor,
   IResolvers,
+  ExecutionResult,
 } from '@graphql-tools/utils';
 import { addMocksToSchema } from '@graphql-tools/mock';
 

--- a/packages/stitch/tests/typeMerging.example.test.ts
+++ b/packages/stitch/tests/typeMerging.example.test.ts
@@ -1,9 +1,11 @@
 // Conversion of Apollo Federation demo from https://github.com/apollographql/federation-demo.
 // See: https://github.com/ardatan/graphql-tools/issues/1697
 
-import { graphql, ExecutionResult } from 'graphql';
+import { graphql } from 'graphql';
 
 import { makeExecutableSchema } from '@graphql-tools/schema';
+
+import { ExecutionResult } from '@graphql-tools/utils';
 
 import { stitchSchemas } from '../src/stitchSchemas';
 

--- a/packages/utils/tests/directives.test.ts
+++ b/packages/utils/tests/directives.test.ts
@@ -1,7 +1,6 @@
 import { createHash } from 'crypto';
 
 import {
-  ExecutionResult,
   GraphQLArgument,
   GraphQLEnumType,
   GraphQLEnumValue,
@@ -29,9 +28,12 @@ import {
 import formatDate from 'dateformat';
 
 import { makeExecutableSchema } from '@graphql-tools/schema';
-import { VisitableSchemaType, SchemaDirectiveVisitor,
+import {
+  VisitableSchemaType,
+  SchemaDirectiveVisitor,
   SchemaVisitor,
   visitSchema,
+  ExecutionResult,
 } from '@graphql-tools/utils';
 
 const typeDefs = `

--- a/packages/utils/tests/schemaTransforms.test.ts
+++ b/packages/utils/tests/schemaTransforms.test.ts
@@ -7,7 +7,6 @@ import {
   defaultFieldResolver,
   graphql,
   GraphQLString,
-  ExecutionResult,
   GraphQLScalarType,
   StringValueNode,
   GraphQLInputFieldConfig,
@@ -31,6 +30,7 @@ import {
   mapSchema,
   MapperKind,
   getDirectives,
+  ExecutionResult,
 } from '@graphql-tools/utils';
 
 const typeDefs = `

--- a/packages/wrap/tests/fragmentsAreNotDuplicated.test.ts
+++ b/packages/wrap/tests/fragmentsAreNotDuplicated.test.ts
@@ -1,8 +1,9 @@
-import { ExecutionResult, graphql } from 'graphql';
+import { graphql } from 'graphql';
 
 import { wrapSchema } from '../src';
 import { makeExecutableSchema } from '@graphql-tools/schema'
 import { addMocksToSchema } from '@graphql-tools/mock';
+import { ExecutionResult } from '@graphql-tools/utils';
 
 describe('Merging schemas', () => {
   test('should not throw `There can be only one fragment named "FieldName"` errors', async () => {


### PR DESCRIPTION
to be from internal polyfill
this can probably be changed back to import from graphql after support for versions < 15.2 is dropped

See:
https://github.com/graphql/graphql-js/releases/tag/v15.2.0
https://github.com/graphql/graphql-js/pull/2644
