### PR TITLE
Annotate code base with JSDoc comments

### DIFF
--- a/packages/graphql-tag-pluck/src/index.ts
+++ b/packages/graphql-tag-pluck/src/index.ts
@@ -5,9 +5,98 @@ import createVisitor from './visitor';
 import traverse from '@babel/traverse';
 import { freeText } from './utils';
 
+/**
+ * Additional options for determining how a file is parsed.
+ */
 export interface GraphQLTagPluckOptions {
+  /**
+   * Additional options for determining how a file is parsed.An array of packages that are responsible for exporting the GraphQL string parser function. The following modules are supported by default:
+   * ```js
+   * {
+   *   modules: [
+   *     {
+   *       // import gql from 'graphql-tag'
+   *       name: 'graphql-tag',
+   *     },
+   *     {
+   *       name: 'graphql-tag.macro',
+   *     },
+   *     {
+   *       // import { graphql } from 'gatsby'
+   *       name: 'gatsby',
+   *       identifier: 'graphql',
+   *     },
+   *     {
+   *       name: 'apollo-server-express',
+   *       identifier: 'gql',
+   *     },
+   *     {
+   *       name: 'apollo-server',
+   *       identifier: 'gql',
+   *     },
+   *     {
+   *       name: 'react-relay',
+   *       identifier: 'graphql',
+   *     },
+   *     {
+   *       name: 'apollo-boost',
+   *       identifier: 'gql',
+   *     },
+   *     {
+   *       name: 'apollo-server-koa',
+   *       identifier: 'gql',
+   *     },
+   *     {
+   *       name: 'apollo-server-hapi',
+   *       identifier: 'gql',
+   *     },
+   *     {
+   *       name: 'apollo-server-fastify',
+   *       identifier: 'gql',
+   *     },
+   *     {
+   *       name: ' apollo-server-lambda',
+   *       identifier: 'gql',
+   *     },
+   *     {
+   *       name: 'apollo-server-micro',
+   *       identifier: 'gql',
+   *     },
+   *     {
+   *       name: 'apollo-server-azure-functions',
+   *       identifier: 'gql',
+   *     },
+   *     {
+   *       name: 'apollo-server-cloud-functions',
+   *       identifier: 'gql',
+   *     },
+   *     {
+   *       name: 'apollo-server-cloudflare',
+   *       identifier: 'gql',
+   *     },
+   *   ];
+   * }
+   * ```
+   */
   modules?: Array<{ name: string; identifier?: string }>;
+  /**
+   * The magic comment anchor to look for when parsing GraphQL strings. Defaults to `graphql`.
+   */
   gqlMagicComment?: string;
+  /**
+   * Allows to use a global identifier instead of a module import.
+   * ```js
+   * // `graphql` is a global function
+   * export const usersQuery = graphql`
+   *   {
+   *     users {
+   *       id
+   *       name
+   *     }
+   *   }
+   * `;
+   * ```
+   */
   globalGqlIdentifierName?: string | string[];
 }
 
@@ -20,6 +109,15 @@ function parseWithVue(vueTemplateCompiler: typeof import('vue-template-compiler'
   return parsed.script ? parsed.script.content : '';
 }
 
+/**
+ * Asynchronously plucks GraphQL template literals from a single file.
+ *
+ * Supported file extensions include: `.js`, `.jsx`, `.ts`, `.tsx`, `.flow`, `.flow.js`, `.flow.jsx`, `.vue`
+ *
+ * @param filePath Path to the file containing the code. Required to detect the file type
+ * @param code The contents of the file being parsed.
+ * @param options Additional options for determining how a file is parsed.
+ */
 export const gqlPluckFromCodeString = async (
   filePath: string,
   code: string,
@@ -36,6 +134,15 @@ export const gqlPluckFromCodeString = async (
   return parseCode({ code, filePath, options });
 };
 
+/**
+ * Synchronously plucks GraphQL template literals from a single file
+ *
+ * Supported file extensions include: `.js`, `.jsx`, `.ts`, `.tsx`, `.flow`, `.flow.js`, `.flow.jsx`, `.vue`
+ *
+ * @param filePath Path to the file containing the code. Required to detect the file type
+ * @param code The contents of the file being parsed.
+ * @param options Additional options for determining how a file is parsed.
+ */
 export const gqlPluckFromCodeStringSync = (
   filePath: string,
   code: string,
@@ -85,7 +192,7 @@ function extractExtension(filePath: string) {
 
   if (fileExt) {
     if (!supportedExtensions.includes(fileExt)) {
-      throw TypeError(`Provided file type must be one of ${supportedExtensions.join(', ')}`);
+      throw TypeError(`Provided file type must be one of ${supportedExtensions.join(', ')} `);
     }
   }
 

--- a/packages/load-files/src/index.ts
+++ b/packages/load-files/src/index.ts
@@ -73,14 +73,25 @@ function extractExports(fileExport: any, exportNames: string[]): any | null {
   return fileExport;
 }
 
+/**
+ * Additional options for loading files
+ */
 export interface LoadFilesOptions {
+  // Extensions to explicitly ignore. Defaults to `['spec', 'test', 'd', 'map']`
   ignoredExtensions?: string[];
+  // Extensions to include when loading files. Defaults to `['gql', 'graphql', 'graphqls', 'ts', 'js']`
   extensions?: string[];
+  // Load files using `require` regardless of the file extension
   useRequire?: boolean;
+  // An alternative to `require` to use if `require` would be used to load a file
   requireMethod?: any;
+  // Additional options to pass to globby
   globOptions?: GlobbyOptions;
+  // Named exports to extract from each file. Defaults to ['typeDefs', 'schema']
   exportNames?: string[];
+  // Load files from nested directories. Set to `false` to only search the top-level directory.
   recursive?: boolean;
+  // Set to `true` to ignore files named `index.js` and `index.ts`
   ignoreIndex?: boolean;
 }
 
@@ -97,6 +108,11 @@ const LoadFilesDefaultOptions: LoadFilesOptions = {
   ignoreIndex: false,
 };
 
+/**
+ * Synchronously loads files using the provided glob pattern.
+ * @param pattern Glob pattern or patterns to use when loading files
+ * @param options Additional options
+ */
 export function loadFilesSync<T = any>(
   pattern: string | string[],
   options: LoadFilesOptions = LoadFilesDefaultOptions
@@ -188,6 +204,11 @@ const checkExtension = (
   return false;
 };
 
+/**
+ * Asynchronously loads files using the provided glob pattern.
+ * @param pattern Glob pattern or patterns to use when loading files
+ * @param options Additional options
+ */
 export async function loadFiles(
   pattern: string | string[],
   options: LoadFilesOptions = LoadFilesDefaultOptions

--- a/packages/load/src/documents.ts
+++ b/packages/load/src/documents.ts
@@ -2,21 +2,44 @@ import { Source } from '@graphql-tools/utils';
 import { Kind } from 'graphql';
 import { LoadTypedefsOptions, loadTypedefs, loadTypedefsSync, UnnormalizedTypeDefPointer } from './load-typedefs';
 
+/**
+ * Kinds of AST nodes that are included in executable documents
+ */
 export const OPERATION_KINDS = [Kind.OPERATION_DEFINITION, Kind.FRAGMENT_DEFINITION];
+
+/**
+ * Kinds of AST nodes that are included in type system definition documents
+ */
 export const NON_OPERATION_KINDS = Object.keys(Kind)
   .reduce((prev, v) => [...prev, Kind[v]], [])
   .filter(v => !OPERATION_KINDS.includes(v));
 
+/**
+ * Asynchronously loads executable documents (i.e. operations and fragments) from
+ * the provided pointers. The pointers may be individual files or a glob pattern.
+ * The files themselves may be `.graphql` files or `.js` and `.ts` (in which
+ * case they will be parsed using graphql-tag-pluck).
+ * @param pointerOrPointers Pointers to the files to load the documents from
+ * @param options Additional options
+ */
 export function loadDocuments(
-  documentDef: UnnormalizedTypeDefPointer | UnnormalizedTypeDefPointer[],
+  pointerOrPointers: UnnormalizedTypeDefPointer | UnnormalizedTypeDefPointer[],
   options: LoadTypedefsOptions
 ): Promise<Source[]> {
-  return loadTypedefs(documentDef, { noRequire: true, filterKinds: NON_OPERATION_KINDS, ...options });
+  return loadTypedefs(pointerOrPointers, { noRequire: true, filterKinds: NON_OPERATION_KINDS, ...options });
 }
 
+/**
+ * Synchronously loads executable documents (i.e. operations and fragments) from
+ * the provided pointers. The pointers may be individual files or a glob pattern.
+ * The files themselves may be `.graphql` files or `.js` and `.ts` (in which
+ * case they will be parsed using graphql-tag-pluck).
+ * @param pointerOrPointers Pointers to the files to load the documents from
+ * @param options Additional options
+ */
 export function loadDocumentsSync(
-  documentDef: UnnormalizedTypeDefPointer | UnnormalizedTypeDefPointer[],
+  pointerOrPointers: UnnormalizedTypeDefPointer | UnnormalizedTypeDefPointer[],
   options: LoadTypedefsOptions
 ): Source[] {
-  return loadTypedefsSync(documentDef, { noRequire: true, filterKinds: NON_OPERATION_KINDS, ...options });
+  return loadTypedefsSync(pointerOrPointers, { noRequire: true, filterKinds: NON_OPERATION_KINDS, ...options });
 }

--- a/packages/load/src/filter-document-kind.ts
+++ b/packages/load/src/filter-document-kind.ts
@@ -1,6 +1,9 @@
 import { debugLog } from '@graphql-tools/utils';
 import { DocumentNode, DefinitionNode, Kind } from 'graphql';
 
+/**
+ * @internal
+ */
 export const filterKind = (content: DocumentNode, filterKinds: null | string[]) => {
   if (content && content.definitions && content.definitions.length && filterKinds && filterKinds.length > 0) {
     const invalidDefinitions: DefinitionNode[] = [];

--- a/packages/load/src/load-typedefs.ts
+++ b/packages/load/src/load-typedefs.ts
@@ -18,6 +18,13 @@ export type LoadTypedefsOptions<ExtraConfig = { [key: string]: any }> = SingleFi
 
 export type UnnormalizedTypeDefPointer = { [key: string]: any } | string;
 
+/**
+ * Asynchronously loads any GraphQL documents (i.e. executable documents like
+ * operations and fragments as well as type system definitions) from the
+ * provided pointers.
+ * @param pointerOrPointers Pointers to the sources to load the documents from
+ * @param options Additional options
+ */
 export async function loadTypedefs<AdditionalConfig = Record<string, unknown>>(
   pointerOrPointers: UnnormalizedTypeDefPointer | UnnormalizedTypeDefPointer[],
   options: LoadTypedefsOptions<Partial<AdditionalConfig>>
@@ -56,6 +63,13 @@ export async function loadTypedefs<AdditionalConfig = Record<string, unknown>>(
   return prepareResult({ options, pointerOptionMap, validSources });
 }
 
+/**
+ * Synchronously loads any GraphQL documents (i.e. executable documents like
+ * operations and fragments as well as type system definitions) from the
+ * provided pointers.
+ * @param pointerOrPointers Pointers to the sources to load the documents from
+ * @param options Additional options
+ */
 export function loadTypedefsSync<AdditionalConfig = Record<string, unknown>>(
   pointerOrPointers: UnnormalizedTypeDefPointer | UnnormalizedTypeDefPointer[],
   options: LoadTypedefsOptions<Partial<AdditionalConfig>>

--- a/packages/load/src/schema.ts
+++ b/packages/load/src/schema.ts
@@ -15,6 +15,11 @@ export type LoadSchemaOptions = BuildSchemaOptions &
     includeSources?: boolean;
   };
 
+/**
+ * Asynchronously loads a schema from the provided pointers.
+ * @param schemaPointers Pointers to the sources to load the schema from
+ * @param options Additional options
+ */
 export async function loadSchema(
   schemaPointers: UnnormalizedTypeDefPointer | UnnormalizedTypeDefPointer[],
   options: LoadSchemaOptions
@@ -40,6 +45,11 @@ export async function loadSchema(
   return schema;
 }
 
+/**
+ * Synchronously loads a schema from the provided pointers.
+ * @param schemaPointers Pointers to the sources to load the schema from
+ * @param options Additional options
+ */
 export function loadSchemaSync(
   schemaPointers: UnnormalizedTypeDefPointer | UnnormalizedTypeDefPointer[],
   options: LoadSchemaOptions

--- a/packages/loaders/apollo-engine/src/index.ts
+++ b/packages/loaders/apollo-engine/src/index.ts
@@ -2,6 +2,9 @@ import { SchemaLoader, Source, SingleFileOptions } from '@graphql-tools/utils';
 import { fetch } from 'cross-fetch';
 import { buildClientSchema } from 'graphql';
 
+/**
+ * Additional options for loading from Apollo Engine
+ */
 export interface ApolloEngineOptions extends SingleFileOptions {
   engine: {
     endpoint?: string;
@@ -14,6 +17,9 @@ export interface ApolloEngineOptions extends SingleFileOptions {
 
 const DEFAULT_APOLLO_ENDPOINT = 'https://engine-graphql.apollographql.com/api/graphql';
 
+/**
+ * This loader loads a schema from Apollo Engine
+ */
 export class ApolloEngineLoader implements SchemaLoader<ApolloEngineOptions> {
   loaderId() {
     return 'apollo-engine';
@@ -65,6 +71,9 @@ export class ApolloEngineLoader implements SchemaLoader<ApolloEngineOptions> {
   }
 }
 
+/**
+ * @internal
+ */
 export const SCHEMA_QUERY = /* GraphQL */ `
   query GetSchemaByTag($tag: String!, $id: ID!) {
     service(id: $id) {

--- a/packages/loaders/code-file/src/exports.ts
+++ b/packages/loaders/code-file/src/exports.ts
@@ -5,12 +5,18 @@ const identifiersToLookFor = ['default', 'schema', 'typeDefs', 'data'];
 
 // Pick exports
 
+/**
+ * @internal
+ */
 export function pickExportFromModule({ module, filepath }: { module: any; filepath: string }) {
   ensureModule({ module, filepath });
 
   return resolveModule(ensureExports({ module, filepath }));
 }
 
+/**
+ * @internal
+ */
 export function pickExportFromModuleSync({ module, filepath }: { module: any; filepath: string }) {
   ensureModule({ module, filepath });
 

--- a/packages/loaders/code-file/src/helpers.ts
+++ b/packages/loaders/code-file/src/helpers.ts
@@ -1,5 +1,8 @@
 import { DocumentNode, IntrospectionQuery } from 'graphql';
 
+/**
+ * @internal
+ */
 export function pick<T>(obj: any, keys: string[]): T {
   for (const key of keys) {
     if (obj[key]) {
@@ -12,22 +15,34 @@ export function pick<T>(obj: any, keys: string[]): T {
 
 // checkers
 
+/**
+ * @internal
+ */
 export function isSchemaText(obj: any): obj is string {
   return typeof obj === 'string';
 }
 
+/**
+ * @internal
+ */
 export function isWrappedSchemaJson(obj: any): obj is { data: IntrospectionQuery } {
   const json = obj as { data: IntrospectionQuery };
 
   return json.data !== undefined && json.data.__schema !== undefined;
 }
 
+/**
+ * @internal
+ */
 export function isSchemaJson(obj: any): obj is IntrospectionQuery {
   const json = obj as IntrospectionQuery;
 
   return json !== undefined && json.__schema !== undefined;
 }
 
+/**
+ * @internal
+ */
 export function isSchemaAst(obj: any): obj is DocumentNode {
   return (obj as DocumentNode).kind !== undefined;
 }

--- a/packages/loaders/code-file/src/index.ts
+++ b/packages/loaders/code-file/src/index.ts
@@ -21,6 +21,9 @@ import { isAbsolute, resolve } from 'path';
 import { readFileSync, readFile, pathExists, pathExistsSync } from 'fs-extra';
 import { cwd } from 'process';
 
+/**
+ * Additional options for loading from a code file
+ */
 export type CodeFileLoaderOptions = {
   require?: string | string[];
   pluckConfig?: GraphQLTagPluckOptions;
@@ -30,6 +33,20 @@ export type CodeFileLoaderOptions = {
 
 const FILE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.vue'];
 
+/**
+ * This loader loads GraphQL documents and type definitions from code files
+ * using `graphql-tag-pluck`.
+ *
+ * ```js
+ * const documents = await loadDocuments('queries/*.js', {
+ *   loaders: [
+ *     new CodeFileLoader()
+ *   ]
+ * });
+ * ```
+ *
+ * Supported extensions include: `.ts`, `.tsx`, `.js`, `.jsx`, `.vue`
+ */
 export class CodeFileLoader implements UniversalLoader<CodeFileLoaderOptions> {
   loaderId(): string {
     return 'code-file';

--- a/packages/loaders/code-file/src/load-from-module.ts
+++ b/packages/loaders/code-file/src/load-from-module.ts
@@ -1,6 +1,9 @@
 import { DocumentNode, GraphQLSchema } from 'graphql';
 import { pickExportFromModule, pickExportFromModuleSync } from './exports';
 
+/**
+ * @internal
+ */
 export async function tryToLoadFromExport(rawFilePath: string): Promise<GraphQLSchema | DocumentNode> {
   try {
     const filepath = ensureFilepath(rawFilePath);
@@ -13,6 +16,9 @@ export async function tryToLoadFromExport(rawFilePath: string): Promise<GraphQLS
   }
 }
 
+/**
+ * @internal
+ */
 export function tryToLoadFromExportSync(rawFilePath: string): GraphQLSchema | DocumentNode {
   try {
     const filepath = ensureFilepath(rawFilePath);
@@ -25,6 +31,9 @@ export function tryToLoadFromExportSync(rawFilePath: string): GraphQLSchema | Do
   }
 }
 
+/**
+ * @internal
+ */
 function ensureFilepath(filepath: string) {
   if (typeof require !== 'undefined' && require.cache) {
     filepath = require.resolve(filepath);

--- a/packages/loaders/git/src/index.ts
+++ b/packages/loaders/git/src/index.ts
@@ -27,10 +27,27 @@ function extractData(
   };
 }
 
-type GitLoaderOptions = SingleFileOptions & { pluckConfig: GraphQLTagPluckOptions };
+/**
+ * Additional options for loading from git
+ */
+export type GitLoaderOptions = SingleFileOptions & {
+  /**
+   * Additional options to pass to `graphql-tag-pluck`
+   */
+  pluckConfig: GraphQLTagPluckOptions;
+};
 
 const createInvalidExtensionError = (path: string) => new Error(`Invalid file extension: ${path}`);
 
+/**
+ * This loader loads a file from git.
+ *
+ * ```js
+ * const typeDefs = await loadTypedefs('git:someBranch:some/path/to/file.js', {
+ *   loaders: [new GitLoader()],
+ * })
+ * ```
+ */
 export class GitLoader implements UniversalLoader {
   loaderId() {
     return 'git-loader';

--- a/packages/loaders/git/src/load-git.ts
+++ b/packages/loaders/git/src/load-git.ts
@@ -8,6 +8,9 @@ const createCommand = ({ ref, path }: Input) => {
   return [`${ref}:${path}`];
 };
 
+/**
+ * @internal
+ */
 export async function loadFromGit(input: Input): Promise<string | never> {
   try {
     const git = simplegit();
@@ -17,6 +20,9 @@ export async function loadFromGit(input: Input): Promise<string | never> {
   }
 }
 
+/**
+ * @internal
+ */
 export function loadFromGitSync(input: Input): string | never {
   try {
     const git = simplegitSync();

--- a/packages/loaders/git/src/parse.ts
+++ b/packages/loaders/git/src/parse.ts
@@ -1,5 +1,8 @@
 import { parseGraphQLSDL, parseGraphQLJSON, Source } from '@graphql-tools/utils';
 
+/**
+ * @internal
+ */
 export function parse<T>({
   path,
   pointer,

--- a/packages/loaders/github/src/index.ts
+++ b/packages/loaders/github/src/index.ts
@@ -23,11 +23,30 @@ function extractData(
   };
 }
 
+/**
+ * Additional options for loading from GitHub
+ */
 export interface GithubLoaderOptions extends SingleFileOptions {
+  /**
+   * A GitHub access token
+   */
   token: string;
+  /**
+   * Additional options to pass to `graphql-tag-pluck`
+   */
   pluckConfig?: GraphQLTagPluckOptions;
 }
 
+/**
+ * This loader loads a file from GitHub.
+ *
+ * ```js
+ * const typeDefs = await loadTypedefs('github:githubUser/githubRepo#branchName:path/to/file.ts', {
+ *   loaders: [new GithubLoader()],
+ *   token: YOUR_GITHUB_TOKEN,
+ * })
+ * ```
+ */
 export class GithubLoader implements UniversalLoader<GithubLoaderOptions> {
   loaderId() {
     return 'github-loader';

--- a/packages/loaders/graphql-file/src/index.ts
+++ b/packages/loaders/graphql-file/src/index.ts
@@ -14,7 +14,13 @@ import { processImport } from '@graphql-tools/import';
 
 const FILE_EXTENSIONS = ['.gql', '.gqls', '.graphql', '.graphqls'];
 
+/**
+ * Additional options for loading from a GraphQL file
+ */
 export interface GraphQLFileLoaderOptions extends SingleFileOptions {
+  /**
+   * Set to `true` to disable handling `#import` syntax
+   */
   skipGraphQLImport?: boolean;
 }
 
@@ -23,6 +29,29 @@ function isGraphQLImportFile(rawSDL: string) {
   return trimmedRawSDL.startsWith('# import') || trimmedRawSDL.startsWith('#import');
 }
 
+/**
+ * This loader loads documents and type definitions from `.graphql` files.
+ *
+ * You can load a single source:
+ *
+ * ```js
+ * const schema = await loadSchema('schema.graphql', {
+ *   loaders: [
+ *     new GraphQLFileLoader()
+ *   ]
+ * });
+ * ```
+ *
+ * Or provide a glob pattern to load multiple sources:
+ *
+ * ```js
+ * const schema = await loadSchema('graphql/*.graphql', {
+ *   loaders: [
+ *     new GraphQLFileLoader()
+ *   ]
+ * });
+ * ```
+ */
 export class GraphQLFileLoader implements UniversalLoader<GraphQLFileLoaderOptions> {
   loaderId(): string {
     return 'graphql-file';

--- a/packages/loaders/json-file/src/index.ts
+++ b/packages/loaders/json-file/src/index.ts
@@ -12,8 +12,34 @@ import { cwd } from 'process';
 
 const FILE_EXTENSIONS = ['.json'];
 
+/**
+ * Additional options for loading from a JSON file
+ */
 export interface JsonFileLoaderOptions extends SingleFileOptions {}
 
+/**
+ * This loader loads documents and type definitions from JSON files.
+ *
+ * The JSON file can be the result of an introspection query made against a schema:
+ *
+ * ```js
+ * const schema = await loadSchema('schema-introspection.json', {
+ *   loaders: [
+ *     new JsonFileLoader()
+ *   ]
+ * });
+ * ```
+ *
+ * Or it can be a `DocumentNode` object representing a GraphQL document or type definitions:
+ *
+ * ```js
+ * const documents = await loadDocuments('queries/*.json', {
+ *   loaders: [
+ *     new GraphQLFileLoader()
+ *   ]
+ * });
+ * ```
+ */
 export class JsonFileLoader implements DocumentLoader {
   loaderId(): string {
     return 'json-file';

--- a/packages/loaders/module/src/index.ts
+++ b/packages/loaders/module/src/index.ts
@@ -30,6 +30,15 @@ function extractData(
   };
 }
 
+/**
+ * * This loader loads documents and type definitions from a Node module
+ *
+ * ```js
+ * const schema = await loadSchema('module:someModuleName#someNamedExport', {
+ *   loaders: [new ModuleLoader()],
+ * })
+ * ```
+ */
 export class ModuleLoader implements UniversalLoader {
   loaderId() {
     return 'module-loader';

--- a/packages/loaders/prisma/src/index.ts
+++ b/packages/loaders/prisma/src/index.ts
@@ -5,12 +5,18 @@ import { pathExists } from 'fs-extra';
 import { homedir } from 'os';
 import { cwd } from 'process';
 
-interface PrismaLoaderOptions extends LoadFromUrlOptions {
+/**
+ * additional options for loading from a `prisma.yml` file
+ */
+export interface PrismaLoaderOptions extends LoadFromUrlOptions {
   envVars?: { [key: string]: string };
   graceful?: boolean;
   cwd?: string;
 }
 
+/**
+ * This loader loads a schema from a `prisma.yml` file
+ */
 export class PrismaLoader extends UrlLoader {
   loaderId() {
     return 'prisma';

--- a/packages/loaders/url/src/index.ts
+++ b/packages/loaders/url/src/index.ts
@@ -18,15 +18,50 @@ export type FetchFn = typeof import('cross-fetch').fetch;
 
 type Headers = Record<string, string> | Array<Record<string, string>>;
 
+/**
+ * Additional options for loading from a URL
+ */
 export interface LoadFromUrlOptions extends SingleFileOptions, Partial<IntrospectionOptions> {
+  /**
+   * Additional headers to include when querying the original schema
+   */
   headers?: Headers;
+  /**
+   * A custom `fetch` implementation to use when querying the original schema.
+   * Defaults to `cross-fetch`
+   */
   customFetch?: FetchFn | string;
+  /**
+   * HTTP method to use when querying the original schema.
+   */
   method?: 'GET' | 'POST';
+  /**
+   * Whether to enable subscriptions on the loaded schema
+   */
   enableSubscriptions?: boolean;
+  /**
+   * Custom WebSocket implementation used by the loaded schema if subscriptions
+   * are enabled
+   */
   webSocketImpl?: typeof w3cwebsocket | string;
+  /**
+   * Whether to use the GET HTTP method for queries when querying the original schema
+   */
   useGETForQueries?: boolean;
 }
 
+/**
+ * This loader loads a schema from a URL. The loaded schema is a fully-executable,
+ * remote schema since it's created using [@graphql-tools/wrap](remote-schemas).
+ *
+ * ```
+ * const schema = await loadSchema('http://localhost:3000/graphql', {
+ *   loaders: [
+ *     new UrlLoader(),
+ *   ]
+ * });
+ * ```
+ */
 export class UrlLoader implements DocumentLoader<LoadFromUrlOptions> {
   loaderId(): string {
     return 'url';

--- a/packages/merge/src/merge-resolvers.ts
+++ b/packages/merge/src/merge-resolvers.ts
@@ -3,10 +3,42 @@ import { IResolvers, mergeDeep } from '@graphql-tools/utils';
 export type ResolversFactory<TContext> = (...args: any[]) => IResolvers<any, TContext>;
 export type ResolversDefinition<TContext> = IResolvers<any, TContext> | ResolversFactory<TContext>;
 
+/**
+ * Additional options for merging resolvers
+ */
 export interface MergeResolversOptions {
   exclusions?: string[];
 }
 
+/**
+ * Deep merges multiple resolver definition objects into a single definition.
+ * @param resolversDefinitions Resolver definitions to be merged
+ * @param options Additional options
+ *
+ * ```js
+ * const { mergeResolvers } = require('@graphql-tools/merge');
+ * const clientResolver = require('./clientResolver');
+ * const productResolver = require('./productResolver');
+ *
+ * const resolvers = mergeResolvers([
+ *  clientResolver,
+ *  productResolver,
+ * ]);
+ * ```
+ *
+ * If you don't want to manually create the array of resolver objects, you can
+ * also use this function along with loadFiles:
+ *
+ * ```js
+ * const path = require('path');
+ * const { mergeResolvers } = require('@graphql-tools/merge');
+ * const { loadFilesSync } = require('@graphql-tools/load-files');
+ *
+ * const resolversArray = loadFilesSync(path.join(__dirname, './resolvers'));
+ *
+ * const resolvers = mergeResolvers(resolversArray)
+ * ```
+ */
 export function mergeResolvers<TContext, T extends ResolversDefinition<TContext>>(
   resolversDefinitions: T[],
   options?: MergeResolversOptions

--- a/packages/merge/src/merge-schemas.ts
+++ b/packages/merge/src/merge-schemas.ts
@@ -11,12 +11,33 @@ import {
 } from '@graphql-tools/utils';
 import { mergeExtensions, extractExtensionsFromSchema, applyExtensions, SchemaExtensions } from './extensions';
 
+/**
+ * Configuration object for schema merging
+ */
 export interface MergeSchemasConfig<Resolvers extends IResolvers = IResolvers> extends Config, BuildSchemaOptions {
+  /**
+   * The schemas to be merged
+   */
   schemas: GraphQLSchema[];
+  /**
+   * Additional type definitions to also merge
+   */
   typeDefs?: (DocumentNode | string)[] | DocumentNode | string;
+  /**
+   * Additional resolvers to also merge
+   */
   resolvers?: Resolvers | Resolvers[];
+  /**
+   * Schema directives to apply to the type definitions being merged, if provided
+   */
   schemaDirectives?: { [directiveName: string]: typeof SchemaDirectiveVisitor };
+  /**
+   * Options to validate the resolvers being merged, if provided
+   */
   resolverValidationOptions?: IResolverValidationOptions;
+  /**
+   * Custom logger instance
+   */
   logger?: ILogger;
 }
 
@@ -28,6 +49,10 @@ const defaultResolverValidationOptions: Partial<IResolverValidationOptions> = {
   allowResolversNotInSchema: true,
 };
 
+/**
+ * Synchronously merges multiple schemas, typeDefinitions and/or resolvers into a single schema.
+ * @param config Configuration object
+ */
 export function mergeSchemas(config: MergeSchemasConfig) {
   const typeDefs = mergeTypes(config);
   const extractedResolvers: IResolvers<any, any>[] = [];
@@ -44,6 +69,10 @@ export function mergeSchemas(config: MergeSchemasConfig) {
   return makeSchema({ resolvers, typeDefs, extensions }, config);
 }
 
+/**
+ * Synchronously merges multiple schemas, typeDefinitions and/or resolvers into a single schema.
+ * @param config Configuration object
+ */
 export async function mergeSchemasAsync(config: MergeSchemasConfig) {
   const [typeDefs, resolvers, extensions] = await Promise.all([
     mergeTypes(config),

--- a/packages/merge/src/typedefs-mergers/merge-typedefs.ts
+++ b/packages/merge/src/typedefs-mergers/merge-typedefs.ts
@@ -73,6 +73,10 @@ export function mergeGraphQLSchemas(
   return mergeGraphQLTypes(types, config);
 }
 
+/**
+ * Merges multiple type definitions into a single `DocumentNode`
+ * @param types The type definitions to be merged
+ */
 export function mergeTypeDefs(types: Array<string | Source | DocumentNode | GraphQLSchema>): DocumentNode;
 export function mergeTypeDefs(
   types: Array<string | Source | DocumentNode | GraphQLSchema>,

--- a/packages/mock/src/types.ts
+++ b/packages/mock/src/types.ts
@@ -2,21 +2,39 @@ import { GraphQLFieldResolver, GraphQLType, GraphQLSchema } from 'graphql';
 
 import { ExecutionResult } from '@graphql-tools/utils';
 
-/* XXX on mocks, args are optional, Not sure if a bug. */
+// XXX on mocks, args are optional, Not sure if a bug.
 export type IMockFn = GraphQLFieldResolver<any, any>;
 
 export interface IMocks {
   [key: string]: IMockFn;
 }
 
+/**
+ * @internal
+ */
 export type IMockTypeFn = (type: GraphQLType, typeName?: string, fieldName?: string) => GraphQLFieldResolver<any, any>;
 
 export interface IMockOptions {
+  /**
+   * The schema to which to add mocks. This can also be a set of type definitions instead.
+   */
   schema?: GraphQLSchema;
+  /**
+   * The mocks to add to the schema.
+   */
   mocks?: IMocks;
+  /**
+   * Set to `true` to prevent existing resolvers from being overwritten to provide
+   * mock data. This can be used to mock some parts of the server and not others.
+   */
   preserveResolvers?: boolean;
 }
 
 export interface IMockServer {
+  /**
+   * Executes the provided query against the mocked schema.
+   * @param query GraphQL query to execute
+   * @param vars Variables
+   */
   query: (query: string, vars?: Record<string, any>) => Promise<ExecutionResult>;
 }

--- a/packages/schema/src/makeExecutableSchema.ts
+++ b/packages/schema/src/makeExecutableSchema.ts
@@ -11,6 +11,50 @@ import { addErrorLoggingToSchema } from './addErrorLoggingToSchema';
 import { addCatchUndefinedToSchema } from './addCatchUndefinedToSchema';
 import { IExecutableSchemaDefinition } from './types';
 
+/**
+ * Builds a schema from the provided type definitions and resolvers.
+ *
+ * The type definitions are written using Schema Definition Language (SDL). They
+ * can be provided as a string, a `DocumentNode`, a function, or an array of any
+ * of these. If a function is provided, it will be passed no arguments and
+ * should return an array of strings or `DocumentNode`s.
+ *
+ * Note: You can use `graphql-tag` to not only parse a string into a
+ * `DocumentNode` but also to provide additinal syntax hightlighting in your
+ * editor (with the appropriate editor plugin).
+ *
+ * ```js
+ * const typeDefs = gql`
+ *   type Query {
+ *     posts: [Post]
+ *     author(id: Int!): Author
+ *   }
+ * `;
+ * ```
+ *
+ * The `resolvers` object should be a map of type names to nested object, which
+ * themselves map the type's fields to their appropriate resolvers.
+ * See the [Resolvers](resolvers) section of the documentation for more details.
+ *
+ * ```js
+ * const resolvers = {
+ *   Query: {
+ *     posts: (obj, args, ctx, info) => getAllPosts(),
+ *     author: (obj, args, ctx, info) => getAuthorById(args.id)
+ *   }
+ * };
+ * ```
+ *
+ * Once you've defined both the `typeDefs` and `resolvers`, you can create your
+ * schema:
+ *
+ * ```js
+ * const schema = makeExecutableSchema({
+ *   typeDefs,
+ *   resolvers,
+ * })
+ * ```
+ */
 export function makeExecutableSchema<TContext = any>({
   typeDefs,
   resolvers = {},

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -13,16 +13,57 @@ export interface ILogger {
   log: (error: Error) => void;
 }
 
+/**
+ * Configuration object for creating an executable schema
+ */
 export interface IExecutableSchemaDefinition<TContext = any> {
+  /**
+   * The type definitions used to create the schema
+   */
   typeDefs: ITypeDefinitions;
+  /**
+   * Object describing the field resolvers for the provided type definitions
+   */
   resolvers?: IResolvers<any, TContext> | Array<IResolvers<any, TContext>>;
+  /**
+   * Logger instance used to print errors to the server console that are
+   * usually swallowed by GraphQL.
+   */
   logger?: ILogger;
+  /**
+   * Set to `false` to have resolvers throw an if they return undefined, which
+   * can help make debugging easier
+   */
   allowUndefinedInResolve?: boolean;
+  /**
+   * Additional options for validating the provided resolvers
+   */
   resolverValidationOptions?: IResolverValidationOptions;
+  /**
+   * Map of directive resolvers
+   */
   directiveResolvers?: IDirectiveResolvers<any, TContext>;
+  /**
+   * A map of schema directives used with the legacy class-based implementation
+   * of schema directives
+   */
   schemaDirectives?: Record<string, SchemaDirectiveVisitorClass>;
+  /**
+   * An array of schema transformation functions
+   */
   schemaTransforms?: Array<SchemaTransform>;
+  /**
+   * Additional options for parsing the type definitions if they are provided
+   * as a string
+   */
   parseOptions?: GraphQLParseOptions;
+  /**
+   * GraphQL object types that implement interfaces will inherit any missing
+   * resolvers from their interface types defined in the `resolvers` object
+   */
   inheritResolversFromInterfaces?: boolean;
+  /**
+   * Additional options for removing unused types from the schema
+   */
   pruningOptions?: PruneSchemaOptions;
 }

--- a/packages/utils/src/Interfaces.ts
+++ b/packages/utils/src/Interfaces.ts
@@ -84,20 +84,65 @@ export interface GraphQLParseOptions {
 
 // graphql-tools typings
 
+/**
+ * Options for validating resolvers
+ */
 export interface IResolverValidationOptions {
+  /**
+   * Set to `true` to require a resolver to be defined for any field that has
+   * arguments. Defaults to `false`.
+   */
   requireResolversForArgs?: boolean;
+  /**
+   * Set to `true` to require a resolver to be defined for any field which has
+   * a return type that isn't a scalar. Defaults to `false`.
+   */
   requireResolversForNonScalar?: boolean;
+  /**
+   * Set to `true` to require a resolver for be defined for all fields defined
+   * in the schema. Defaults to `false`.
+   */
   requireResolversForAllFields?: boolean;
+  /**
+   * Set to `true` to require a `resolveType()` for Interface and Union types.
+   * Defaults to `false`.
+   */
   requireResolversForResolveType?: boolean;
+  /**
+   * Set to `false` to require all defined resolvers to match fields that
+   * actually exist in the schema. Defaults to `true`.
+   */
   allowResolversNotInSchema?: boolean;
 }
 
+/**
+ * Configuration object for adding resolvers to a schema
+ */
 export interface IAddResolversToSchemaOptions {
+  /**
+   * The schema to which to add resolvers
+   */
   schema: GraphQLSchema;
+  /**
+   * Object describing the field resolvers to add to the provided schema
+   */
   resolvers: IResolvers;
+  /**
+   * Override the default field resolver provided by `graphql-js`
+   */
   defaultFieldResolver?: IFieldResolver<any, any>;
+  /**
+   * Additional options for validating the provided resolvers
+   */
   resolverValidationOptions?: IResolverValidationOptions;
+  /**
+   * GraphQL object types that implement interfaces will inherit any missing
+   * resolvers from their interface types defined in the `resolvers` object
+   */
   inheritResolversFromInterfaces?: boolean;
+  /**
+   * Set to `true` to modify the existing schema instead of creating a new one
+   */
   updateResolversInPlace?: boolean;
 }
 

--- a/packages/utils/src/prune.ts
+++ b/packages/utils/src/prune.ts
@@ -31,13 +31,34 @@ interface PruningContext {
   implementations: Record<string, Record<string, boolean>>;
 }
 
+/**
+ * Options for removing unused types from the schema
+ */
 export interface PruneSchemaOptions {
+  /**
+   * Set to `true` to skip pruning object types or interfaces with no no fields
+   */
   skipEmptyCompositeTypePruning?: boolean;
+  /**
+   * Set to `true` to skip pruning interfaces that are not implemented by any
+   * other types
+   */
   skipUnimplementedInterfacesPruning?: boolean;
+  /**
+   * Set to `true` to skip pruning empty unions
+   */
   skipEmptyUnionPruning?: boolean;
+  /**
+   * Set to `true` to skip pruning unused types
+   */
   skipUnusedTypesPruning?: boolean;
 }
 
+/**
+ * Prunes the provided schema, removing unused and empty types
+ * @param schema The schema to prune
+ * @param options Additional options for removing unused types from the schema
+ */
 export function pruneSchema(schema: GraphQLSchema, options: PruneSchemaOptions = {}): GraphQLSchema {
   const pruningContext: PruningContext = {
     schema,


### PR DESCRIPTION
Partially addresses #1758. This is the initial batch of JSDoc comments to facilitate API documentation generation from source code. There's still a good chunk of code to go through, so subsequent PRs will need to follow. 

- [X] graphql-tag-pluck
- [X] load
- [X] load-files
- [X] loaders
- [ ] ~merge~ (partially done, still need to go through the `typedefs-mergers` folder)
- [X] mock
- [ ] ~schema~ (partially done)
- [ ] ~stitch~
- [ ] ~wrap~

I updated parameter names in a few places for consistency and clarity. These are not breaking changes, but I'll add comments to point those out.
