### PR TITLE
refactor out renameTypes function

### DIFF
--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -38,6 +38,7 @@ export * from './selectionSets';
 export * from './getResponseKeyFromInfo';
 export * from './transforms';
 export * from './fields';
+export * from './renameType';
 export * from './collectFields';
 export * from './transformInputValue';
 export * from './mapAsyncIterator';

--- a/packages/utils/src/renameType.ts
+++ b/packages/utils/src/renameType.ts
@@ -1,0 +1,178 @@
+import {
+  GraphQLEnumType,
+  GraphQLInputObjectType,
+  GraphQLInterfaceType,
+  GraphQLObjectType,
+  GraphQLNamedType,
+  GraphQLScalarType,
+  GraphQLUnionType,
+  isEnumType,
+  isInterfaceType,
+  isInputObjectType,
+  isObjectType,
+  isScalarType,
+  isUnionType,
+} from 'graphql';
+
+export function renameType(type: GraphQLObjectType, newTypeName: string): GraphQLObjectType;
+export function renameType(type: GraphQLInterfaceType, newTypeName: string): GraphQLInterfaceType;
+export function renameType(type: GraphQLUnionType, newTypeName: string): GraphQLUnionType;
+export function renameType(type: GraphQLEnumType, newTypeName: string): GraphQLEnumType;
+export function renameType(type: GraphQLScalarType, newTypeName: string): GraphQLScalarType;
+export function renameType(type: GraphQLInputObjectType, newTypeName: string): GraphQLInputObjectType;
+export function renameType(type: GraphQLNamedType, newTypeName: string): GraphQLNamedType;
+export function renameType(type: any, newTypeName: string): GraphQLNamedType {
+  if (isObjectType(type)) {
+    return new GraphQLObjectType({
+      ...type.toConfig(),
+      name: newTypeName,
+      astNode:
+        type.astNode == null
+          ? type.astNode
+          : {
+              ...type.astNode,
+              name: {
+                ...type.astNode.name,
+                value: newTypeName,
+              },
+            },
+      extensionASTNodes:
+        type.extensionASTNodes == null
+          ? type.extensionASTNodes
+          : type.extensionASTNodes.map(node => ({
+              ...node,
+              name: {
+                ...node.name,
+                value: newTypeName,
+              },
+            })),
+    });
+  } else if (isInterfaceType(type)) {
+    return new GraphQLInterfaceType({
+      ...type.toConfig(),
+      name: newTypeName,
+      astNode:
+        type.astNode == null
+          ? type.astNode
+          : {
+              ...type.astNode,
+              name: {
+                ...type.astNode.name,
+                value: newTypeName,
+              },
+            },
+      extensionASTNodes:
+        type.extensionASTNodes == null
+          ? type.extensionASTNodes
+          : type.extensionASTNodes.map(node => ({
+              ...node,
+              name: {
+                ...node.name,
+                value: newTypeName,
+              },
+            })),
+    });
+  } else if (isUnionType(type)) {
+    return new GraphQLUnionType({
+      ...type.toConfig(),
+      name: newTypeName,
+      astNode:
+        type.astNode == null
+          ? type.astNode
+          : {
+              ...type.astNode,
+              name: {
+                ...type.astNode.name,
+                value: newTypeName,
+              },
+            },
+      extensionASTNodes:
+        type.extensionASTNodes == null
+          ? type.extensionASTNodes
+          : type.extensionASTNodes.map(node => ({
+              ...node,
+              name: {
+                ...node.name,
+                value: newTypeName,
+              },
+            })),
+    });
+  } else if (isInputObjectType(type)) {
+    return new GraphQLInputObjectType({
+      ...type.toConfig(),
+      name: newTypeName,
+      astNode:
+        type.astNode == null
+          ? type.astNode
+          : {
+              ...type.astNode,
+              name: {
+                ...type.astNode.name,
+                value: newTypeName,
+              },
+            },
+      extensionASTNodes:
+        type.extensionASTNodes == null
+          ? type.extensionASTNodes
+          : type.extensionASTNodes.map(node => ({
+              ...node,
+              name: {
+                ...node.name,
+                value: newTypeName,
+              },
+            })),
+    });
+  } else if (isEnumType(type)) {
+    return new GraphQLEnumType({
+      ...type.toConfig(),
+      name: newTypeName,
+      astNode:
+        type.astNode == null
+          ? type.astNode
+          : {
+              ...type.astNode,
+              name: {
+                ...type.astNode.name,
+                value: newTypeName,
+              },
+            },
+      extensionASTNodes:
+        type.extensionASTNodes == null
+          ? type.extensionASTNodes
+          : type.extensionASTNodes.map(node => ({
+              ...node,
+              name: {
+                ...node.name,
+                value: newTypeName,
+              },
+            })),
+    });
+  } else if (isScalarType(type)) {
+    return new GraphQLScalarType({
+      ...type.toConfig(),
+      name: newTypeName,
+      astNode:
+        type.astNode == null
+          ? type.astNode
+          : {
+              ...type.astNode,
+              name: {
+                ...type.astNode.name,
+                value: newTypeName,
+              },
+            },
+      extensionASTNodes:
+        type.extensionASTNodes == null
+          ? type.extensionASTNodes
+          : type.extensionASTNodes.map(node => ({
+              ...node,
+              name: {
+                ...node.name,
+                value: newTypeName,
+              },
+            })),
+    });
+  }
+
+  throw new Error(`Unknown type ${type as string}.`);
+}

--- a/packages/wrap/src/transforms/RenameRootTypes.ts
+++ b/packages/wrap/src/transforms/RenameRootTypes.ts
@@ -1,6 +1,14 @@
-import { visit, GraphQLSchema, NamedTypeNode, Kind, GraphQLObjectType } from 'graphql';
+import { visit, GraphQLSchema, NamedTypeNode, Kind } from 'graphql';
 
-import { Request, ExecutionResult, MapperKind, Transform, mapSchema } from '@graphql-tools/utils';
+import {
+  Request,
+  ExecutionResult,
+  MapperKind,
+  Transform,
+  mapSchema,
+  renameType,
+  visitData,
+} from '@graphql-tools/utils';
 
 export default class RenameRootTypes implements Transform {
   private readonly renamer: (name: string) => string | undefined;
@@ -21,10 +29,8 @@ export default class RenameRootTypes implements Transform {
         if (newName !== undefined && newName !== oldName) {
           this.map[oldName] = newName;
           this.reverseMap[newName] = oldName;
-          return new GraphQLObjectType({
-            ...type.toConfig(),
-            name: newName,
-          });
+
+          return renameType(type, newName);
         }
       },
     });
@@ -54,34 +60,13 @@ export default class RenameRootTypes implements Transform {
   public transformResult(result: ExecutionResult): ExecutionResult {
     return {
       ...result,
-      data: this.transformData(result.data),
-    };
-  }
-
-  private transformData(data: any): any {
-    if (data == null) {
-      return data;
-    } else if (Array.isArray(data)) {
-      return data.map(value => this.transformData(value));
-    } else if (typeof data === 'object') {
-      return this.transformObject(data);
-    }
-
-    return data;
-  }
-
-  private transformObject(object: Record<string, any>): Record<string, any> {
-    Object.keys(object).forEach(key => {
-      const value = object[key];
-      if (key === '__typename') {
-        if (value in this.map) {
-          object[key] = this.map[value];
+      data: visitData(result.data, object => {
+        const typeName = object?.__typename;
+        if (typeName != null && typeName in this.map) {
+          object.__typename = this.map[typeName];
         }
-      } else {
-        object[key] = this.transformData(value);
-      }
-    });
-
-    return object;
+        return object;
+      }),
+    };
   }
 }

--- a/packages/wrap/src/transforms/RenameTypes.ts
+++ b/packages/wrap/src/transforms/RenameTypes.ts
@@ -1,21 +1,10 @@
 import {
-  GraphQLEnumType,
-  GraphQLInputObjectType,
-  GraphQLInterfaceType,
   GraphQLNamedType,
-  GraphQLObjectType,
   GraphQLSchema,
-  GraphQLScalarType,
-  GraphQLUnionType,
   Kind,
   NamedTypeNode,
-  isEnumType,
-  isInputObjectType,
-  isInterfaceType,
-  isObjectType,
   isScalarType,
   isSpecifiedScalarType,
-  isUnionType,
   visit,
 } from 'graphql';
 
@@ -27,6 +16,7 @@ import {
   RenameTypesOptions,
   mapSchema,
   visitData,
+  renameType,
 } from '@graphql-tools/utils';
 
 export default class RenameTypes implements Transform {
@@ -60,159 +50,7 @@ export default class RenameTypes implements Transform {
           this.map[oldName] = newName;
           this.reverseMap[newName] = oldName;
 
-          if (isObjectType(type)) {
-            return new GraphQLObjectType({
-              ...type.toConfig(),
-              name: newName,
-              astNode:
-                type.astNode == null
-                  ? type.astNode
-                  : {
-                      ...type.astNode,
-                      name: {
-                        ...type.astNode.name,
-                        value: newName,
-                      },
-                    },
-              extensionASTNodes:
-                type.extensionASTNodes == null
-                  ? type.extensionASTNodes
-                  : type.extensionASTNodes.map(node => ({
-                      ...node,
-                      name: {
-                        ...node.name,
-                        value: newName,
-                      },
-                    })),
-            });
-          } else if (isInterfaceType(type)) {
-            return new GraphQLInterfaceType({
-              ...type.toConfig(),
-              name: newName,
-              astNode:
-                type.astNode == null
-                  ? type.astNode
-                  : {
-                      ...type.astNode,
-                      name: {
-                        ...type.astNode.name,
-                        value: newName,
-                      },
-                    },
-              extensionASTNodes:
-                type.extensionASTNodes == null
-                  ? type.extensionASTNodes
-                  : type.extensionASTNodes.map(node => ({
-                      ...node,
-                      name: {
-                        ...node.name,
-                        value: newName,
-                      },
-                    })),
-            });
-          } else if (isUnionType(type)) {
-            return new GraphQLUnionType({
-              ...type.toConfig(),
-              name: newName,
-              astNode:
-                type.astNode == null
-                  ? type.astNode
-                  : {
-                      ...type.astNode,
-                      name: {
-                        ...type.astNode.name,
-                        value: newName,
-                      },
-                    },
-              extensionASTNodes:
-                type.extensionASTNodes == null
-                  ? type.extensionASTNodes
-                  : type.extensionASTNodes.map(node => ({
-                      ...node,
-                      name: {
-                        ...node.name,
-                        value: newName,
-                      },
-                    })),
-            });
-          } else if (isInputObjectType(type)) {
-            return new GraphQLInputObjectType({
-              ...type.toConfig(),
-              name: newName,
-              astNode:
-                type.astNode == null
-                  ? type.astNode
-                  : {
-                      ...type.astNode,
-                      name: {
-                        ...type.astNode.name,
-                        value: newName,
-                      },
-                    },
-              extensionASTNodes:
-                type.extensionASTNodes == null
-                  ? type.extensionASTNodes
-                  : type.extensionASTNodes.map(node => ({
-                      ...node,
-                      name: {
-                        ...node.name,
-                        value: newName,
-                      },
-                    })),
-            });
-          } else if (isEnumType(type)) {
-            return new GraphQLEnumType({
-              ...type.toConfig(),
-              name: newName,
-              astNode:
-                type.astNode == null
-                  ? type.astNode
-                  : {
-                      ...type.astNode,
-                      name: {
-                        ...type.astNode.name,
-                        value: newName,
-                      },
-                    },
-              extensionASTNodes:
-                type.extensionASTNodes == null
-                  ? type.extensionASTNodes
-                  : type.extensionASTNodes.map(node => ({
-                      ...node,
-                      name: {
-                        ...node.name,
-                        value: newName,
-                      },
-                    })),
-            });
-          } else if (isScalarType(type)) {
-            return new GraphQLScalarType({
-              ...type.toConfig(),
-              name: newName,
-              astNode:
-                type.astNode == null
-                  ? type.astNode
-                  : {
-                      ...type.astNode,
-                      name: {
-                        ...type.astNode.name,
-                        value: newName,
-                      },
-                    },
-              extensionASTNodes:
-                type.extensionASTNodes == null
-                  ? type.extensionASTNodes
-                  : type.extensionASTNodes.map(node => ({
-                      ...node,
-                      name: {
-                        ...node.name,
-                        value: newName,
-                      },
-                    })),
-            });
-          }
-
-          throw new Error(`Unknown type ${type as string}.`);
+          return renameType(type, newName);
         }
       },
 


### PR DESCRIPTION
from RenameTypes transform

= to remove duplicative functionality from RenameRootTypes

= also switch RenameRootTypes to use visitData just like RenameTypes