### PR TITLE
Failing test for broken aliases in stitched list objects

### DIFF
--- a/packages/stitch/tests/listAliases.test.ts
+++ b/packages/stitch/tests/listAliases.test.ts
@@ -1,0 +1,103 @@
+import { graphql } from 'graphql';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { stitchSchemas } from '@graphql-tools/stitch';
+import { delegateToSchema } from '@graphql-tools/delegate';
+
+describe('stitching via list endpoints', () => {
+  test('field aliases should still work', async () => {
+    const usersSchema = makeExecutableSchema({
+      typeDefs: `
+        type User {
+          id: ID!
+          username: String
+        }
+        type Query {
+          users(ids: [ID]!): [User]!
+        }
+      `,
+      resolvers: {
+        Query: {
+          users(obj, args) {
+            return args.ids.map(id => ({ id, username: `user${id}` }));
+          }
+        }
+      }
+    });
+
+    const postsSchema = makeExecutableSchema({
+      typeDefs: `
+        type Post {
+          id: ID!
+          userId: ID!
+        }
+        type Query {
+          post(id: ID!): Post!
+        }
+      `,
+      resolvers: {
+        Query: {
+          post(obj, args) {
+            return {
+              id: args.id,
+              userId: 55,
+            };
+          }
+        }
+      }
+    });
+
+    const gatewaySchema = stitchSchemas({
+      subschemas: [
+        { schema: usersSchema },
+        { schema: postsSchema },
+      ],
+      typeDefs: `
+        extend type Post {
+          user: User!
+        }
+      `,
+      resolvers: {
+        Post: {
+          user: {
+            selectionSet: '{ userId }',
+            async resolve(post, args, context, info) {
+              const users = await delegateToSchema({
+                schema: usersSchema,
+                operation: 'query',
+                fieldName: 'users',
+                args: { ids: [post.userId] },
+                context,
+                info
+              });
+
+              return users[0];
+            }
+          }
+        }
+      }
+    });
+
+    const result = await graphql(gatewaySchema, `
+      query {
+        post(id: 1) {
+          user {
+            id
+            name: username
+          }
+        }
+      }
+    `);
+
+    expect(result).toEqual({
+      data: {
+        post: {
+          user: {
+            id: '55',
+            name: 'user55',
+          },
+        },
+      },
+    });
+
+  });
+});


### PR DESCRIPTION
This is a failing test demonstrating the issue described in https://github.com/ardatan/graphql-tools/issues/1819. (per the request of @yaacovCR)

### Issue

The specific issue that I describe in https://github.com/ardatan/graphql-tools/issues/1819 (aliases are null in stitched objects) appears to result from stitching onto a list method that returns an array of results (versus a record endpoint that returns a single result). As demonstrated in this test, field aliases are broken when a resolver like the one below loads a record via an array (ie: DataLoader batch):

```js
Post: { 
  user: {
    selectionSet: '{ userId }',
    async resolve(post, args, context, info) {
      // loads results via an array (as you would using DataLoader)...
      const users = await delegateToSchema({
        schema: usersSchema,
        operation: 'query',
        fieldName: 'users',
        args: { ids: [post.userId] },
        context,
        info
      });

      return users[0];
    }
  }
}
```
Noodling around in resolvers, I can fix this aliasing issue for specific fields by adding a field resolver that does this:

```js
User: {
  // Fixes the aliasing issue for a single field:
  username(obj, args, context, info) {
    return obj[info.path.key];
  }
}
```
It would appear that the `obj[info.path.key]` reference needs to somehow be worked into the default resolver method. The aliases are properly being rendered by the subservice, it's just the gateway resolver layer that fails to align the returned data aliases with the request aliases.

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
