### PR TITLE
refactor to rely on mapSchema

### DIFF
--- a/packages/utils/src/fields.ts
+++ b/packages/utils/src/fields.ts
@@ -1,14 +1,6 @@
-import {
-  GraphQLFieldConfigMap,
-  GraphQLObjectType,
-  GraphQLFieldConfig,
-  GraphQLSchema,
-  ObjectTypeDefinitionNode,
-  ObjectTypeExtensionNode,
-  FieldDefinitionNode,
-} from 'graphql';
+import { GraphQLFieldConfigMap, GraphQLObjectType, GraphQLFieldConfig, GraphQLSchema } from 'graphql';
 import { MapperKind } from './Interfaces';
-import { mapSchema } from './mapSchema';
+import { mapSchema, rebuildAstNode, rebuildExtensionAstNodes } from './mapSchema';
 import { addTypes } from './addTypes';
 
 export function appendObjectFields(
@@ -151,43 +143,4 @@ export function modifyObjectFields(
   });
 
   return [newSchema, removedFields];
-}
-
-function rebuildAstNode(
-  astNode: ObjectTypeDefinitionNode,
-  fieldConfigMap: Record<string, GraphQLFieldConfig<any, any>>
-): ObjectTypeDefinitionNode {
-  if (astNode == null) {
-    return undefined;
-  }
-
-  const newAstNode: ObjectTypeDefinitionNode = {
-    ...astNode,
-    fields: undefined,
-  };
-
-  const fields: Array<FieldDefinitionNode> = [];
-  Object.values(fieldConfigMap).forEach(fieldConfig => {
-    if (fieldConfig.astNode != null) {
-      fields.push(fieldConfig.astNode);
-    }
-  });
-
-  return {
-    ...newAstNode,
-    fields,
-  };
-}
-
-function rebuildExtensionAstNodes(
-  extensionASTNodes: ReadonlyArray<ObjectTypeExtensionNode>
-): Array<ObjectTypeExtensionNode> {
-  if (!extensionASTNodes?.length) {
-    return [];
-  }
-
-  return extensionASTNodes.map(node => ({
-    ...node,
-    fields: undefined,
-  }));
 }

--- a/packages/utils/src/mapSchema.ts
+++ b/packages/utils/src/mapSchema.ts
@@ -497,7 +497,7 @@ function getEnumValueMapper(schemaMapper: SchemaMapper): EnumValueMapper | null 
   return enumValueMapper != null ? enumValueMapper : null;
 }
 
-function rebuildAstNode<
+export function rebuildAstNode<
   TypeDefinitionNode extends ObjectTypeDefinitionNode | InterfaceTypeDefinitionNode | InputObjectTypeDefinitionNode
 >(
   astNode: TypeDefinitionNode,
@@ -530,7 +530,7 @@ function rebuildAstNode<
   };
 }
 
-function rebuildExtensionAstNodes<
+export function rebuildExtensionAstNodes<
   TypeExtensionNode extends ObjectTypeExtensionNode | InterfaceTypeExtensionNode | InputObjectTypeExtensionNode
 >(extensionASTNodes: ReadonlyArray<TypeExtensionNode>): Array<TypeExtensionNode> {
   if (!extensionASTNodes?.length) {

--- a/packages/wrap/src/transforms/TransformInputObjectFields.ts
+++ b/packages/wrap/src/transforms/TransformInputObjectFields.ts
@@ -10,10 +10,6 @@ import {
   GraphQLInputObjectType,
   ObjectValueNode,
   ObjectFieldNode,
-  InputObjectTypeDefinitionNode,
-  InputObjectTypeExtensionNode,
-  GraphQLInputFieldConfig,
-  InputValueDefinitionNode,
 } from 'graphql';
 
 import { Transform, Request, MapperKind, mapSchema } from '@graphql-tools/utils';
@@ -40,8 +36,20 @@ export default class TransformInputObjectFields implements Transform {
 
   public transformSchema(originalSchema: GraphQLSchema): GraphQLSchema {
     this.transformedSchema = mapSchema(originalSchema, {
-      [MapperKind.INPUT_OBJECT_TYPE]: (type: GraphQLInputObjectType) =>
-        this.transformFields(type, this.inputFieldTransformer),
+      [MapperKind.INPUT_OBJECT_FIELD]: (inputFieldConfig, fieldName, typeName) => {
+        const transformedInputField = this.inputFieldTransformer(typeName, fieldName, inputFieldConfig);
+        if (Array.isArray(transformedInputField)) {
+          const newFieldName = transformedInputField[0];
+
+          if (newFieldName !== fieldName) {
+            if (!(typeName in this.mapping)) {
+              this.mapping[typeName] = {};
+            }
+            this.mapping[typeName][newFieldName] = fieldName;
+          }
+        }
+        return transformedInputField;
+      },
     });
 
     return this.transformedSchema;
@@ -67,59 +75,6 @@ export default class TransformInputObjectFields implements Transform {
       ...originalRequest,
       document,
     };
-  }
-
-  private transformFields(type: GraphQLInputObjectType, inputFieldTransformer: InputFieldTransformer): any {
-    const config = type.toConfig();
-
-    const originalInputFieldConfigMap = config.fields;
-    const newInputFieldConfigMap = {};
-
-    Object.keys(originalInputFieldConfigMap).forEach(fieldName => {
-      const originalInputFieldConfig = originalInputFieldConfigMap[fieldName];
-      const transformedField = inputFieldTransformer(type.name, fieldName, originalInputFieldConfig);
-
-      if (transformedField === undefined) {
-        newInputFieldConfigMap[fieldName] = originalInputFieldConfig;
-      } else if (Array.isArray(transformedField)) {
-        const newFieldName = transformedField[0];
-        const newFieldConfig = transformedField[1];
-
-        if (newFieldName !== fieldName) {
-          const typeName = type.name;
-          if (!(typeName in this.mapping)) {
-            this.mapping[typeName] = {};
-          }
-          this.mapping[typeName][newFieldName] = fieldName;
-
-          if (newFieldConfig.astNode != null) {
-            newFieldConfig.astNode = {
-              ...newFieldConfig.astNode,
-              name: {
-                ...newFieldConfig.astNode.name,
-                value: newFieldName,
-              },
-            };
-          }
-        }
-
-        newInputFieldConfigMap[newFieldName] = newFieldConfig;
-      } else if (transformedField != null) {
-        newInputFieldConfigMap[fieldName] = transformedField;
-      }
-    });
-
-    if (!Object.keys(newInputFieldConfigMap).length) {
-      return null;
-    }
-
-    const oldConfig = type.toConfig();
-    return new GraphQLInputObjectType({
-      ...oldConfig,
-      fields: newInputFieldConfigMap,
-      astNode: rebuildAstNode(oldConfig.astNode, newInputFieldConfigMap),
-      extensionASTNodes: rebuildExtensionAstNodes(oldConfig.extensionASTNodes),
-    });
   }
 
   private transformDocument(
@@ -210,43 +165,4 @@ export default class TransformInputObjectFields implements Transform {
     );
     return newDocument;
   }
-}
-
-function rebuildAstNode(
-  astNode: InputObjectTypeDefinitionNode,
-  inputFieldConfigMap: Record<string, GraphQLInputFieldConfig>
-): InputObjectTypeDefinitionNode {
-  if (astNode == null) {
-    return undefined;
-  }
-
-  const newAstNode: InputObjectTypeDefinitionNode = {
-    ...astNode,
-    fields: undefined,
-  };
-
-  const fields: Array<InputValueDefinitionNode> = [];
-  Object.values(inputFieldConfigMap).forEach(inputFieldConfig => {
-    if (inputFieldConfig.astNode != null) {
-      fields.push(inputFieldConfig.astNode);
-    }
-  });
-
-  return {
-    ...newAstNode,
-    fields,
-  };
-}
-
-function rebuildExtensionAstNodes(
-  extensionASTNodes: ReadonlyArray<InputObjectTypeExtensionNode>
-): Array<InputObjectTypeExtensionNode> {
-  if (!extensionASTNodes?.length) {
-    return [];
-  }
-
-  return extensionASTNodes.map(node => ({
-    ...node,
-    fields: undefined,
-  }));
 }


### PR DESCRIPTION
= TransformCompositeFields and TransformInputObjectFields can use mapSchema via MapperKind.COMPOSITE_FIELD and MapperKind.INPUT_OBJECT_FIELD.

= field utility functions can use rebuildAstNode and rebuildExtensionAstNodes from mapSchema