### PR TITLE
Use new relay compiler transform which supports including flattened fragments

### DIFF
--- a/packages/relay-operation-optimizer/tests/relay-optimizer.spec.ts
+++ b/packages/relay-operation-optimizer/tests/relay-optimizer.spec.ts
@@ -24,30 +24,45 @@ const testSchema = buildSchema(/* GraphQL */ `
 `);
 
 it('can be called', async () => {
-    const testDocument = parse(/* GraphQL */ `
+  const testDocument = parse(/* GraphQL */ `
     query user {
       user {
         id
       }
     }
   `);
-    await optimizeDocuments(testSchema, [testDocument], {});
+  await optimizeDocuments(testSchema, [testDocument], {});
+});
+
+it('can include flattened fragments', async () => {
+  const testDocument = parse(/* GraphQL */ `
+    fragment UserFragment on User {
+      id
+    }
+    fragment UserFragment2 on User {
+      ...UserFragment
+      login
+    }
+  `);
+  const result = await optimizeDocuments(testSchema, [testDocument], { includeFragments: true });
+  expect(print(result)).toMatchInlineSnapshot(`Array []`);
 });
 
 it('can be called with queries that include connection fragments', async () => {
-    const testDocument = parse(/* GraphQL */ `
+  const testDocument = parse(/* GraphQL */ `
     query user {
       users @connection(key: "foo") {
         id
       }
     }
   `);
-    await optimizeDocuments(testSchema, [testDocument], {});
+  await optimizeDocuments(testSchema, [testDocument], {});
 });
 
 it('can inline @argumentDefinitions/@arguments annotated fragments', async () => {
-    const fragmentDocument = parse(/* GraphQL */ `
-    fragment UserLogin on User @argumentDefinitions(height: { type: "Int", defaultValue: 10 }, width: { type: "Int", defaultValue: 10 }) {
+  const fragmentDocument = parse(/* GraphQL */ `
+    fragment UserLogin on User
+      @argumentDefinitions(height: { type: "Int", defaultValue: 10 }, width: { type: "Int", defaultValue: 10 }) {
       id
       login
       avatar(width: $width, height: $height) {
@@ -56,19 +71,19 @@ it('can inline @argumentDefinitions/@arguments annotated fragments', async () =>
       }
     }
   `);
-    const queryDocument = parse(/* GraphQL */ `
+  const queryDocument = parse(/* GraphQL */ `
     query user {
       users {
         ...UserLogin @arguments(height: 30, width: 30)
       }
     }
   `);
-    const input = [fragmentDocument, queryDocument];
-    const output = await optimizeDocuments(testSchema, input, {});
-    const queryDoc = output.find(doc => doc.definitions[0].kind === 'OperationDefinition');
+  const input = [fragmentDocument, queryDocument];
+  const output = await optimizeDocuments(testSchema, input, {});
+  const queryDoc = output.find(doc => doc.definitions[0].kind === 'OperationDefinition');
 
-    expect(queryDoc).toBeDefined();
-    expect(print(queryDoc)).toBeSimilarGqlDoc(/* GraphQL */ `
+  expect(queryDoc).toBeDefined();
+  expect(print(queryDoc)).toBeSimilarGqlDoc(/* GraphQL */ `
     query user {
       users {
         id
@@ -83,7 +98,7 @@ it('can inline @argumentDefinitions/@arguments annotated fragments', async () =>
 });
 
 it('handles unions with interfaces the correct way', async () => {
-    const schema = buildSchema(/* GraphQL */ `
+  const schema = buildSchema(/* GraphQL */ `
     type User {
       id: ID!
       login: String!
@@ -108,7 +123,7 @@ it('handles unions with interfaces the correct way', async () => {
     }
   `);
 
-    const queryDocument = parse(/* GraphQL */ `
+  const queryDocument = parse(/* GraphQL */ `
     query user {
       user {
         ... on User {
@@ -122,12 +137,12 @@ it('handles unions with interfaces the correct way', async () => {
     }
   `);
 
-    const input = [queryDocument];
-    const output = await optimizeDocuments(schema, input, {});
-    const queryDoc = output.find(doc => doc.definitions[0].kind === 'OperationDefinition');
+  const input = [queryDocument];
+  const output = await optimizeDocuments(schema, input, {});
+  const queryDoc = output.find(doc => doc.definitions[0].kind === 'OperationDefinition');
 
-    expect(queryDoc).toBeDefined();
-    expect(print(queryDoc)).toBeSimilarGqlDoc(/* GraphQL */ `
+  expect(queryDoc).toBeDefined();
+  expect(print(queryDoc)).toBeSimilarGqlDoc(/* GraphQL */ `
     query user {
       user {
         ... on User {


### PR DESCRIPTION
This PR uses a new (not yet landed) relay compiler transform option which allows
including flattened fragments in the optimized document. This results in better 
generated fragment types.

Dependent on: https://github.com/facebook/relay/pull/3115

<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass