### PR TITLE
Update loadFilesSync docs for specifying extensions

### DIFF
--- a/website/docs/merge-resolvers.md
+++ b/website/docs/merge-resolvers.md
@@ -70,14 +70,14 @@ module.exports = mergeResolvers(resolversArray);
 This means that you should be careful with Queries, Mutations or Subscriptions with naming conflicts.
 
 You can also load files with specified extensions by setting the extensions option.
-Only these values are supported now. `'.ts', '.js', '.gql', '.graphql', '.graphqls'`
+Only these values are supported now. `'ts', 'js', 'gql', 'graphql', 'graphqls'`
 ```js
 // ./graphql/resolvers.js
 const path = require('path');
 const { mergeResolvers } = require('@graphql-tools/merge');
 const { loadFilesSync } = require('@graphql-tools/load-files');
 
-const resolversArray = loadFilesSync(path.join(__dirname, './resolvers'), { extensions: ['.js'] });
+const resolversArray = loadFilesSync(path.join(__dirname, './resolvers'), { extensions: ['js'] });
 
 module.exports = mergeResolvers(resolversArray);
 ```

--- a/website/docs/merge-typedefs.md
+++ b/website/docs/merge-typedefs.md
@@ -116,6 +116,19 @@ module.exports = mergeTypeDefs(typesArray, { all: true });
 ```
 When using the `loadFilesSync` function you can also implement your type definitions using `.graphql` or `.gql` or `.graphqls` files.
 
+You can also load files with specified extensions by setting the extensions option.
+Only these values are supported now. `'ts', 'js', 'gql', 'graphql', 'graphqls'`
+```js
+// ./graphql/typeDefs.js
+const path = require('path');
+const { loadFilesSync } = require('@graphql-tools/load-files');
+const { mergeTypeDefs } = require('@graphql-tools/merge');
+
+const typesArray = loadFilesSync(path.join(__dirname, './types'), { extensions: ['graphql'] });
+
+module.exports = mergeTypeDefs(typesArray, { all: true });
+```
+
 > The `loadFilesSync` function will by default ignore files named `index.js` or `index.ts` (use `{ignoreIndex: false}` option to change this behavior). This allows you to create your index file inside the actual types folder if desired.
 
 ```graphql


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

After moving to graphql-tools v6, the extensions specified when using `loadFilesSync` now do not require the `.` e.g. `.graphql` --> `graphql`.

TODO:

- [x] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
