### PR TITLE
Fix GraphQLFileLoader #import syntax handling

### DIFF
--- a/packages/loaders/graphql-file/tests/loader.spec.ts
+++ b/packages/loaders/graphql-file/tests/loader.spec.ts
@@ -1,9 +1,11 @@
 import { join } from 'path';
 
+import { print } from 'graphql'
 import { Source } from '@graphql-tools/utils';
 
 import { GraphQLFileLoader } from '../src';
 import { runTests } from '../../../testing/utils';
+import '../../../testing/to-be-similar-gql-doc'
 
 describe('GraphQLFileLoader', () => {
   const loader = new GraphQLFileLoader();
@@ -59,9 +61,32 @@ describe('GraphQLFileLoader', () => {
         expect(result.document).toBeDefined();
       });
 
-      it('should load file with #import expression', async () => {
+      it('should load type definitions document with #import expression', async () => {
         const result: Source = await load(getPointer('type-defs-with-import.graphql'), {});
-        expect(result.document?.definitions.length).toBe(2);
+        expect(print(result.document!)).toBeSimilarGqlDoc(/* GraphQL */`
+          type Query {
+            a: A
+          }
+
+          type A {
+            b: String
+          }
+        `)
+      });
+
+      it('should load executable document with #import expression', async () => {
+        const result: Source = await load(getPointer('executable.graphql'), {});
+        expect(print(result.document!)).toBeSimilarGqlDoc(/* GraphQL */`
+          query MyQuery {
+            a {
+              ...AFragment
+            }
+          }
+
+          fragment AFragment on A {
+            b
+          }
+        `)
       });
     });
   });

--- a/packages/loaders/graphql-file/tests/test-files/executable.graphql
+++ b/packages/loaders/graphql-file/tests/test-files/executable.graphql
@@ -1,0 +1,7 @@
+#import AFragment from "./fragment.graphql"
+
+query MyQuery {
+  a {
+    ...AFragment
+  }
+}

--- a/packages/loaders/graphql-file/tests/test-files/fragment.graphql
+++ b/packages/loaders/graphql-file/tests/test-files/fragment.graphql
@@ -1,0 +1,3 @@
+fragment AFragment on A {
+  b
+}

--- a/packages/loaders/graphql-file/tests/test-files/import-me.graphql
+++ b/packages/loaders/graphql-file/tests/test-files/import-me.graphql
@@ -1,3 +1,3 @@
-type Mutation {
-  sayGoodbye: String
+type A {
+  b: String
 }

--- a/packages/loaders/graphql-file/tests/test-files/type-defs-with-import.graphql
+++ b/packages/loaders/graphql-file/tests/test-files/type-defs-with-import.graphql
@@ -1,5 +1,5 @@
-#import Mutation from "./import-me.graphql"
+#import A from "./import-me.graphql"
 
 type Query {
-  hello: String
+  a: A
 }


### PR DESCRIPTION
Temporary fix for `GraphQLFileLoader` until we can revisit how `processImport` works