### PR TITLE
Add link to full API for loadDocuments

### DIFF
--- a/website/docs/documents-loading.md
+++ b/website/docs/documents-loading.md
@@ -40,7 +40,7 @@ const document4 = loadDocuments('./src/my-component.ts', {  // load from code fi
 
 ```
 
-`loadDocuments` return an array of document sources and these source objects have the following structure;
+`loadDocuments` returns an array of document sources. Each source object has the following structure:
 ```ts
 interface DocumentSource {
   document: DocumentNode; // Object representation of GraphQL Content
@@ -48,5 +48,7 @@ interface DocumentSource {
   location: string; // Way to access to that source
 }
 ```
+
+`loadDocuments` takes in additional configuration via the `options` object (the second argument). There are some defaults to be aware of - to learn more, see [the full API documentation](/docs/api/modules/load/#loaddocuments).
 
 > You can learn more about [loaders](/docs/loaders) to load documents from different sources.


### PR DESCRIPTION
Spent a few hours debugging why `loadDocuments` wasn't working as expected - there's a default of filtering NON_OPERATION_KINDS in the options that I missed :(

I had only read this page - telling the user "hey watch out, there's some defaults to be aware of!" and linking to them would be great.

Thanks! :)

Thanks!

<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
