### PR TITLE
Modify ast nodes when transforming schemas

### DIFF
--- a/packages/utils/src/fields.ts
+++ b/packages/utils/src/fields.ts
@@ -42,8 +42,8 @@ export function appendObjectFields(
         return new GraphQLObjectType({
           ...config,
           fields: newFieldConfigMap,
-          astNode: rebuildAstNode(config.astNode, config.extensionASTNodes, newFieldConfigMap),
-          extensionASTNodes: [],
+          astNode: rebuildAstNode(config.astNode, newFieldConfigMap),
+          extensionASTNodes: rebuildExtensionAstNodes(config.extensionASTNodes),
         });
       }
     },
@@ -75,8 +75,8 @@ export function removeObjectFields(
         return new GraphQLObjectType({
           ...config,
           fields: newFieldConfigMap,
-          astNode: rebuildAstNode(config.astNode, config.extensionASTNodes, newFieldConfigMap),
-          extensionASTNodes: [],
+          astNode: rebuildAstNode(config.astNode, newFieldConfigMap),
+          extensionASTNodes: rebuildExtensionAstNodes(config.extensionASTNodes),
         });
       }
     },
@@ -143,8 +143,8 @@ export function modifyObjectFields(
         return new GraphQLObjectType({
           ...config,
           fields: newFieldConfigMap,
-          astNode: rebuildAstNode(config.astNode, config.extensionASTNodes, newFieldConfigMap),
-          extensionASTNodes: [],
+          astNode: rebuildAstNode(config.astNode, newFieldConfigMap),
+          extensionASTNodes: rebuildExtensionAstNodes(config.extensionASTNodes),
         });
       }
     },
@@ -155,28 +155,16 @@ export function modifyObjectFields(
 
 function rebuildAstNode(
   astNode: ObjectTypeDefinitionNode,
-  extensionASTNodes: ReadonlyArray<ObjectTypeExtensionNode>,
   fieldConfigMap: Record<string, GraphQLFieldConfig<any, any>>
 ): ObjectTypeDefinitionNode {
-  if (astNode == null && !extensionASTNodes?.length) {
+  if (astNode == null) {
     return undefined;
   }
 
-  let newAstNode: ObjectTypeDefinitionNode = {
+  const newAstNode: ObjectTypeDefinitionNode = {
     ...astNode,
     fields: undefined,
   };
-
-  if (extensionASTNodes != null) {
-    extensionASTNodes.forEach(node => {
-      newAstNode = {
-        ...newAstNode,
-        ...node,
-        kind: newAstNode.kind,
-        fields: undefined,
-      };
-    });
-  }
 
   const fields: Array<FieldDefinitionNode> = [];
   Object.values(fieldConfigMap).forEach(fieldConfig => {
@@ -189,4 +177,17 @@ function rebuildAstNode(
     ...newAstNode,
     fields,
   };
+}
+
+function rebuildExtensionAstNodes(
+  extensionASTNodes: ReadonlyArray<ObjectTypeExtensionNode>
+): Array<ObjectTypeExtensionNode> {
+  if (!extensionASTNodes?.length) {
+    return [];
+  }
+
+  return extensionASTNodes.map(node => ({
+    ...node,
+    fields: undefined,
+  }));
 }

--- a/packages/utils/src/mapSchema.ts
+++ b/packages/utils/src/mapSchema.ts
@@ -24,6 +24,14 @@ import {
   GraphQLList,
   GraphQLNonNull,
   GraphQLEnumType,
+  ObjectTypeDefinitionNode,
+  InterfaceTypeDefinitionNode,
+  InputObjectTypeDefinitionNode,
+  InputObjectTypeExtensionNode,
+  InterfaceTypeExtensionNode,
+  ObjectTypeExtensionNode,
+  InputValueDefinitionNode,
+  FieldDefinitionNode,
 } from 'graphql';
 
 import {
@@ -239,6 +247,15 @@ function mapFields(originalTypeMap: TypeMap, schema: GraphQLSchema, schemaMapper
           newFieldConfigMap[fieldName] = originalFieldConfig;
         } else if (Array.isArray(mappedField)) {
           const [newFieldName, newFieldConfig] = mappedField;
+          if (newFieldConfig.astNode != null) {
+            newFieldConfig.astNode = {
+              ...newFieldConfig.astNode,
+              name: {
+                ...newFieldConfig.astNode.name,
+                value: newFieldName,
+              },
+            };
+          }
           newFieldConfigMap[newFieldName] = newFieldConfig;
         } else if (mappedField !== null) {
           newFieldConfigMap[fieldName] = mappedField;
@@ -247,18 +264,26 @@ function mapFields(originalTypeMap: TypeMap, schema: GraphQLSchema, schemaMapper
 
       if (isObjectType(originalType)) {
         newTypeMap[typeName] = new GraphQLObjectType({
-          ...((config as unknown) as GraphQLObjectTypeConfig<any, any>),
+          ...(config as GraphQLObjectTypeConfig<any, any>),
           fields: newFieldConfigMap,
+          astNode: rebuildAstNode((config as GraphQLObjectTypeConfig<any, any>).astNode, newFieldConfigMap),
+          extensionASTNodes: rebuildExtensionAstNodes((config as GraphQLObjectTypeConfig<any, any>).extensionASTNodes),
         });
       } else if (isInterfaceType(originalType)) {
         newTypeMap[typeName] = new GraphQLInterfaceType({
-          ...((config as unknown) as GraphQLInterfaceTypeConfig<any, any>),
+          ...(config as GraphQLInterfaceTypeConfig<any, any>),
           fields: newFieldConfigMap,
+          astNode: rebuildAstNode((config as GraphQLInterfaceTypeConfig<any, any>).astNode, newFieldConfigMap),
+          extensionASTNodes: rebuildExtensionAstNodes(
+            (config as GraphQLInterfaceTypeConfig<any, any>).extensionASTNodes
+          ),
         });
       } else {
         newTypeMap[typeName] = new GraphQLInputObjectType({
-          ...((config as unknown) as GraphQLInputObjectTypeConfig),
+          ...(config as GraphQLInputObjectTypeConfig),
           fields: newFieldConfigMap,
+          astNode: rebuildAstNode((config as GraphQLInputObjectTypeConfig).astNode, newFieldConfigMap),
+          extensionASTNodes: rebuildExtensionAstNodes((config as GraphQLInputObjectTypeConfig).extensionASTNodes),
         });
       }
     }
@@ -470,4 +495,50 @@ function getDirectiveMapper(schemaMapper: SchemaMapper): DirectiveMapper | null 
 function getEnumValueMapper(schemaMapper: SchemaMapper): EnumValueMapper | null {
   const enumValueMapper = schemaMapper[MapperKind.ENUM_VALUE];
   return enumValueMapper != null ? enumValueMapper : null;
+}
+
+function rebuildAstNode<
+  TypeDefinitionNode extends ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode | InputObjectTypeDefinitionNode
+>(
+  astNode: TypeDefinitionNode,
+  fieldOrInputFieldConfigMap: Record<
+    string,
+    TypeDefinitionNode extends ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode
+      ? GraphQLFieldConfig<any, any>
+      : GraphQLInputFieldConfig
+  >
+): TypeDefinitionNode {
+  if (astNode == null) {
+    return undefined;
+  }
+
+  const newAstNode: TypeDefinitionNode = {
+    ...astNode,
+    fields: undefined,
+  };
+
+  const fields: Array<FieldDefinitionNode | InputValueDefinitionNode> = [];
+  Object.values(fieldOrInputFieldConfigMap).forEach(fieldOrInputFieldConfig => {
+    if (fieldOrInputFieldConfig.astNode != null) {
+      fields.push(fieldOrInputFieldConfig.astNode);
+    }
+  });
+
+  return {
+    ...newAstNode,
+    fields,
+  };
+}
+
+function rebuildExtensionAstNodes<
+  TypeExtensionNode extends ObjectTypeExtensionNode | InterfaceTypeExtensionNode | InputObjectTypeExtensionNode
+>(extensionASTNodes: ReadonlyArray<TypeExtensionNode>): Array<TypeExtensionNode> {
+  if (!extensionASTNodes?.length) {
+    return [];
+  }
+
+  return extensionASTNodes.map(node => ({
+    ...node,
+    fields: undefined,
+  }));
 }

--- a/packages/wrap/src/transforms/MapFields.ts
+++ b/packages/wrap/src/transforms/MapFields.ts
@@ -15,7 +15,7 @@ export default class MapFields implements Transform {
     errorsTransformer?: ErrorsTransformer
   ) {
     this.transformer = new TransformCompositeFields(
-      (_typeName, _fieldName, fieldConfig) => fieldConfig,
+      () => undefined,
       (typeName, fieldName, fieldNode, fragments, transformationContext) => {
         const typeTransformers = fieldNodeTransformerMap[typeName];
         if (typeTransformers == null) {

--- a/packages/wrap/src/transforms/RenameTypes.ts
+++ b/packages/wrap/src/transforms/RenameTypes.ts
@@ -64,31 +64,151 @@ export default class RenameTypes implements Transform {
             return new GraphQLObjectType({
               ...type.toConfig(),
               name: newName,
+              astNode:
+                type.astNode == null
+                  ? type.astNode
+                  : {
+                      ...type.astNode,
+                      name: {
+                        ...type.astNode.name,
+                        value: newName,
+                      },
+                    },
+              extensionASTNodes:
+                type.extensionASTNodes == null
+                  ? type.extensionASTNodes
+                  : type.extensionASTNodes.map(node => ({
+                      ...node,
+                      name: {
+                        ...node.name,
+                        value: newName,
+                      },
+                    })),
             });
           } else if (isInterfaceType(type)) {
             return new GraphQLInterfaceType({
               ...type.toConfig(),
               name: newName,
+              astNode:
+                type.astNode == null
+                  ? type.astNode
+                  : {
+                      ...type.astNode,
+                      name: {
+                        ...type.astNode.name,
+                        value: newName,
+                      },
+                    },
+              extensionASTNodes:
+                type.extensionASTNodes == null
+                  ? type.extensionASTNodes
+                  : type.extensionASTNodes.map(node => ({
+                      ...node,
+                      name: {
+                        ...node.name,
+                        value: newName,
+                      },
+                    })),
             });
           } else if (isUnionType(type)) {
             return new GraphQLUnionType({
               ...type.toConfig(),
               name: newName,
+              astNode:
+                type.astNode == null
+                  ? type.astNode
+                  : {
+                      ...type.astNode,
+                      name: {
+                        ...type.astNode.name,
+                        value: newName,
+                      },
+                    },
+              extensionASTNodes:
+                type.extensionASTNodes == null
+                  ? type.extensionASTNodes
+                  : type.extensionASTNodes.map(node => ({
+                      ...node,
+                      name: {
+                        ...node.name,
+                        value: newName,
+                      },
+                    })),
             });
           } else if (isInputObjectType(type)) {
             return new GraphQLInputObjectType({
               ...type.toConfig(),
               name: newName,
+              astNode:
+                type.astNode == null
+                  ? type.astNode
+                  : {
+                      ...type.astNode,
+                      name: {
+                        ...type.astNode.name,
+                        value: newName,
+                      },
+                    },
+              extensionASTNodes:
+                type.extensionASTNodes == null
+                  ? type.extensionASTNodes
+                  : type.extensionASTNodes.map(node => ({
+                      ...node,
+                      name: {
+                        ...node.name,
+                        value: newName,
+                      },
+                    })),
             });
           } else if (isEnumType(type)) {
             return new GraphQLEnumType({
               ...type.toConfig(),
               name: newName,
+              astNode:
+                type.astNode == null
+                  ? type.astNode
+                  : {
+                      ...type.astNode,
+                      name: {
+                        ...type.astNode.name,
+                        value: newName,
+                      },
+                    },
+              extensionASTNodes:
+                type.extensionASTNodes == null
+                  ? type.extensionASTNodes
+                  : type.extensionASTNodes.map(node => ({
+                      ...node,
+                      name: {
+                        ...node.name,
+                        value: newName,
+                      },
+                    })),
             });
           } else if (isScalarType(type)) {
             return new GraphQLScalarType({
               ...type.toConfig(),
               name: newName,
+              astNode:
+                type.astNode == null
+                  ? type.astNode
+                  : {
+                      ...type.astNode,
+                      name: {
+                        ...type.astNode.name,
+                        value: newName,
+                      },
+                    },
+              extensionASTNodes:
+                type.extensionASTNodes == null
+                  ? type.extensionASTNodes
+                  : type.extensionASTNodes.map(node => ({
+                      ...node,
+                      name: {
+                        ...node.name,
+                        value: newName,
+                      },
+                    })),
             });
           }
 

--- a/packages/wrap/src/transforms/TransformCompositeFields.ts
+++ b/packages/wrap/src/transforms/TransformCompositeFields.ts
@@ -266,7 +266,7 @@ function rebuildAstNode<TypeDefinitionNode extends ObjectTypeDefinitionNode | In
   >,
   fieldConfigMap: Record<string, GraphQLFieldConfig<any, any>>
 ): TypeDefinitionNode {
-  if (astNode == null && !extensionASTNodes.length) {
+  if (astNode == null && !extensionASTNodes?.length) {
     return undefined;
   }
 

--- a/packages/wrap/src/transforms/TransformCompositeFields.ts
+++ b/packages/wrap/src/transforms/TransformCompositeFields.ts
@@ -280,6 +280,7 @@ function rebuildAstNode<TypeDefinitionNode extends ObjectTypeDefinitionNode | In
       newAstNode = {
         ...newAstNode,
         ...node,
+        kind: newAstNode.kind,
         fields: undefined,
       };
     });

--- a/packages/wrap/src/transforms/TransformCompositeFields.ts
+++ b/packages/wrap/src/transforms/TransformCompositeFields.ts
@@ -13,6 +13,12 @@ import {
   isObjectType,
   isInterfaceType,
   GraphQLObjectType,
+  GraphQLFieldConfig,
+  FieldDefinitionNode,
+  ObjectTypeDefinitionNode,
+  InterfaceTypeDefinitionNode,
+  ObjectTypeExtensionNode,
+  InterfaceTypeExtensionNode,
 } from 'graphql';
 
 import { Transform, Request, MapperKind, mapSchema, visitData, ExecutionResult } from '@graphql-tools/utils';
@@ -101,7 +107,6 @@ export default class TransformCompositeFields implements Transform {
       } else if (Array.isArray(transformedField)) {
         const newFieldName = transformedField[0];
         const newFieldConfig = transformedField[1];
-        newFieldConfigMap[newFieldName] = newFieldConfig;
 
         if (newFieldName !== fieldName) {
           const typeName = type.name;
@@ -109,7 +114,19 @@ export default class TransformCompositeFields implements Transform {
             this.mapping[typeName] = {};
           }
           this.mapping[typeName][newFieldName] = fieldName;
+
+          if (newFieldConfig.astNode != null) {
+            newFieldConfig.astNode = {
+              ...newFieldConfig.astNode,
+              name: {
+                ...newFieldConfig.astNode.name,
+                value: newFieldName,
+              },
+            };
+          }
         }
+
+        newFieldConfigMap[newFieldName] = newFieldConfig;
       } else if (transformedField != null) {
         newFieldConfigMap[fieldName] = transformedField;
       }
@@ -120,14 +137,20 @@ export default class TransformCompositeFields implements Transform {
     }
 
     if (isObjectType(type)) {
+      const oldConfig = type.toConfig();
       return new GraphQLObjectType({
-        ...type.toConfig(),
+        ...oldConfig,
         fields: newFieldConfigMap,
+        astNode: rebuildAstNode(oldConfig.astNode, oldConfig.extensionASTNodes, newFieldConfigMap),
+        extensionASTNodes: [],
       });
     } else if (isInterfaceType(type)) {
+      const oldConfig = type.toConfig();
       return new GraphQLInterfaceType({
         ...type.toConfig(),
         fields: newFieldConfigMap,
+        astNode: rebuildAstNode(oldConfig.astNode, oldConfig.extensionASTNodes, newFieldConfigMap),
+        extensionASTNodes: [],
       });
     }
   }
@@ -234,4 +257,43 @@ export default class TransformCompositeFields implements Transform {
       selections: newSelections,
     };
   }
+}
+
+function rebuildAstNode<TypeDefinitionNode extends ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode>(
+  astNode: TypeDefinitionNode,
+  extensionASTNodes: ReadonlyArray<
+    TypeDefinitionNode extends ObjectTypeDefinitionNode ? ObjectTypeExtensionNode : InterfaceTypeExtensionNode
+  >,
+  fieldConfigMap: Record<string, GraphQLFieldConfig<any, any>>
+): TypeDefinitionNode {
+  if (astNode == null && !extensionASTNodes.length) {
+    return undefined;
+  }
+
+  let newAstNode: TypeDefinitionNode = {
+    ...astNode,
+    fields: undefined,
+  };
+
+  if (extensionASTNodes != null) {
+    extensionASTNodes.forEach(node => {
+      newAstNode = {
+        ...newAstNode,
+        ...node,
+        fields: undefined,
+      };
+    });
+  }
+
+  const fields: Array<FieldDefinitionNode> = [];
+  Object.values(fieldConfigMap).forEach(fieldConfig => {
+    if (fieldConfig.astNode != null) {
+      fields.push(fieldConfig.astNode);
+    }
+  });
+
+  return {
+    ...newAstNode,
+    fields,
+  };
 }

--- a/packages/wrap/src/transforms/TransformInputObjectFields.ts
+++ b/packages/wrap/src/transforms/TransformInputObjectFields.ts
@@ -10,6 +10,10 @@ import {
   GraphQLInputObjectType,
   ObjectValueNode,
   ObjectFieldNode,
+  InputObjectTypeDefinitionNode,
+  InputObjectTypeExtensionNode,
+  GraphQLInputFieldConfig,
+  InputValueDefinitionNode,
 } from 'graphql';
 
 import { Transform, Request, MapperKind, mapSchema } from '@graphql-tools/utils';
@@ -80,7 +84,6 @@ export default class TransformInputObjectFields implements Transform {
       } else if (Array.isArray(transformedField)) {
         const newFieldName = transformedField[0];
         const newFieldConfig = transformedField[1];
-        newInputFieldConfigMap[newFieldName] = newFieldConfig;
 
         if (newFieldName !== fieldName) {
           const typeName = type.name;
@@ -88,7 +91,19 @@ export default class TransformInputObjectFields implements Transform {
             this.mapping[typeName] = {};
           }
           this.mapping[typeName][newFieldName] = fieldName;
+
+          if (newFieldConfig.astNode != null) {
+            newFieldConfig.astNode = {
+              ...newFieldConfig.astNode,
+              name: {
+                ...newFieldConfig.astNode.name,
+                value: newFieldName,
+              },
+            };
+          }
         }
+
+        newInputFieldConfigMap[newFieldName] = newFieldConfig;
       } else if (transformedField != null) {
         newInputFieldConfigMap[fieldName] = transformedField;
       }
@@ -98,9 +113,12 @@ export default class TransformInputObjectFields implements Transform {
       return null;
     }
 
+    const oldConfig = type.toConfig();
     return new GraphQLInputObjectType({
-      ...type.toConfig(),
+      ...oldConfig,
       fields: newInputFieldConfigMap,
+      astNode: rebuildAstNode(oldConfig.astNode, oldConfig.extensionASTNodes, newInputFieldConfigMap),
+      extensionASTNodes: [],
     });
   }
 
@@ -192,4 +210,42 @@ export default class TransformInputObjectFields implements Transform {
     );
     return newDocument;
   }
+}
+
+function rebuildAstNode(
+  astNode: InputObjectTypeDefinitionNode,
+  extensionASTNodes: ReadonlyArray<InputObjectTypeExtensionNode>,
+  fieldConfigMap: Record<string, GraphQLInputFieldConfig>
+): InputObjectTypeDefinitionNode {
+  if (astNode == null && !extensionASTNodes.length) {
+    return undefined;
+  }
+
+  let newAstNode: InputObjectTypeDefinitionNode = {
+    ...astNode,
+    fields: undefined,
+  };
+
+  if (extensionASTNodes != null) {
+    extensionASTNodes.forEach(node => {
+      newAstNode = {
+        ...newAstNode,
+        ...node,
+        kind: newAstNode.kind,
+        fields: undefined,
+      };
+    });
+  }
+
+  const fields: Array<InputValueDefinitionNode> = [];
+  Object.values(fieldConfigMap).forEach(fieldConfig => {
+    if (fieldConfig.astNode != null) {
+      fields.push(fieldConfig.astNode);
+    }
+  });
+
+  return {
+    ...newAstNode,
+    fields,
+  };
 }

--- a/packages/wrap/src/transforms/TransformInputObjectFields.ts
+++ b/packages/wrap/src/transforms/TransformInputObjectFields.ts
@@ -217,7 +217,7 @@ function rebuildAstNode(
   extensionASTNodes: ReadonlyArray<InputObjectTypeExtensionNode>,
   fieldConfigMap: Record<string, GraphQLInputFieldConfig>
 ): InputObjectTypeDefinitionNode {
-  if (astNode == null && !extensionASTNodes.length) {
+  if (astNode == null && !extensionASTNodes?.length) {
     return undefined;
   }
 


### PR DESCRIPTION
Each transform should also modify the underlying astnode and extensionASTNodes, if they exist.

This PR also changes mapSchema to automatically update a type's astNode list of field definitions to match the actual field definitions includes within the type's new config map after mapping.

There is likely space for making sure to update additional astNodes within types to match the enclosed graphql type system objects, for example, enum types with the enclosed enum values. That may be included in a separate PR at this time.

Addresses #1747