### PR TITLE
allow selectionSet hints for stitching to be functions

### DIFF
--- a/packages/delegate/src/delegationBindings.ts
+++ b/packages/delegate/src/delegationBindings.ts
@@ -40,9 +40,10 @@ export function defaultDelegationBinding(delegationContext: DelegationContext): 
     delegationTransforms = delegationTransforms.concat([
       new AddSelectionSets(
         info.schema,
+        returnType,
         stitchingInfo.selectionSetsByType,
         stitchingInfo.selectionSetsByField,
-        returnType
+        stitchingInfo.dynamicSelectionSetsByField
       ),
       new WrapConcreteTypes(returnType, transformedSchema),
       new ExpandAbstractTypes(info.schema, transformedSchema),

--- a/packages/delegate/src/transforms/AddSelectionSets.ts
+++ b/packages/delegate/src/transforms/AddSelectionSets.ts
@@ -1,4 +1,4 @@
-import { GraphQLSchema, SelectionSetNode, TypeInfo, GraphQLOutputType, Kind } from 'graphql';
+import { GraphQLSchema, SelectionSetNode, TypeInfo, GraphQLOutputType, Kind, FieldNode } from 'graphql';
 
 import { Transform, Request } from '@graphql-tools/utils';
 import VisitSelectionSets from './VisitSelectionSets';
@@ -8,12 +8,13 @@ export default class AddSelectionSetsByField implements Transform {
 
   constructor(
     sourceSchema: GraphQLSchema,
+    initialType: GraphQLOutputType,
     selectionSetsByType: Record<string, SelectionSetNode>,
     selectionSetsByField: Record<string, Record<string, SelectionSetNode>>,
-    initialType: GraphQLOutputType
+    dynamicSelectionSetsByField: Record<string, Record<string, Array<(node: FieldNode) => SelectionSetNode>>>
   ) {
     this.transformer = new VisitSelectionSets(sourceSchema, initialType, (node, typeInfo) =>
-      visitSelectionSet(node, typeInfo, selectionSetsByType, selectionSetsByField)
+      visitSelectionSet(node, typeInfo, selectionSetsByType, selectionSetsByField, dynamicSelectionSetsByField)
     );
   }
 
@@ -26,7 +27,8 @@ function visitSelectionSet(
   node: SelectionSetNode,
   typeInfo: TypeInfo,
   selectionSetsByType: Record<string, SelectionSetNode>,
-  selectionSetsByField: Record<string, Record<string, SelectionSetNode>>
+  selectionSetsByField: Record<string, Record<string, SelectionSetNode>>,
+  dynamicSelectionSetsByField: Record<string, Record<string, Array<(node: FieldNode) => SelectionSetNode>>>
 ): SelectionSetNode {
   const parentType = typeInfo.getParentType();
   if (parentType != null) {
@@ -47,6 +49,23 @@ function visitSelectionSet(
           const selectionSet = selectionSetsByField[parentTypeName][name];
           if (selectionSet != null) {
             selections = selections.concat(selectionSet.selections);
+          }
+        }
+      });
+    }
+
+    if (parentTypeName in dynamicSelectionSetsByField) {
+      node.selections.forEach(selection => {
+        if (selection.kind === Kind.FIELD) {
+          const name = selection.name.value;
+          const dynamicSelectionSets = dynamicSelectionSetsByField[parentTypeName][name];
+          if (dynamicSelectionSets != null) {
+            dynamicSelectionSets.forEach(selectionSetFn => {
+              const selectionSet = selectionSetFn(selection);
+              if (selectionSet != null) {
+                selections = selections.concat(selectionSet.selections);
+              }
+            });
           }
         }
       });

--- a/packages/delegate/src/types.ts
+++ b/packages/delegate/src/types.ts
@@ -151,7 +151,8 @@ export type MergedTypeResolver = (
 export interface StitchingInfo {
   transformedSchemas: Map<GraphQLSchema | SubschemaConfig, GraphQLSchema>;
   fragmentsByField: Record<string, Record<string, InlineFragmentNode>>;
-  selectionSetsByField: Record<string, Record<string, SelectionSetNode>>;
   selectionSetsByType: Record<string, SelectionSetNode>;
+  selectionSetsByField: Record<string, Record<string, SelectionSetNode>>;
+  dynamicSelectionSetsByField: Record<string, Record<string, Array<(node: FieldNode) => SelectionSetNode>>>;
   mergedTypes: Record<string, MergedTypeInfo>;
 }

--- a/packages/stitch/src/types.ts
+++ b/packages/stitch/src/types.ts
@@ -5,6 +5,7 @@ import {
   DocumentNode,
   SelectionNode,
   InlineFragmentNode,
+  FieldNode,
 } from 'graphql';
 import { ITypeDefinitions, TypeMap } from '@graphql-tools/utils';
 import { SubschemaConfig } from '@graphql-tools/delegate';
@@ -32,8 +33,9 @@ export interface MergedTypeInfo {
 export interface StitchingInfo {
   transformedSchemas: Map<GraphQLSchema | SubschemaConfig, GraphQLSchema>;
   fragmentsByField: Record<string, Record<string, InlineFragmentNode>>;
-  selectionSetsByField: Record<string, Record<string, SelectionSetNode>>;
   selectionSetsByType: Record<string, SelectionSetNode>;
+  selectionSetsByField: Record<string, Record<string, SelectionSetNode>>;
+  dynamicSelectionSetsByField: Record<string, Record<string, Array<(node: FieldNode) => SelectionSetNode>>>;
   mergedTypes: Record<string, MergedTypeInfo>;
 }
 
@@ -65,6 +67,6 @@ export type OnTypeConflict = (
 declare module '@graphql-tools/utils' {
   interface IFieldResolverOptions<TSource = any, TContext = any, TArgs = any> {
     fragment?: string;
-    selectionSet?: string;
+    selectionSet?: string | ((node: FieldNode) => SelectionSetNode);
   }
 }


### PR DESCRIPTION
that take the specified gateway field as a parameter and produce a required selection set, allowing passing of arguments from the gateway field to the required target schema field.

See #1709