### PR TITLE
fix(createRequest): selectionSet overrides fieldNodes

### DIFF
--- a/packages/delegate/src/createRequest.ts
+++ b/packages/delegate/src/createRequest.ts
@@ -66,10 +66,11 @@ export function createRequest({
   selectionSet,
   fieldNodes,
 }: ICreateRequest): Request {
-  let newSelectionSet: SelectionSetNode = selectionSet;
+  let newSelectionSet: SelectionSetNode;
   let argumentNodeMap: Record<string, ArgumentNode>;
 
-  if (fieldNodes == null) {
+  if (selectionSet != null) {
+    newSelectionSet = selectionSet;
     argumentNodeMap = Object.create(null);
   } else {
     const selections: Array<SelectionNode> = fieldNodes.reduce(


### PR DESCRIPTION
selectionSet option is used with bare execution, where fieldNodes is not present, without issue.

with type merging, info.fieldNodes and fieldNodes may be specified, but selectionSet should override, as there may be situation when both appear but selectionSet desired, unlikely for them both to appear but fieldNodes to be desired, as fieldNodes is auto generated, and selectionSet is more likely to be created manually.

<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
