### PR TITLE
feat(batch-delegate): added mapping function to createBatchDelegateFn

### DIFF
--- a/packages/batch-delegate/src/createBatchDelegateFn.ts
+++ b/packages/batch-delegate/src/createBatchDelegateFn.ts
@@ -9,6 +9,7 @@ import { BatchDelegateOptionsFn, BatchDelegateFn, BatchDelegateOptions } from '.
 export function createBatchDelegateFn<K = any, V = any, C = K>(
   argFn: (args: ReadonlyArray<K>) => Record<string, any>,
   batchDelegateOptionsFn: BatchDelegateOptionsFn,
+  mappingFn?: (keys: ReadonlyArray<K>, results: any) => V[],
   dataLoaderOptions?: DataLoader.Options<K, V, C>
 ): BatchDelegateFn<K> {
   let cache: WeakMap<ReadonlyArray<FieldNode>, DataLoader<K, V, C>>;
@@ -20,7 +21,7 @@ export function createBatchDelegateFn<K = any, V = any, C = K>(
         args: argFn(keys),
         ...batchDelegateOptionsFn(options),
       });
-      return Array.isArray(results) ? results : keys.map(() => results);
+      return mappingFn ? mappingFn(keys, results) : results;
     };
   }
 

--- a/packages/batch-delegate/src/createBatchDelegateFn.ts
+++ b/packages/batch-delegate/src/createBatchDelegateFn.ts
@@ -22,7 +22,7 @@ export function createBatchDelegateFn<K = any, V = any, C = K>(
         ...batchDelegateOptionsFn(options),
       });
       results = resultsFn ? resultsFn(results, keys) : results;
-      return Array.isArray(results) ? results : keys.map(() => results)
+      return Array.isArray(results) ? results : keys.map(() => results);
     };
   }
 


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

I love the recent addition of the batch-delegate package! The only thing that prevents me from using it is the inability to edit the server's response before returning the results to the dataloader. I believe there is a general need for this feature (e.g. what if the array of entities is not in order, or what if the we want to group entities together by key for a one-to-many relation?), so I wrote a quick PR to make this available. Let me know what you think!