### PR TITLE
Fix processImport and toBeSimilarGqlDoc matcher

### DIFF
--- a/packages/import/tests/documents/import-documents.spec.ts
+++ b/packages/import/tests/documents/import-documents.spec.ts
@@ -1,8 +1,7 @@
 import '../../../testing/to-be-similar-gql-doc';
 import { processImport } from '../../src';
-import { print } from 'graphql';
 
-const importDocuments = (documentPath: string) => print(processImport(documentPath, __dirname));
+const importDocuments = (documentPath: string) => processImport(documentPath, __dirname);
 
 describe('import in documents', () => {
       it('should get documents with default imports properly', async () => {

--- a/packages/import/tests/schema/import-schema.spec.ts
+++ b/packages/import/tests/schema/import-schema.spec.ts
@@ -2,14 +2,14 @@ import * as fs from 'fs';
 import '../../../testing/to-be-similar-gql-doc';
 import { parseImportLine, processImport } from '../../src';
 import { mergeTypeDefs } from '@graphql-tools/merge';
-import { Kind, print } from 'graphql';
+import { Kind } from 'graphql';
 
 const importSchema = (schema: string, schemas?: Record<string, string>) => {
   const document = processImport(schema, __dirname, schemas);
-  return print(mergeTypeDefs(document.definitions.map(definition => ({ kind: Kind.DOCUMENT, definitions: [definition] })), {
+  return mergeTypeDefs(document.definitions.map(definition => ({ kind: Kind.DOCUMENT, definitions: [definition] })), {
     sort: true,
     useSchemaDefinition: false,
-  }))
+  })
 };
 
 const parseSDL = (content: string) => content.split('\n').map(str => str.trim()).filter(str => str.startsWith('# import ') || str.startsWith('#import ')).map(str => parseImportLine(str.replace('#', '').trim()));

--- a/packages/load/tests/loaders/schema/integration.spec.ts
+++ b/packages/load/tests/loaders/schema/integration.spec.ts
@@ -1,7 +1,7 @@
 import { loadSchema, loadSchemaSync } from '@graphql-tools/load';
 import { CodeFileLoader } from '@graphql-tools/code-file-loader';
 import { GraphQLFileLoader } from '@graphql-tools/graphql-file-loader';
-import { printSchema } from 'graphql';
+import { printSchema, parse } from 'graphql';
 import { runTests, useMonorepo } from '../../../../testing/utils';
 import '../../../../testing/to-be-similar-gql-doc';
 
@@ -50,9 +50,9 @@ describe('loadSchema', () => {
       const schema = await load('../import/tests/schema/fixtures/multiple-root/*/schema.graphql', {
         loaders: [new GraphQLFileLoader()]
       });
-      const schemaStr = printSchema(schema);
+      const schemaDocument = parse(printSchema(schema));
 
-      expect(schemaStr).toBeSimilarGqlDoc(/* GraphQL */`
+      expect(schemaDocument).toBeSimilarGqlDoc(/* GraphQL */`
         type Query {
           a: A
           b: B

--- a/packages/relay-operation-optimizer/tests/relay-optimizer.spec.ts
+++ b/packages/relay-operation-optimizer/tests/relay-optimizer.spec.ts
@@ -1,4 +1,4 @@
-import { buildSchema, parse, print } from 'graphql';
+import { buildSchema, parse } from 'graphql';
 import { optimizeDocuments } from '@graphql-tools/relay-operation-optimizer';
 import '../../testing/to-be-similar-gql-doc';
 
@@ -68,7 +68,7 @@ it('can inline @argumentDefinitions/@arguments annotated fragments', async () =>
     const queryDoc = output.find(doc => doc.definitions[0].kind === 'OperationDefinition');
 
     expect(queryDoc).toBeDefined();
-    expect(print(queryDoc)).toBeSimilarGqlDoc(/* GraphQL */ `
+    expect(queryDoc).toBeSimilarGqlDoc(/* GraphQL */ `
     query user {
       users {
         id
@@ -127,7 +127,7 @@ it('handles unions with interfaces the correct way', async () => {
     const queryDoc = output.find(doc => doc.definitions[0].kind === 'OperationDefinition');
 
     expect(queryDoc).toBeDefined();
-    expect(print(queryDoc)).toBeSimilarGqlDoc(/* GraphQL */ `
+    expect(queryDoc).toBeSimilarGqlDoc(/* GraphQL */ `
     query user {
       user {
         ... on User {


### PR DESCRIPTION
This modifies the `toBeSimilarGqlDoc` matcher so that it compares actual `DocumentNode` objects instead of relying on a string comparison, which masks problems like duplicate definitions being generated.