### PR TITLE
Pull code from unmaintained prisma-yml package into prisma-loader package.

### DIFF
--- a/packages/loaders/prisma/package.json
+++ b/packages/loaders/prisma/package.json
@@ -16,11 +16,30 @@
     "graphql": "^14.0.0 || ^15.0.0"
   },
   "dependencies": {
-    "@graphql-tools/utils": "6.0.15",
     "@graphql-tools/url-loader": "6.0.15",
+    "@graphql-tools/utils": "6.0.15",
+    "@types/http-proxy-agent": "^2.0.2",
+    "@types/js-yaml": "^3.12.5",
+    "@types/json-stable-stringify": "^1.0.32",
+    "@types/jsonwebtoken": "^8.5.0",
+    "ajv": "^6.12.3",
+    "bluebird": "^3.7.2",
+    "chalk": "^4.1.0",
+    "debug": "^4.1.1",
+    "dotenv": "^8.2.0",
     "fs-extra": "9.0.1",
-    "prisma-yml": "1.34.10",
-    "tslib": "~2.0.0"
+    "graphql-request": "^2.0.0",
+    "http-proxy-agent": "^4.0.1",
+    "https-proxy-agent": "^5.0.0",
+    "isomorphic-fetch": "^2.2.1",
+    "js-yaml": "^3.14.0",
+    "json-stable-stringify": "^1.0.1",
+    "jsonwebtoken": "^8.5.1",
+    "lodash": "^4.17.19",
+    "replaceall": "^0.1.6",
+    "scuid": "^1.1.0",
+    "tslib": "~2.0.0",
+    "yaml-ast-parser": "^0.0.43"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/loaders/prisma/src/index.ts
+++ b/packages/loaders/prisma/src/index.ts
@@ -1,5 +1,5 @@
 import { UrlLoader, LoadFromUrlOptions } from '@graphql-tools/url-loader';
-import { PrismaDefinitionClass, Environment } from 'prisma-yml';
+import { PrismaDefinitionClass, Environment } from './prisma-yml';
 import { join } from 'path';
 import { pathExists } from 'fs-extra';
 import { homedir } from 'os';

--- a/packages/loaders/prisma/src/prisma-yml/Cluster.test.ts
+++ b/packages/loaders/prisma/src/prisma-yml/Cluster.test.ts
@@ -1,0 +1,31 @@
+import { Cluster, Output } from '.';
+
+describe('cluster endpoint generation', () => {
+  test('local cluster', () => {
+    const cluster = new Cluster(new Output(), 'local', 'http://localhost:4466', undefined, true);
+    expect(cluster.getApiEndpoint('default', 'default')).toMatchSnapshot();
+    expect(cluster.getApiEndpoint('dev', 'default')).toMatchSnapshot();
+    expect(cluster.getApiEndpoint('default', 'dev')).toMatchSnapshot();
+    expect(cluster.getApiEndpoint('default', 'dev', 'ignore-me')).toMatchSnapshot();
+  });
+  test('private cluster', () => {
+    const cluster = new Cluster(
+      new Output(),
+      'test01',
+      'https://test01_workspace.prisma.sh',
+      undefined,
+      false,
+      false,
+      true
+    );
+    expect(cluster.getApiEndpoint('default', 'default', 'workspace')).toMatchSnapshot();
+    expect(cluster.getApiEndpoint('dev', 'default', 'workspace')).toMatchSnapshot();
+    expect(cluster.getApiEndpoint('default', 'dev', 'workspace')).toMatchSnapshot();
+  });
+  test('sandbox cluster', () => {
+    const cluster = new Cluster(new Output(), 'prisma-eu1', 'https://eu1.prisma.sh', undefined, false, true, false);
+    expect(cluster.getApiEndpoint('default', 'default', 'workspace')).toMatchSnapshot();
+    expect(cluster.getApiEndpoint('dev', 'default', 'workspace')).toMatchSnapshot();
+    expect(cluster.getApiEndpoint('default', 'dev', 'workspace')).toMatchSnapshot();
+  });
+});

--- a/packages/loaders/prisma/src/prisma-yml/Cluster.ts
+++ b/packages/loaders/prisma/src/prisma-yml/Cluster.ts
@@ -1,0 +1,282 @@
+import 'isomorphic-fetch';
+import * as jwt from 'jsonwebtoken';
+import { cloudApiEndpoint } from './constants';
+import { GraphQLClient } from 'graphql-request';
+import chalk from 'chalk';
+import { IOutput } from './Output';
+import { getProxyAgent } from './utils/getProxyAgent';
+const debug = require('debug')('environment');
+
+export class Cluster {
+  name: string;
+  baseUrl: string;
+  local: boolean;
+  shared: boolean;
+  clusterSecret?: string;
+  requiresAuth: boolean;
+  out: IOutput;
+  isPrivate: boolean;
+  workspaceSlug?: string;
+  private cachedToken?: string;
+  hasOldDeployEndpoint: boolean;
+  custom?: boolean;
+  constructor(
+    out: IOutput,
+    name: string,
+    baseUrl: string,
+    clusterSecret?: string,
+    local = true,
+    shared = false,
+    isPrivate = false,
+    workspaceSlug?: string
+  ) {
+    this.out = out;
+    this.name = name;
+
+    // All `baseUrl` extension points in this class
+    // adds a trailing slash. Here we remove it from
+    // the passed `baseUrl` in order to avoid double
+    // slashes.
+    this.baseUrl = baseUrl.replace(/\/$/, '');
+    this.clusterSecret = clusterSecret;
+    this.local = local;
+    this.shared = shared;
+    this.isPrivate = isPrivate;
+    this.workspaceSlug = workspaceSlug;
+    this.hasOldDeployEndpoint = false;
+  }
+
+  async getToken(serviceName: string, workspaceSlug?: string, stageName?: string): Promise<string | null> {
+    // public clusters just take the token
+
+    const needsAuth = await this.needsAuth();
+    debug({ needsAuth });
+    if (!needsAuth) {
+      return null;
+    }
+
+    if (this.name === 'shared-public-demo') {
+      return '';
+    }
+    if (this.isPrivate && process.env.PRISMA_MANAGEMENT_API_SECRET) {
+      return this.getLocalToken();
+    }
+    if (this.shared || (this.isPrivate && !process.env.PRISMA_MANAGEMENT_API_SECRET)) {
+      return this.generateClusterToken(serviceName, workspaceSlug, stageName);
+    } else {
+      return this.getLocalToken();
+    }
+  }
+
+  getLocalToken(): string | null {
+    if (!this.clusterSecret && !process.env.PRISMA_MANAGEMENT_API_SECRET) {
+      return null;
+    }
+    if (!this.cachedToken) {
+      const grants = [{ target: `*/*`, action: '*' }];
+      const secret = process.env.PRISMA_MANAGEMENT_API_SECRET || this.clusterSecret;
+
+      try {
+        const algorithm = process.env.PRISMA_MANAGEMENT_API_SECRET ? 'HS256' : 'RS256';
+        this.cachedToken = jwt.sign({ grants }, secret, {
+          expiresIn: '5y',
+          algorithm,
+        });
+      } catch (e) {
+        throw new Error(
+          `Could not generate token for cluster ${chalk.bold(
+            this.getDeployEndpoint()
+          )}. Did you provide the env var PRISMA_MANAGEMENT_API_SECRET?
+Original error: ${e.message}`
+        );
+      }
+    }
+
+    return this.cachedToken!;
+  }
+
+  get cloudClient() {
+    return new GraphQLClient(cloudApiEndpoint, {
+      headers: {
+        Authorization: `Bearer ${this.clusterSecret}`,
+      },
+      agent: getProxyAgent(cloudApiEndpoint),
+    } as any);
+  }
+
+  async generateClusterToken(
+    serviceName: string,
+    workspaceSlug: string = this.workspaceSlug || '*',
+    stageName?: string
+  ): Promise<string> {
+    const query = `
+      mutation ($input: GenerateClusterTokenRequest!) {
+        generateClusterToken(input: $input) {
+          clusterToken
+        }
+      }
+    `;
+
+    const {
+      generateClusterToken: { clusterToken },
+    } = await this.cloudClient.request<{
+      generateClusterToken: {
+        clusterToken: string;
+      };
+    }>(query, {
+      input: {
+        workspaceSlug,
+        clusterName: this.name,
+        serviceName,
+        stageName,
+      },
+    });
+
+    return clusterToken;
+  }
+
+  async addServiceToCloudDBIfMissing(
+    serviceName: string,
+    workspaceSlug: string = this.workspaceSlug!,
+    stageName?: string
+  ): Promise<boolean> {
+    const query = `
+      mutation ($input: GenerateClusterTokenRequest!) {
+        addServiceToCloudDBIfMissing(input: $input)
+      }
+    `;
+
+    const serviceCreated = await this.cloudClient.request<{
+      addServiceToCloudDBIfMissing: boolean;
+    }>(query, {
+      input: {
+        workspaceSlug,
+        clusterName: this.name,
+        serviceName,
+        stageName,
+      },
+    });
+
+    return serviceCreated.addServiceToCloudDBIfMissing;
+  }
+
+  getApiEndpoint(service: string, stage: string, workspaceSlug?: string | null) {
+    if (!this.shared && service === 'default' && stage === 'default') {
+      return this.baseUrl;
+    }
+    if (!this.shared && stage === 'default') {
+      return `${this.baseUrl}/${service}`;
+    }
+    if (this.isPrivate || this.local) {
+      return `${this.baseUrl}/${service}/${stage}`;
+    }
+    const workspaceString = workspaceSlug ? `${workspaceSlug}/` : '';
+    return `${this.baseUrl}/${workspaceString}${service}/${stage}`;
+  }
+
+  getWSEndpoint(service: string, stage: string, workspaceSlug?: string | null) {
+    return this.getApiEndpoint(service, stage, workspaceSlug).replace(/^http/, 'ws');
+  }
+
+  getImportEndpoint(service: string, stage: string, workspaceSlug?: string | null) {
+    return this.getApiEndpoint(service, stage, workspaceSlug) + `/import`;
+  }
+
+  getExportEndpoint(service: string, stage: string, workspaceSlug?: string | null) {
+    return this.getApiEndpoint(service, stage, workspaceSlug) + `/export`;
+  }
+
+  getDeployEndpoint() {
+    return `${this.baseUrl}/${this.hasOldDeployEndpoint ? 'cluster' : 'management'}`;
+  }
+
+  async isOnline(): Promise<boolean> {
+    const version = await this.getVersion();
+    return typeof version === 'string';
+  }
+
+  async getVersion(): Promise<string | null> {
+    // first try new api
+    try {
+      const result = await this.request(`{
+        serverInfo {
+          version
+        }
+      }`);
+
+      const res = await result.json();
+      const { data, errors } = res;
+      if (errors && errors[0].code === 3016 && errors[0].message.includes('management@default')) {
+        this.hasOldDeployEndpoint = true;
+        return await this.getVersion();
+      }
+      if (data && data.serverInfo) {
+        return data.serverInfo.version;
+      }
+    } catch (e) {
+      debug(e);
+    }
+
+    // if that doesn't work, try the old one
+    try {
+      const result = await this.request(`{
+        serverInfo {
+          version
+        }
+      }`);
+
+      const res = await result.json();
+      const { data } = res;
+      return data.serverInfo.version;
+    } catch (e) {
+      debug(e);
+    }
+
+    return null;
+  }
+
+  request(query: string, variables?: any) {
+    return fetch(this.getDeployEndpoint(), {
+      method: 'post',
+      headers: {
+        'Content-Type': 'application/json',
+      } as any,
+      body: JSON.stringify({
+        query,
+        variables,
+      }),
+      agent: getProxyAgent(this.getDeployEndpoint()),
+    } as any);
+  }
+
+  async needsAuth(): Promise<boolean> {
+    try {
+      const result = await this.request(`{
+        listProjects {
+          name
+        }
+      }`);
+      const data = await result.json();
+      if (data.errors && data.errors.length > 0) {
+        return true;
+      }
+      return false;
+    } catch (e) {
+      debug('Assuming that the server needs authentication');
+      debug(e.toString());
+      return true;
+    }
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      baseUrl: this.baseUrl,
+      local: this.local,
+      clusterSecret: this.clusterSecret,
+      shared: this.shared,
+      isPrivate: this.isPrivate,
+      workspaceSlug: this.workspaceSlug,
+    };
+  }
+}

--- a/packages/loaders/prisma/src/prisma-yml/Environment.test.ts
+++ b/packages/loaders/prisma/src/prisma-yml/Environment.test.ts
@@ -1,0 +1,60 @@
+import { Environment } from './Environment';
+import { getTmpDir } from './test/getTmpDir';
+import * as fs from 'fs-extra';
+import { Cluster } from './Cluster';
+import { Output } from './Output';
+
+export function makeEnv(_?: string) {
+  const tmpDir = getTmpDir();
+  return new Environment(tmpDir);
+}
+
+const out = new Output();
+
+describe('Environment', () => {
+  test('non-existent global prisma rc', async () => {
+    const env = makeEnv();
+    await env.load();
+    expect(env.clusters).toMatchSnapshot();
+  });
+  test('persists .prisma correctly', async () => {
+    const env = makeEnv();
+    await env.load();
+    const cluster = new Cluster(out, 'cluster', `http://localhost:60000`, '');
+    env.addCluster(cluster);
+    env.saveGlobalRC();
+    expect(fs.readFileSync(env.rcPath, 'utf-8')).toMatchSnapshot();
+    expect(env.clusters).toMatchSnapshot();
+  });
+  test('empty global prisma rc', async () => {
+    const env = makeEnv('');
+    await env.load();
+    expect(env.clusters).toMatchSnapshot();
+  });
+  test('sets the platform token correctly', async () => {
+    const env = makeEnv(`platformToken: asdf`);
+    await env.load();
+    expect(env.clusters).toMatchSnapshot();
+  });
+  test('interpolates env vars', async () => {
+    process.env.SPECIAL_TEST_ENV_VAR = 'this-is-so-special';
+    const env = makeEnv(`platformToken: \${env:SPECIAL_TEST_ENV_VAR}`);
+    await env.load();
+    expect(env.clusters).toMatchSnapshot();
+  });
+  test('loads multiple cluster definitions correctly + gives cluster by name', async () => {
+    const rc = `clusters:
+    local:
+      host: 'http://localhost:60000'
+    remote:
+      host: 'https://remote.graph.cool'
+      clusterSecret: 'here-is-a-token'
+  `;
+    const env = makeEnv(rc);
+    await env.load();
+    expect(env.clusters).toMatchSnapshot();
+
+    const cluster = env.clusterByName('remote');
+    expect(cluster).toMatchSnapshot();
+  });
+});

--- a/packages/loaders/prisma/src/prisma-yml/Environment.ts
+++ b/packages/loaders/prisma/src/prisma-yml/Environment.ts
@@ -1,0 +1,274 @@
+import { Args } from './types/common';
+import { Cluster } from './Cluster';
+import * as fs from 'fs-extra';
+import * as yaml from 'js-yaml';
+import { ClusterNotFound } from './errors/ClusterNotFound';
+import { Variables } from './Variables';
+import { IOutput, Output } from './Output';
+import * as path from 'path';
+import 'isomorphic-fetch';
+import { RC } from './index';
+import { ClusterNotSet } from './errors/ClusterNotSet';
+import { clusterEndpointMap } from './constants';
+import { getProxyAgent } from './utils/getProxyAgent';
+// eslint-disable-next-line
+// @ts-ignore
+import * as jwt from 'jsonwebtoken';
+const debug = require('debug')('Environment');
+
+export class Environment {
+  sharedClusters: string[] = ['prisma-eu1', 'prisma-us1'];
+  clusterEndpointMap = clusterEndpointMap;
+  args: Args;
+  activeCluster: Cluster;
+  globalRC: RC = {};
+  clusters: Cluster[];
+  out: IOutput;
+  home: string;
+  rcPath: string;
+  clustersFetched = false;
+  version?: string;
+  constructor(home: string, out: IOutput = new Output(), version?: string) {
+    this.out = out;
+    this.home = home;
+    this.version = version;
+
+    this.rcPath = path.join(this.home, '.prisma/config.yml');
+    fs.mkdirpSync(path.dirname(this.rcPath));
+  }
+
+  async load() {
+    await this.loadGlobalRC();
+  }
+
+  get cloudSessionKey(): string | undefined {
+    return process.env.PRISMA_CLOUD_SESSION_KEY || this.globalRC.cloudSessionKey;
+  }
+
+  async renewToken() {
+    if (this.cloudSessionKey) {
+      const data: any = jwt.decode(this.cloudSessionKey);
+      if (!data.exp) {
+        return;
+      }
+      const timeLeft = data.exp * 1000 - Date.now();
+      if (timeLeft < 1000 * 60 * 60 * 24 && timeLeft > 0) {
+        try {
+          const res = await this.requestCloudApi(`
+          mutation {
+            renewToken
+          }
+        `);
+          if (res.renewToken) {
+            this.globalRC.cloudSessionKey = res.renewToken;
+            this.saveGlobalRC();
+          }
+        } catch (e) {
+          debug(e);
+        }
+      }
+    }
+  }
+
+  async fetchClusters() {
+    if (!this.clustersFetched && this.cloudSessionKey) {
+      const renewPromise = this.renewToken();
+      try {
+        const res = (await Promise.race([
+          this.requestCloudApi(`
+            query prismaCliGetClusters {
+              me {
+                memberships {
+                  workspace {
+                    id
+                    slug
+                    clusters {
+                      id
+                      name
+                      connectInfo {
+                        endpoint
+                      }
+                      customConnectionInfo {
+                        endpoint
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          `),
+          // eslint-disable-next-line
+          new Promise((_, r) => setTimeout(() => r(), 6000)),
+        ])) as any;
+        if (!res) {
+          return;
+        }
+        if (res.me && res.me.memberships && Array.isArray(res.me.memberships)) {
+          // clean up all prisma-eu1 and prisma-us1 clusters if they already exist
+          this.clusters = this.clusters.filter(c => c.name !== 'prisma-eu1' && c.name !== 'prisma-us1');
+
+          res.me.memberships.forEach((m: any) => {
+            m.workspace.clusters.forEach((cluster: any) => {
+              const endpoint = cluster.connectInfo
+                ? cluster.connectInfo.endpoint
+                : cluster.customConnectionInfo
+                ? cluster.customConnectionInfo.endpoint
+                : this.clusterEndpointMap[cluster.name];
+              this.addCluster(
+                new Cluster(
+                  this.out,
+                  cluster.name,
+                  endpoint,
+                  this.globalRC.cloudSessionKey,
+                  false,
+                  ['prisma-eu1', 'prisma-us1'].includes(cluster.name),
+                  !['prisma-eu1', 'prisma-us1'].includes(cluster.name),
+                  m.workspace.slug
+                )
+              );
+            });
+          });
+        }
+      } catch (e) {
+        debug(e);
+      }
+      await renewPromise;
+    }
+  }
+
+  clusterByName(name: string, throws = false): Cluster | undefined {
+    if (!this.clusters) {
+      return;
+    }
+    const cluster = this.clusters.find(c => c.name === name);
+    if (!throws) {
+      return cluster;
+    }
+
+    if (!cluster) {
+      if (!name) {
+        throw new ClusterNotSet();
+      }
+      throw new ClusterNotFound(name);
+    }
+
+    return cluster;
+  }
+
+  setToken(token: string | undefined) {
+    this.globalRC.cloudSessionKey = token;
+  }
+
+  addCluster(cluster: Cluster) {
+    const existingClusterIndex = this.clusters.findIndex(c => {
+      if (cluster.workspaceSlug) {
+        return c.workspaceSlug === cluster.workspaceSlug && c.name === cluster.name;
+      } else {
+        return c.name === cluster.name;
+      }
+    });
+    if (existingClusterIndex > -1) {
+      this.clusters.splice(existingClusterIndex, 1);
+    }
+    this.clusters.push(cluster);
+  }
+
+  removeCluster(name: string) {
+    this.clusters = this.clusters.filter(c => c.name !== name);
+  }
+
+  saveGlobalRC() {
+    const rc = {
+      cloudSessionKey: this.globalRC.cloudSessionKey ? this.globalRC.cloudSessionKey.trim() : undefined,
+      clusters: this.getLocalClusterConfig(),
+    };
+    // parse & stringify to rm undefined for yaml parser
+    const rcString = yaml.safeDump(JSON.parse(JSON.stringify(rc)));
+    fs.writeFileSync(this.rcPath, rcString);
+  }
+
+  setActiveCluster(cluster: Cluster) {
+    this.activeCluster = cluster;
+  }
+
+  async loadGlobalRC(): Promise<void> {
+    const globalFile =
+      this.rcPath && fs.pathExistsSync(this.rcPath) ? fs.readFileSync(this.rcPath, 'utf-8') : undefined;
+    await this.parseGlobalRC(globalFile);
+  }
+
+  async parseGlobalRC(globalFile?: string): Promise<void> {
+    if (globalFile) {
+      this.globalRC = await this.loadYaml(globalFile, this.rcPath);
+    }
+    this.clusters = this.initClusters(this.globalRC);
+  }
+
+  private async loadYaml(file: string | null, filePath: string | null = null): Promise<any> {
+    if (file) {
+      let content;
+      try {
+        content = yaml.safeLoad(file);
+      } catch (e) {
+        throw new Error(`Yaml parsing error in ${filePath}: ${e.message}`);
+      }
+      const variables = new Variables(filePath || 'no filepath provided', this.args, this.out);
+      content = await variables.populateJson(content);
+
+      return content;
+    } else {
+      return {};
+    }
+  }
+
+  private initClusters(rc: RC): Cluster[] {
+    const sharedClusters = this.getSharedClusters(rc);
+    return [...sharedClusters];
+  }
+
+  private getSharedClusters(rc: RC): Cluster[] {
+    return this.sharedClusters.map(clusterName => {
+      return new Cluster(
+        this.out,
+        clusterName,
+        this.clusterEndpointMap[clusterName],
+        rc && rc.cloudSessionKey,
+        false,
+        true
+      );
+    });
+  }
+
+  private getLocalClusterConfig() {
+    return this.clusters
+      .filter(c => !c.shared && c.clusterSecret !== this.cloudSessionKey && !c.isPrivate)
+      .reduce((acc, cluster) => {
+        return {
+          ...acc,
+          [cluster.name]: {
+            host: cluster.baseUrl,
+            clusterSecret: cluster.clusterSecret,
+          },
+        };
+      }, {});
+  }
+
+  private async requestCloudApi(query: string) {
+    const res = await fetch('https://api.cloud.prisma.sh', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.cloudSessionKey}`,
+        'X-Cli-Version': this.version,
+      } as any,
+      body: JSON.stringify({
+        query,
+      }),
+      proxy: getProxyAgent('https://api.cloud.prisma.sh'),
+    } as any);
+    const json = await res.json();
+    return json.data;
+  }
+}
+
+export const isLocal = (hostname: any) => hostname.includes('localhost') || hostname.includes('127.0.0.1');

--- a/packages/loaders/prisma/src/prisma-yml/Output.ts
+++ b/packages/loaders/prisma/src/prisma-yml/Output.ts
@@ -1,0 +1,39 @@
+export class Output {
+  log(...args: any) {
+    console.log(args);
+  }
+
+  warn(...args: any) {
+    console.warn(args);
+  }
+
+  getErrorPrefix(fileName: string, type: 'error' | 'warning' = 'error') {
+    return `[${type.toUpperCase()}] in ${fileName}: `;
+  }
+}
+
+export class TestOutput {
+  output: string[];
+
+  constructor() {
+    this.output = [];
+  }
+
+  log(...args: any) {
+    this.output = this.output.concat(args);
+  }
+
+  warn(...args: any) {
+    this.output = this.output.concat(args);
+  }
+
+  getErrorPrefix(fileName: string, type: 'error' | 'warning' = 'error') {
+    return `[${type.toUpperCase()}] in ${fileName}: `;
+  }
+}
+
+export interface IOutput {
+  warn: (...args: any) => void;
+  log: (...args: any) => void;
+  getErrorPrefix: (fileName: string, type?: 'error' | 'warning') => string;
+}

--- a/packages/loaders/prisma/src/prisma-yml/PrismaDefinition.test.ts
+++ b/packages/loaders/prisma/src/prisma-yml/PrismaDefinition.test.ts
@@ -1,0 +1,315 @@
+import { PrismaDefinitionClass } from './PrismaDefinition';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { getTmpDir } from './test/getTmpDir';
+import { makeEnv } from './Environment.test';
+import { Args } from './types/common';
+
+const defaultGlobalRC = `prisma-1.0:
+  clusters:
+    local:
+      host: 'http://localhost:4466'
+    remote:
+      host: 'https://remote.graph.cool'
+      clusterSecret: 'here-is-a-token'
+`;
+
+function makeDefinition(
+  yml: string,
+  datamodel: string,
+  _: Args = {},
+  __: string = defaultGlobalRC,
+  envVars: any = process.env
+) {
+  const definitionDir = getTmpDir();
+  const definitionPath = path.join(definitionDir, 'prisma.yml');
+  const modelPath = path.join(definitionDir, 'datamodel.prisma');
+  const env = makeEnv(defaultGlobalRC);
+
+  const definition = new PrismaDefinitionClass(env, definitionPath, envVars);
+
+  fs.writeFileSync(modelPath, datamodel);
+  fs.writeFileSync(definitionPath, yml);
+
+  return { env, definition };
+}
+
+async function loadDefinition(
+  yml: string,
+  datamodel: string,
+  args: Args = {},
+  envPath?: string,
+  globalRC: string = defaultGlobalRC
+) {
+  const { env, definition } = makeDefinition(yml, datamodel, args, globalRC);
+  await env.load();
+  await definition.load(args, envPath);
+  return { env, definition };
+}
+
+describe('prisma definition', () => {
+  test('load basic yml, provide cluster', async () => {
+    const yml = `\
+service: jj
+stage: dev
+cluster: local
+
+datamodel:
+- datamodel.prisma
+
+secret: some-secret
+
+schema: schemas/database.graphql
+    `;
+    const datamodel = `
+type User @model {
+  id: ID! @isUnique
+  name: String!
+  lol: Int
+  what: String
+}
+`;
+    try {
+      await loadDefinition(yml, datamodel);
+    } catch (e) {
+      expect(e).toMatchSnapshot();
+    }
+  });
+  test('load yml with secret and env var', async () => {
+    const secret = 'this-is-a-long-secret';
+    process.env.MY_TEST_SECRET = secret;
+    const yml = `\
+service: jj
+stage: dev
+cluster: local
+
+datamodel:
+- datamodel.prisma
+
+secret: \${env:MY_TEST_SECRET}
+
+schema: schemas/database.graphql
+    `;
+    const datamodel = `
+type User @model {
+  id: ID! @isUnique
+  name: String!
+  lol: Int
+  what: String
+}
+`;
+
+    try {
+      await loadDefinition(yml, datamodel);
+    } catch (e) {
+      expect(e).toMatchSnapshot();
+    }
+  });
+  test('load yml with secret and env var in .env', async () => {
+    const yml = `\
+service: jj
+stage: dev
+cluster: local
+
+datamodel:
+- datamodel.prisma
+
+secret: \${env:MY_DOT_ENV_SECRET}
+
+schema: schemas/database.graphql
+    `;
+    const datamodel = `
+type User @model {
+  id: ID! @isUnique
+  name: String!
+  lol: Int
+  what: String
+}
+`;
+    const { definition, env } = makeDefinition(yml, datamodel, {});
+    const envPath = path.join(definition.definitionDir, '.env');
+
+    fs.outputFileSync(envPath, `MY_DOT_ENV_SECRET=this-is-very-secret,and-comma,seperated`);
+
+    await env.load();
+
+    try {
+      await loadDefinition(yml, datamodel);
+    } catch (e) {
+      expect(e).toMatchSnapshot();
+    }
+  });
+  test('load yml with injected env var', async () => {
+    const yml = `\
+service: jj
+stage: dev
+cluster: local
+
+datamodel:
+- datamodel.prisma
+
+secret: \${env:MY_INJECTED_ENV_SECRET}
+
+schema: schemas/database.graphql
+    `;
+    const datamodel = `
+type User @model {
+  id: ID! @isUnique
+  name: String!
+  lol: Int
+  what: String
+}
+`;
+    const envVars = {
+      MY_INJECTED_ENV_SECRET: 'some-secret',
+    };
+
+    const { env } = makeDefinition(yml, datamodel, {}, defaultGlobalRC, envVars);
+
+    await env.load();
+    try {
+      await loadDefinition(yml, datamodel);
+    } catch (e) {
+      expect(e).toMatchSnapshot();
+    }
+  });
+  /**
+   * This test ensures, that GRAPHCOOL_SECRET can't be injected anymore
+   */
+  test('dont load yml with secret and env var in args', async () => {
+    const yml = `\
+service: jj
+stage: dev
+cluster: local
+
+datamodel:
+- datamodel.prisma
+
+schema: schemas/database.graphql
+    `;
+    const datamodel = `
+type User @model {
+  id: ID! @isUnique
+  name: String!
+  lol: Int
+  what: String
+}
+`;
+
+    const definitionDir = getTmpDir();
+    const definitionPath = path.join(definitionDir, 'prisma.yml');
+    const modelPath = path.join(definitionDir, 'datamodel.prisma');
+    const env = makeEnv(defaultGlobalRC);
+
+    const definition = new PrismaDefinitionClass(env, definitionPath, {
+      GRAPHCOOL_SECRET: 'this-is-secret',
+    });
+
+    fs.writeFileSync(modelPath, datamodel);
+    fs.writeFileSync(definitionPath, yml);
+
+    let error;
+    try {
+      await env.load();
+      await definition.load({});
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).toMatchSnapshot();
+  });
+  test('load yml with disableAuth: true', async () => {
+    const yml = `\
+service: jj
+stage: dev
+cluster: local
+
+datamodel:
+- datamodel.prisma
+
+disableAuth: true
+
+schema: schemas/database.graphql
+    `;
+    const datamodel = `
+type User @model {
+  id: ID! @isUnique
+  name: String!
+  lol: Int
+  what: String
+}
+`;
+    const { definition, env } = makeDefinition(yml, datamodel);
+    const envPath = path.join(definition.definitionDir, '.env');
+
+    fs.outputFileSync(envPath, `MY_DOT_ENV_SECRET=this-is-very-secret,and-comma,seperated`);
+
+    await env.load();
+    try {
+      await loadDefinition(yml, datamodel);
+    } catch (e) {
+      expect(e).toMatchSnapshot();
+    }
+  });
+  test('throw when no secret or disable auth provided', async () => {
+    const yml = `\
+service: jj
+stage: dev
+cluster: local
+
+datamodel:
+- datamodel.prisma
+
+schema: schemas/database.graphql
+    `;
+    const datamodel = `
+type User @model {
+  id: ID! @isUnique
+  name: String!
+  lol: Int
+  what: String
+}
+`;
+
+    let error;
+    try {
+      await loadDefinition(yml, datamodel);
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).toMatchSnapshot();
+  });
+  test('throws when stages key apparent', async () => {
+    const yml = `\
+service: jj
+stage: dev
+cluster: local
+
+datamodel:
+- datamodel.prisma
+
+schema: schemas/database.graphql
+
+stages:
+  dev: local
+    `;
+    const datamodel = `
+type User @model {
+  id: ID! @isUnique
+  name: String!
+  lol: Int
+  what: String
+}
+`;
+
+    let error;
+    try {
+      await loadDefinition(yml, datamodel);
+    } catch (e) {
+      error = e;
+    }
+
+    expect(error).toMatchSnapshot();
+  });
+});

--- a/packages/loaders/prisma/src/prisma-yml/PrismaDefinition.ts
+++ b/packages/loaders/prisma/src/prisma-yml/PrismaDefinition.ts
@@ -1,0 +1,364 @@
+import { readDefinition } from './yaml';
+import { PrismaDefinition } from './prisma-json-schema';
+import * as fs from 'fs-extra';
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+// eslint-disable-next-line
+// @ts-ignore
+import * as jwt from 'jsonwebtoken';
+import { Args } from './types/common';
+import { Environment } from './Environment';
+import { IOutput } from './Output';
+import { Cluster } from './Cluster';
+import { FunctionInput, Header } from './types/rc';
+import chalk from 'chalk';
+import { replaceYamlValue } from './utils/yamlComment';
+import { parseEndpoint, ParseEndpointResult } from './utils/parseEndpoint';
+
+export interface EnvVars {
+  [key: string]: string | undefined;
+}
+
+export type HookType = 'post-deploy';
+
+export class PrismaDefinitionClass {
+  definition?: PrismaDefinition;
+  rawJson?: any;
+  typesString?: string;
+  secrets: string[] | null;
+  definitionPath?: string | null;
+  definitionDir: string;
+  env: Environment;
+  out?: IOutput;
+  envVars: any;
+  rawEndpoint?: string;
+  private definitionString: string;
+  constructor(env: Environment, definitionPath?: string | null, envVars: EnvVars = process.env, out?: IOutput) {
+    this.secrets = null;
+    this.definitionPath = definitionPath;
+    if (definitionPath) {
+      this.definitionDir = path.dirname(definitionPath);
+    }
+    this.env = env;
+    this.out = out;
+    this.envVars = envVars;
+  }
+
+  async load(args: Args, envPath?: string, graceful?: boolean) {
+    if (args.project) {
+      const flagPath = path.resolve(args.project as string);
+
+      if (!fs.pathExistsSync(flagPath)) {
+        throw new Error(`Prisma definition path specified by --project '${flagPath}' does not exist`);
+      }
+
+      this.definitionPath = flagPath;
+      this.definitionDir = path.dirname(flagPath);
+      await this.loadDefinition(args, graceful);
+
+      this.validate();
+      return;
+    }
+
+    if (envPath) {
+      if (!fs.pathExistsSync(envPath)) {
+        envPath = path.join(process.cwd(), envPath);
+      }
+
+      if (!fs.pathExistsSync(envPath)) {
+        throw new Error(`--env-file path '${envPath}' does not exist`);
+      }
+    }
+    dotenv.config({ path: envPath });
+    if (this.definitionPath) {
+      await this.loadDefinition(args, graceful);
+
+      this.validate();
+    } else {
+      throw new Error(`Couldn’t find \`prisma.yml\` file. Are you in the right directory?`);
+    }
+  }
+
+  private async loadDefinition(args: any, graceful?: boolean) {
+    const { definition, rawJson } = await readDefinition(this.definitionPath!, args, this.out, this.envVars, graceful);
+    this.rawEndpoint = rawJson.endpoint;
+    this.definition = definition;
+    this.rawJson = rawJson;
+    this.definitionString = fs.readFileSync(this.definitionPath!, 'utf-8');
+    this.typesString = this.getTypesString(this.definition);
+    const secrets = this.definition.secret;
+    this.secrets = secrets ? secrets.replace(/\s/g, '').split(',') : null;
+  }
+
+  get endpoint(): string | undefined {
+    return (this.definition && this.definition.endpoint) || process.env.PRISMA_MANAGEMENT_API_ENDPOINT;
+  }
+
+  get clusterBaseUrl(): string | undefined {
+    if (!this.definition || !this.endpoint) {
+      return undefined;
+    }
+    const { clusterBaseUrl } = parseEndpoint(this.endpoint);
+    return clusterBaseUrl;
+  }
+
+  get service(): string | undefined {
+    if (!this.definition) {
+      return undefined;
+    }
+    if (!this.endpoint) {
+      return undefined;
+    }
+    const { service } = parseEndpoint(this.endpoint);
+    return service;
+  }
+
+  get stage(): string | undefined {
+    if (!this.definition) {
+      return undefined;
+    }
+    if (!this.endpoint) {
+      return undefined;
+    }
+    const { stage } = parseEndpoint(this.endpoint);
+    return stage;
+  }
+
+  get cluster(): string | undefined {
+    if (!this.definition) {
+      return undefined;
+    }
+    if (!this.endpoint) {
+      return undefined;
+    }
+    const { clusterName } = parseEndpoint(this.endpoint);
+    return clusterName;
+  }
+
+  validate() {
+    // shared clusters need a workspace
+    const clusterName = this.getClusterName();
+    const cluster = this.env.clusterByName(clusterName!)!;
+    if (
+      this.definition &&
+      clusterName &&
+      cluster &&
+      cluster.shared &&
+      !cluster.isPrivate &&
+      !this.getWorkspace() &&
+      clusterName !== 'shared-public-demo'
+    ) {
+      throw new Error(
+        `Your \`cluster\` property in the prisma.yml is missing the workspace slug.
+Make sure that your \`cluster\` property looks like this: ${chalk.bold(
+          '<workspace>/<cluster-name>'
+        )}. You can also remove the cluster property from the prisma.yml
+and execute ${chalk.bold.green('prisma deploy')} again, to get that value auto-filled.`
+      );
+    }
+    if (
+      this.definition &&
+      this.definition.endpoint &&
+      clusterName &&
+      cluster &&
+      cluster.shared &&
+      !cluster.isPrivate &&
+      !this.getWorkspace() &&
+      clusterName !== 'shared-public-demo'
+    ) {
+      throw new Error(
+        `The provided endpoint ${this.definition.endpoint} points to a demo cluster, but is missing the workspace slug. A valid demo endpoint looks like this: https://eu1.prisma.sh/myworkspace/service-name/stage-name`
+      );
+    }
+    if (this.definition && this.definition.endpoint && !this.definition.endpoint.startsWith('http')) {
+      throw new Error(
+        `${chalk.bold(this.definition.endpoint)} is not a valid endpoint. It must start with http:// or https://`
+      );
+    }
+  }
+
+  getToken(serviceName: string, stageName: string): string | undefined {
+    if (this.secrets) {
+      const data = {
+        data: {
+          service: `${serviceName}@${stageName}`,
+          roles: ['admin'],
+        },
+      };
+      return jwt.sign(data, this.secrets[0], {
+        expiresIn: '7d',
+      });
+    }
+
+    return undefined;
+  }
+
+  async getCluster(_ = false): Promise<Cluster | undefined> {
+    if (this.definition && this.endpoint) {
+      const clusterData = parseEndpoint(this.endpoint);
+      const cluster = await this.getClusterByEndpoint(clusterData);
+      this.env.removeCluster(clusterData.clusterName);
+      this.env.addCluster(cluster);
+      return cluster;
+    }
+
+    return undefined;
+  }
+
+  findClusterByBaseUrl(baseUrl: string) {
+    return this.env.clusters.find(c => c.baseUrl.toLowerCase() === baseUrl);
+  }
+
+  async getClusterByEndpoint(data: ParseEndpointResult) {
+    if (data.clusterBaseUrl && !process.env.PRISMA_MANAGEMENT_API_SECRET) {
+      const cluster = this.findClusterByBaseUrl(data.clusterBaseUrl);
+      if (cluster) {
+        return cluster;
+      }
+    }
+
+    const { clusterName, clusterBaseUrl, isPrivate, local, shared, workspaceSlug } = data;
+
+    // if the cluster could potentially be served by the cloud api, fetch the available
+    // clusters from the cloud api
+    if (!local) {
+      await this.env.fetchClusters();
+      const cluster = this.findClusterByBaseUrl(data.clusterBaseUrl);
+      if (cluster) {
+        return cluster;
+      }
+    }
+
+    return new Cluster(
+      this.out!,
+      clusterName,
+      clusterBaseUrl,
+      shared || isPrivate ? this.env.cloudSessionKey : undefined,
+      local,
+      shared,
+      isPrivate,
+      workspaceSlug!
+    );
+  }
+
+  getTypesString(definition: PrismaDefinition) {
+    const typesPaths = definition.datamodel
+      ? Array.isArray(definition.datamodel)
+        ? definition.datamodel
+        : [definition.datamodel]
+      : [];
+
+    let allTypes = '';
+    typesPaths.forEach(unresolvedTypesPath => {
+      const typesPath = path.join(this.definitionDir, unresolvedTypesPath!);
+      if (fs.existsSync(typesPath)) {
+        const types = fs.readFileSync(typesPath, 'utf-8');
+        allTypes += types + '\n';
+      } else {
+        throw new Error(`The types definition file "${typesPath}" could not be found.`);
+      }
+    });
+
+    return allTypes;
+  }
+
+  getClusterName(): string | null {
+    return this.cluster || null;
+  }
+
+  getWorkspace(): string | null {
+    if (this.definition && this.endpoint) {
+      const { workspaceSlug } = parseEndpoint(this.endpoint);
+      if (workspaceSlug) {
+        return workspaceSlug;
+      }
+    }
+
+    return null;
+  }
+
+  async getDeployName() {
+    const cluster = await this.getCluster();
+    return concatName(cluster!, this.service!, this.getWorkspace());
+  }
+
+  getSubscriptions(): FunctionInput[] {
+    if (this.definition && this.definition.subscriptions) {
+      return Object.entries(this.definition!.subscriptions!).map(([name, subscription]) => {
+        const url = typeof subscription.webhook === 'string' ? subscription.webhook : subscription.webhook.url;
+        const headers = typeof subscription.webhook === 'string' ? [] : transformHeaders(subscription.webhook.headers);
+
+        let query = subscription.query;
+        if (subscription.query.endsWith('.graphql')) {
+          const queryPath = path.join(this.definitionDir, subscription.query);
+          if (!fs.pathExistsSync(queryPath)) {
+            throw new Error(
+              `Subscription query ${queryPath} provided in subscription "${name}" in prisma.yml does not exist.`
+            );
+          }
+          query = fs.readFileSync(queryPath, 'utf-8');
+        }
+
+        return {
+          name,
+          query,
+          headers,
+          url,
+        };
+      });
+    }
+    return [];
+  }
+
+  replaceEndpoint(newEndpoint: any) {
+    this.definitionString = replaceYamlValue(this.definitionString, 'endpoint', newEndpoint);
+    fs.writeFileSync(this.definitionPath!, this.definitionString);
+  }
+
+  addDatamodel(datamodel: any) {
+    this.definitionString += `\ndatamodel: ${datamodel}`;
+    fs.writeFileSync(this.definitionPath!, this.definitionString);
+    this.definition!.datamodel = datamodel;
+  }
+
+  async getEndpoint(serviceInput?: string, stageInput?: string) {
+    const cluster = await this.getCluster();
+    const service = serviceInput || this.service;
+    const stage = stageInput || this.stage;
+    const workspace = this.getWorkspace();
+
+    if (service && stage && cluster) {
+      return cluster!.getApiEndpoint(service, stage, workspace);
+    }
+
+    return null;
+  }
+
+  getHooks(hookType: HookType): string[] {
+    if (this.definition && this.definition.hooks && this.definition.hooks[hookType]) {
+      const hooks = this.definition.hooks[hookType];
+      if (typeof hooks !== 'string' && !Array.isArray(hooks)) {
+        throw new Error(`Hook ${hookType} provided in prisma.yml must be string or an array of strings.`);
+      }
+      return typeof hooks === 'string' ? [hooks] : hooks;
+    }
+
+    return [];
+  }
+}
+
+export function concatName(cluster: Cluster, name: string, workspace: string | null) {
+  if (cluster.shared) {
+    const workspaceString = workspace ? `${workspace}~` : '';
+    return `${workspaceString}${name}`;
+  }
+
+  return name;
+}
+
+function transformHeaders(headers?: { [key: string]: string }): Header[] {
+  if (!headers) {
+    return [];
+  }
+  return Object.entries(headers).map(([name, value]) => ({ name, value }));
+}

--- a/packages/loaders/prisma/src/prisma-yml/Variables.ts
+++ b/packages/loaders/prisma/src/prisma-yml/Variables.ts
@@ -1,0 +1,245 @@
+'use strict';
+
+import * as lodash from 'lodash';
+// eslint-disable-next-line
+// @ts-ignore
+import replaceall from 'replaceall';
+// eslint-disable-next-line
+// @ts-ignore
+import * as BbPromise from 'bluebird';
+import { Args } from './types/common';
+import { Output, IOutput } from './Output';
+
+export class Variables {
+  json: any;
+  overwriteSyntax = RegExp(/,/g);
+  envRefSyntax = RegExp(/^env:/g);
+  selfRefSyntax = RegExp(/^self:/g);
+  stringRefSyntax = RegExp(/('.*')|(".*")/g);
+  optRefSyntax = RegExp(/^opt:/g);
+  variableSyntax = RegExp(
+    // eslint-disable-next-line
+    '\\${([ ~:a-zA-Z0-9._\'",\\-\\/\\(\\)]+?)}',
+    'g'
+  );
+
+  fileName: string;
+  options: Args;
+  out: Output;
+  envVars: any;
+
+  constructor(fileName: string, options: Args = {}, out: IOutput = new Output(), envVars?: any) {
+    this.out = out;
+    this.fileName = fileName;
+    this.options = options;
+    this.envVars = envVars || process.env;
+  }
+
+  populateJson(json: any): Promise<any> {
+    this.json = json;
+    return this.populateObject(this.json).then(() => {
+      return BbPromise.resolve(this.json);
+    });
+  }
+
+  public populateObject(objectToPopulate: any) {
+    const populateAll: any[] = [];
+    const deepMapValues = (object: any, callback: any, propertyPath?: string[]): any => {
+      const deepMapValuesIteratee = (value: any, key: any) =>
+        deepMapValues(value, callback, propertyPath ? propertyPath.concat(key) : [key]);
+      if (lodash.isArray(object)) {
+        return lodash.map(object, deepMapValuesIteratee);
+      } else if (
+        lodash.isObject(object) &&
+        !lodash.isDate(object) &&
+        !lodash.isRegExp(object) &&
+        !lodash.isFunction(object)
+      ) {
+        return lodash.extend({}, object, lodash.mapValues(object, deepMapValuesIteratee));
+      }
+      return callback(object, propertyPath);
+    };
+
+    deepMapValues(objectToPopulate, (property: any, propertyPath: any) => {
+      if (typeof property === 'string') {
+        const populateSingleProperty = this.populateProperty(property, true)
+          .then((newProperty: any) => lodash.set(objectToPopulate, propertyPath, newProperty))
+          .return();
+        populateAll.push(populateSingleProperty);
+      }
+    });
+
+    return BbPromise.all(populateAll).then(() => objectToPopulate);
+  }
+
+  populateProperty(propertyParam: any, populateInPlace?: boolean) {
+    let property = populateInPlace ? propertyParam : lodash.cloneDeep(propertyParam);
+    const allValuesToPopulate: any[] = [];
+    let warned = false;
+
+    if (typeof property === 'string' && property.match(this.variableSyntax)) {
+      property.match(this.variableSyntax)!.forEach(matchedString => {
+        const variableString = matchedString
+          .replace(this.variableSyntax, (_, varName) => varName.trim())
+          .replace(/\s/g, '');
+
+        let singleValueToPopulate: Promise<any> | null = null;
+        if (variableString.match(this.overwriteSyntax)) {
+          singleValueToPopulate = this.overwrite(variableString);
+        } else {
+          singleValueToPopulate = this.getValueFromSource(variableString).then((valueToPopulate: any) => {
+            if (typeof valueToPopulate === 'object') {
+              return this.populateObject(valueToPopulate);
+            }
+            return valueToPopulate;
+          });
+        }
+
+        singleValueToPopulate = singleValueToPopulate!.then(valueToPopulate => {
+          if (this.warnIfNotFound(variableString, valueToPopulate)) {
+            warned = true;
+          }
+          return this.populateVariable(property, matchedString, valueToPopulate).then((newProperty: any) => {
+            property = newProperty;
+            return BbPromise.resolve(property);
+          });
+        });
+
+        allValuesToPopulate.push(singleValueToPopulate);
+      });
+      return BbPromise.all(allValuesToPopulate).then(() => {
+        if ((property as any) !== (this.json as any) && !warned) {
+          return this.populateProperty(property);
+        }
+        return BbPromise.resolve(property);
+      });
+    }
+    return BbPromise.resolve(property);
+  }
+
+  populateVariable(propertyParam: any, matchedString: any, valueToPopulate: any) {
+    let property = propertyParam;
+    if (typeof valueToPopulate === 'string') {
+      property = replaceall(matchedString, valueToPopulate, property);
+    } else {
+      if (property !== matchedString) {
+        if (typeof valueToPopulate === 'number') {
+          property = replaceall(matchedString, String(valueToPopulate), property);
+        } else {
+          const errorMessage = [
+            'Trying to populate non string value into',
+            ` a string for variable ${matchedString}.`,
+            ' Please make sure the value of the property is a string.',
+          ].join('');
+          this.out.warn(this.out.getErrorPrefix(this.fileName, 'warning') + errorMessage);
+        }
+        return BbPromise.resolve(property);
+      }
+      property = valueToPopulate;
+    }
+    return BbPromise.resolve(property);
+  }
+
+  overwrite(variableStringsString: any) {
+    let finalValue: any;
+    const variableStringsArray = variableStringsString.split(',');
+    const allValuesFromSource = variableStringsArray.map((variableString: any) =>
+      this.getValueFromSource(variableString)
+    );
+    return BbPromise.all(allValuesFromSource).then((valuesFromSources: any) => {
+      valuesFromSources.find((valueFromSource: any) => {
+        finalValue = valueFromSource;
+        return (
+          finalValue !== null &&
+          typeof finalValue !== 'undefined' &&
+          !(typeof finalValue === 'object' && lodash.isEmpty(finalValue))
+        );
+      });
+      return BbPromise.resolve(finalValue);
+    });
+  }
+
+  getValueFromSource(variableString: any) {
+    if (variableString.match(this.envRefSyntax)) {
+      return this.getValueFromEnv(variableString);
+    } else if (variableString.match(this.optRefSyntax)) {
+      return this.getValueFromOptions(variableString);
+    } else if (variableString.match(this.selfRefSyntax)) {
+      return this.getValueFromSelf(variableString);
+    } else if (variableString.match(this.stringRefSyntax)) {
+      return this.getValueFromString(variableString);
+    }
+    const errorMessage = [
+      `Invalid variable reference syntax for variable ${variableString}.`,
+      ' You can only reference env vars, options, & files.',
+      ' You can check our docs for more info.',
+    ].join('');
+    this.out.warn(this.out.getErrorPrefix(this.fileName, 'warning') + errorMessage);
+  }
+
+  getValueFromEnv(variableString: any) {
+    const requestedEnvVar = variableString.split(':')[1];
+    const valueToPopulate = requestedEnvVar !== '' || '' in this.envVars ? this.envVars[requestedEnvVar] : this.envVars;
+    return BbPromise.resolve(valueToPopulate);
+  }
+
+  getValueFromString(variableString: any) {
+    const valueToPopulate = variableString.replace(/^['"]|['"]$/g, '');
+    return BbPromise.resolve(valueToPopulate);
+  }
+
+  getValueFromOptions(variableString: any) {
+    const requestedOption = variableString.split(':')[1];
+    const valueToPopulate = requestedOption !== '' || '' in this.options ? this.options[requestedOption] : this.options;
+    return BbPromise.resolve(valueToPopulate);
+  }
+
+  getValueFromSelf(variableString: any) {
+    const valueToPopulate = this.json;
+    const deepProperties = variableString.split(':')[1].split('.');
+    return this.getDeepValue(deepProperties, valueToPopulate);
+  }
+
+  getDeepValue(deepProperties: any, valueToPopulate: any) {
+    return BbPromise.reduce(
+      deepProperties,
+      (computedValueToPopulateParam: any, subProperty: any) => {
+        let computedValueToPopulate = computedValueToPopulateParam;
+        if (typeof computedValueToPopulate === 'undefined') {
+          computedValueToPopulate = {};
+        } else if (subProperty !== '' || '' in computedValueToPopulate) {
+          computedValueToPopulate = computedValueToPopulate[subProperty];
+        }
+        if (typeof computedValueToPopulate === 'string' && computedValueToPopulate.match(this.variableSyntax)) {
+          return this.populateProperty(computedValueToPopulate);
+        }
+        return BbPromise.resolve(computedValueToPopulate);
+      },
+      valueToPopulate
+    );
+  }
+
+  warnIfNotFound(variableString: any, valueToPopulate: any): boolean {
+    if (
+      valueToPopulate === null ||
+      typeof valueToPopulate === 'undefined' ||
+      (typeof valueToPopulate === 'object' && lodash.isEmpty(valueToPopulate))
+    ) {
+      let varType;
+      if (variableString.match(this.envRefSyntax)) {
+        varType = 'environment variable';
+      } else if (variableString.match(this.optRefSyntax)) {
+        varType = 'option';
+      } else if (variableString.match(this.selfRefSyntax)) {
+        varType = 'self reference';
+      }
+      this.out.warn(
+        this.out.getErrorPrefix(this.fileName, 'warning') +
+          `A valid ${varType} to satisfy the declaration '${variableString}' could not be found.`
+      );
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/packages/loaders/prisma/src/prisma-yml/__snapshots__/Cluster.test.ts.snap
+++ b/packages/loaders/prisma/src/prisma-yml/__snapshots__/Cluster.test.ts.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`cluster endpoint generation local cluster 1`] = `"http://localhost:4466"`;
+
+exports[`cluster endpoint generation local cluster 2`] = `"http://localhost:4466/dev"`;
+
+exports[`cluster endpoint generation local cluster 3`] = `"http://localhost:4466/default/dev"`;
+
+exports[`cluster endpoint generation local cluster 4`] = `"http://localhost:4466/default/dev"`;
+
+exports[`cluster endpoint generation private cluster 1`] = `"https://test01_workspace.prisma.sh"`;
+
+exports[`cluster endpoint generation private cluster 2`] = `"https://test01_workspace.prisma.sh/dev"`;
+
+exports[`cluster endpoint generation private cluster 3`] = `"https://test01_workspace.prisma.sh/default/dev"`;
+
+exports[`cluster endpoint generation sandbox cluster 1`] = `"https://eu1.prisma.sh/workspace/default/default"`;
+
+exports[`cluster endpoint generation sandbox cluster 2`] = `"https://eu1.prisma.sh/workspace/dev/default"`;
+
+exports[`cluster endpoint generation sandbox cluster 3`] = `"https://eu1.prisma.sh/workspace/default/dev"`;

--- a/packages/loaders/prisma/src/prisma-yml/__snapshots__/Environment.test.ts.snap
+++ b/packages/loaders/prisma/src/prisma-yml/__snapshots__/Environment.test.ts.snap
@@ -1,0 +1,158 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Environment empty global prisma rc 1`] = `
+Array [
+  Object {
+    "baseUrl": "https://eu1.prisma.sh",
+    "clusterSecret": undefined,
+    "isPrivate": false,
+    "local": false,
+    "name": "prisma-eu1",
+    "shared": true,
+    "workspaceSlug": undefined,
+  },
+  Object {
+    "baseUrl": "https://us1.prisma.sh",
+    "clusterSecret": undefined,
+    "isPrivate": false,
+    "local": false,
+    "name": "prisma-us1",
+    "shared": true,
+    "workspaceSlug": undefined,
+  },
+]
+`;
+
+exports[`Environment interpolates env vars 1`] = `
+Array [
+  Object {
+    "baseUrl": "https://eu1.prisma.sh",
+    "clusterSecret": undefined,
+    "isPrivate": false,
+    "local": false,
+    "name": "prisma-eu1",
+    "shared": true,
+    "workspaceSlug": undefined,
+  },
+  Object {
+    "baseUrl": "https://us1.prisma.sh",
+    "clusterSecret": undefined,
+    "isPrivate": false,
+    "local": false,
+    "name": "prisma-us1",
+    "shared": true,
+    "workspaceSlug": undefined,
+  },
+]
+`;
+
+exports[`Environment loads multiple cluster definitions correctly + gives cluster by name 1`] = `
+Array [
+  Object {
+    "baseUrl": "https://eu1.prisma.sh",
+    "clusterSecret": undefined,
+    "isPrivate": false,
+    "local": false,
+    "name": "prisma-eu1",
+    "shared": true,
+    "workspaceSlug": undefined,
+  },
+  Object {
+    "baseUrl": "https://us1.prisma.sh",
+    "clusterSecret": undefined,
+    "isPrivate": false,
+    "local": false,
+    "name": "prisma-us1",
+    "shared": true,
+    "workspaceSlug": undefined,
+  },
+]
+`;
+
+exports[`Environment loads multiple cluster definitions correctly + gives cluster by name 2`] = `undefined`;
+
+exports[`Environment non-existent global prisma rc 1`] = `
+Array [
+  Object {
+    "baseUrl": "https://eu1.prisma.sh",
+    "clusterSecret": undefined,
+    "isPrivate": false,
+    "local": false,
+    "name": "prisma-eu1",
+    "shared": true,
+    "workspaceSlug": undefined,
+  },
+  Object {
+    "baseUrl": "https://us1.prisma.sh",
+    "clusterSecret": undefined,
+    "isPrivate": false,
+    "local": false,
+    "name": "prisma-us1",
+    "shared": true,
+    "workspaceSlug": undefined,
+  },
+]
+`;
+
+exports[`Environment persists .prisma correctly 1`] = `
+"clusters:
+  cluster:
+    host: 'http://localhost:60000'
+    clusterSecret: ''
+"
+`;
+
+exports[`Environment persists .prisma correctly 2`] = `
+Array [
+  Object {
+    "baseUrl": "https://eu1.prisma.sh",
+    "clusterSecret": undefined,
+    "isPrivate": false,
+    "local": false,
+    "name": "prisma-eu1",
+    "shared": true,
+    "workspaceSlug": undefined,
+  },
+  Object {
+    "baseUrl": "https://us1.prisma.sh",
+    "clusterSecret": undefined,
+    "isPrivate": false,
+    "local": false,
+    "name": "prisma-us1",
+    "shared": true,
+    "workspaceSlug": undefined,
+  },
+  Object {
+    "baseUrl": "http://localhost:60000",
+    "clusterSecret": "",
+    "isPrivate": false,
+    "local": true,
+    "name": "cluster",
+    "shared": false,
+    "workspaceSlug": undefined,
+  },
+]
+`;
+
+exports[`Environment sets the platform token correctly 1`] = `
+Array [
+  Object {
+    "baseUrl": "https://eu1.prisma.sh",
+    "clusterSecret": undefined,
+    "isPrivate": false,
+    "local": false,
+    "name": "prisma-eu1",
+    "shared": true,
+    "workspaceSlug": undefined,
+  },
+  Object {
+    "baseUrl": "https://us1.prisma.sh",
+    "clusterSecret": undefined,
+    "isPrivate": false,
+    "local": false,
+    "name": "prisma-us1",
+    "shared": true,
+    "workspaceSlug": undefined,
+  },
+]
+`;

--- a/packages/loaders/prisma/src/prisma-yml/__snapshots__/PrismaDefinition.test.ts.snap
+++ b/packages/loaders/prisma/src/prisma-yml/__snapshots__/PrismaDefinition.test.ts.snap
@@ -1,0 +1,198 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Environment empty global prisma rc 1`] = `
+Array [
+  Object {
+    "baseUrl": "https://eu1.prisma.sh",
+    "clusterSecret": undefined,
+    "isPrivate": false,
+    "local": false,
+    "name": "prisma-eu1",
+    "shared": true,
+    "workspaceSlug": undefined,
+  },
+  Object {
+    "baseUrl": "https://us1.prisma.sh",
+    "clusterSecret": undefined,
+    "isPrivate": false,
+    "local": false,
+    "name": "prisma-us1",
+    "shared": true,
+    "workspaceSlug": undefined,
+  },
+]
+`;
+
+exports[`Environment interpolates env vars 1`] = `
+Array [
+  Object {
+    "baseUrl": "https://eu1.prisma.sh",
+    "clusterSecret": undefined,
+    "isPrivate": false,
+    "local": false,
+    "name": "prisma-eu1",
+    "shared": true,
+    "workspaceSlug": undefined,
+  },
+  Object {
+    "baseUrl": "https://us1.prisma.sh",
+    "clusterSecret": undefined,
+    "isPrivate": false,
+    "local": false,
+    "name": "prisma-us1",
+    "shared": true,
+    "workspaceSlug": undefined,
+  },
+]
+`;
+
+exports[`Environment loads multiple cluster definitions correctly + gives cluster by name 1`] = `
+Array [
+  Object {
+    "baseUrl": "https://eu1.prisma.sh",
+    "clusterSecret": undefined,
+    "isPrivate": false,
+    "local": false,
+    "name": "prisma-eu1",
+    "shared": true,
+    "workspaceSlug": undefined,
+  },
+  Object {
+    "baseUrl": "https://us1.prisma.sh",
+    "clusterSecret": undefined,
+    "isPrivate": false,
+    "local": false,
+    "name": "prisma-us1",
+    "shared": true,
+    "workspaceSlug": undefined,
+  },
+]
+`;
+
+exports[`Environment loads multiple cluster definitions correctly + gives cluster by name 2`] = `undefined`;
+
+exports[`Environment non-existent global prisma rc 1`] = `
+Array [
+  Object {
+    "baseUrl": "https://eu1.prisma.sh",
+    "clusterSecret": undefined,
+    "isPrivate": false,
+    "local": false,
+    "name": "prisma-eu1",
+    "shared": true,
+    "workspaceSlug": undefined,
+  },
+  Object {
+    "baseUrl": "https://us1.prisma.sh",
+    "clusterSecret": undefined,
+    "isPrivate": false,
+    "local": false,
+    "name": "prisma-us1",
+    "shared": true,
+    "workspaceSlug": undefined,
+  },
+]
+`;
+
+exports[`Environment persists .prisma correctly 1`] = `
+"clusters:
+  cluster:
+    host: 'http://localhost:60000'
+    clusterSecret: ''
+"
+`;
+
+exports[`Environment persists .prisma correctly 2`] = `
+Array [
+  Object {
+    "baseUrl": "https://eu1.prisma.sh",
+    "clusterSecret": undefined,
+    "isPrivate": false,
+    "local": false,
+    "name": "prisma-eu1",
+    "shared": true,
+    "workspaceSlug": undefined,
+  },
+  Object {
+    "baseUrl": "https://us1.prisma.sh",
+    "clusterSecret": undefined,
+    "isPrivate": false,
+    "local": false,
+    "name": "prisma-us1",
+    "shared": true,
+    "workspaceSlug": undefined,
+  },
+  Object {
+    "baseUrl": "http://localhost:60000",
+    "clusterSecret": "",
+    "isPrivate": false,
+    "local": true,
+    "name": "cluster",
+    "shared": false,
+    "workspaceSlug": undefined,
+  },
+]
+`;
+
+exports[`Environment sets the platform token correctly 1`] = `
+Array [
+  Object {
+    "baseUrl": "https://eu1.prisma.sh",
+    "clusterSecret": undefined,
+    "isPrivate": false,
+    "local": false,
+    "name": "prisma-eu1",
+    "shared": true,
+    "workspaceSlug": undefined,
+  },
+  Object {
+    "baseUrl": "https://us1.prisma.sh",
+    "clusterSecret": undefined,
+    "isPrivate": false,
+    "local": false,
+    "name": "prisma-us1",
+    "shared": true,
+    "workspaceSlug": undefined,
+  },
+]
+`;
+
+exports[`prisma definition dont load yml with secret and env var in args 1`] = `
+[Error: Invalid prisma.yml file
+prisma.yml should NOT have additional properties. additionalProperty: service]
+`;
+
+exports[`prisma definition load basic yml, provide cluster 1`] = `
+[Error: Invalid prisma.yml file
+prisma.yml should NOT have additional properties. additionalProperty: service]
+`;
+
+exports[`prisma definition load yml with disableAuth: true 1`] = `
+[Error: Invalid prisma.yml file
+prisma.yml should NOT have additional properties. additionalProperty: service]
+`;
+
+exports[`prisma definition load yml with injected env var 1`] = `
+[Error: Invalid prisma.yml file
+prisma.yml should NOT have additional properties. additionalProperty: service]
+`;
+
+exports[`prisma definition load yml with secret and env var 1`] = `
+[Error: Invalid prisma.yml file
+prisma.yml should NOT have additional properties. additionalProperty: service]
+`;
+
+exports[`prisma definition load yml with secret and env var in .env 1`] = `
+[Error: Invalid prisma.yml file
+prisma.yml should NOT have additional properties. additionalProperty: service]
+`;
+
+exports[`prisma definition throw when no secret or disable auth provided 1`] = `
+[Error: Invalid prisma.yml file
+prisma.yml should NOT have additional properties. additionalProperty: service]
+`;
+
+exports[`prisma definition throws when stages key apparent 1`] = `
+[Error: Invalid prisma.yml file
+prisma.yml should NOT have additional properties. additionalProperty: service]
+`;

--- a/packages/loaders/prisma/src/prisma-yml/constants.ts
+++ b/packages/loaders/prisma/src/prisma-yml/constants.ts
@@ -1,0 +1,10 @@
+import { invert } from 'lodash';
+
+export const cloudApiEndpoint = process.env.CLOUD_API_ENDPOINT || 'https://api.cloud.prisma.sh';
+
+export const clusterEndpointMap: { [key: string]: string } = {
+  'prisma-eu1': 'https://eu1.prisma.sh',
+  'prisma-us1': 'https://us1.prisma.sh',
+};
+
+export const clusterEndpointMapReverse: { [key: string]: string } = invert(clusterEndpointMap);

--- a/packages/loaders/prisma/src/prisma-yml/errors/ClusterNotFound.ts
+++ b/packages/loaders/prisma/src/prisma-yml/errors/ClusterNotFound.ts
@@ -1,0 +1,5 @@
+export class ClusterNotFound extends Error {
+  constructor(name: string) {
+    super(`Cluster '${name}' is neither a known shared cluster nor defined in your global .prismarc.`);
+  }
+}

--- a/packages/loaders/prisma/src/prisma-yml/errors/ClusterNotSet.ts
+++ b/packages/loaders/prisma/src/prisma-yml/errors/ClusterNotSet.ts
@@ -1,0 +1,5 @@
+export class ClusterNotSet extends Error {
+  constructor() {
+    super(`No cluster set. In order to run this command, please set the "cluster" property in your prisma.yml`);
+  }
+}

--- a/packages/loaders/prisma/src/prisma-yml/errors/StageNotFound.ts
+++ b/packages/loaders/prisma/src/prisma-yml/errors/StageNotFound.ts
@@ -1,0 +1,9 @@
+export class StageNotFound extends Error {
+  constructor(name?: string) {
+    if (name) {
+      super(`Stage '${name}' could not be found in the local prisma.yml`);
+    } else {
+      super(`No stage provided and no default stage set`);
+    }
+  }
+}

--- a/packages/loaders/prisma/src/prisma-yml/index.ts
+++ b/packages/loaders/prisma/src/prisma-yml/index.ts
@@ -1,0 +1,12 @@
+export { parseEndpoint } from './utils/parseEndpoint';
+export { Cluster } from './Cluster';
+export { PrismaDefinitionClass } from './PrismaDefinition';
+export { Environment } from './Environment';
+export { Args } from './types/common';
+export { ClusterNotFound } from './errors/ClusterNotFound';
+export { ClusterNotSet } from './errors/ClusterNotSet';
+export { StageNotFound } from './errors/StageNotFound';
+export { Output, IOutput } from './Output';
+export { Variables } from './Variables';
+export { RC, Clusters, ClusterConfig, FunctionInput } from './types/rc';
+export { getProxyAgent } from './utils/getProxyAgent';

--- a/packages/loaders/prisma/src/prisma-yml/prisma-json-schema.ts
+++ b/packages/loaders/prisma/src/prisma-yml/prisma-json-schema.ts
@@ -1,0 +1,158 @@
+export interface PrismaDefinition {
+  datamodel?: string | string[];
+  subscriptions?: SubscriptionMap;
+  custom?: any;
+  secret?: string;
+  disableAuth?: boolean;
+  seed?: Seed;
+  endpoint?: string;
+  hooks?: any;
+  generate?: Generate[];
+  databaseType?: DatabaseType;
+}
+
+export type DatabaseType = 'relational' | 'document';
+
+export interface Generate {
+  generator: string;
+  output: string;
+}
+
+export interface Seed {
+  import?: string;
+  run?: string;
+}
+
+export interface SubscriptionMap {
+  [subscriptionName: string]: SubscriptionDefinition;
+}
+
+export interface SubscriptionDefinition {
+  query: string;
+  webhook: FunctionHandlerWebhookSource;
+}
+
+export type FunctionHandlerWebhookSource = string | FunctionHandlerWebhookWithHeaders;
+
+export interface FunctionHandlerWebhookWithHeaders {
+  url: string;
+  headers?: Headers;
+}
+
+export interface Headers {
+  [key: string]: string;
+}
+
+const schema = JSON.parse(`{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "JSON schema for Prisma prisma.yml files",
+  "definitions": {
+    "subscription": {
+      "description": "A piece of code that you should run.",
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string"
+        },
+        "webhook": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": "string"
+                },
+                "headers": {
+                  "type": "object"
+                }
+              },
+              "required": ["url"]
+            }
+          ]
+        }
+      },
+      "required": ["query", "webhook"]
+    }
+  },
+  "properties": {
+    "datamodel": {
+      "description": "Type definitions for database models, relations, enums and other types",
+      "type": ["string", "array"],
+      "items": {
+        "type": ["string", "array"]
+      }
+    },
+    "secret": {
+      "description": "Secret for securing the API Endpoint",
+      "type": "string",
+      "items": {
+        "type": "string"
+      }
+    },
+    "disableAuth": {
+      "description": "Disable authentication for the endpoint",
+      "type": "boolean",
+      "items": {
+        "type": "boolean"
+      }
+    },
+    "generate": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "generator": {
+            "type": "string"
+          },
+          "output": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "seed": {
+      "description": "Database seed",
+      "type": "object",
+      "properties": {
+        "import": {
+          "type": "string"
+        },
+        "run": {
+          "type": "string"
+        }
+      }
+    },
+    "subscriptions": {
+      "description": "All server-side subscriptions",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/subscription"
+      }
+    },
+    "custom": {
+      "description": "Custom field to use in variable interpolations with \${self:custom.field}",
+      "type": "object"
+    },
+    "hooks": {
+      "description": "Command hooks. Current available hooks are: post-deploy.",
+      "type": "object"
+    },
+    "endpoint": {
+      "description": "Endpoint the service will be reachable at. This also determines the cluster the service will deployed to.",
+      "type": "string",
+      "items": {
+        "type": "string"
+      }
+    },
+    "databaseType": {
+      "type": "string",
+      "oneOf": [{ "enum": ["relational", "document"] }]
+    }
+  },
+  "additionalProperties": false
+}`);
+
+export default schema;

--- a/packages/loaders/prisma/src/prisma-yml/test/getTmpDir.ts
+++ b/packages/loaders/prisma/src/prisma-yml/test/getTmpDir.ts
@@ -1,0 +1,12 @@
+import * as os from 'os';
+// eslint-disable-next-line
+// @ts-ignore
+import cuid from 'scuid';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+
+export const getTmpDir = () => {
+  const dir = path.join(os.tmpdir(), cuid() + '/');
+  fs.mkdirpSync(dir);
+  return dir;
+};

--- a/packages/loaders/prisma/src/prisma-yml/types/common.ts
+++ b/packages/loaders/prisma/src/prisma-yml/types/common.ts
@@ -1,0 +1,3 @@
+export interface Args {
+  [name: string]: string | boolean;
+}

--- a/packages/loaders/prisma/src/prisma-yml/types/rc.ts
+++ b/packages/loaders/prisma/src/prisma-yml/types/rc.ts
@@ -1,0 +1,25 @@
+export interface RC {
+  cloudSessionKey?: string;
+  clusters?: Clusters;
+}
+
+export interface Clusters {
+  [name: string]: ClusterConfig;
+}
+
+export interface ClusterConfig {
+  host: string;
+  clusterSecret: string;
+}
+
+export interface Header {
+  name: string;
+  value: string;
+}
+
+export interface FunctionInput {
+  name: string;
+  query: string;
+  url: string;
+  headers: Header[];
+}

--- a/packages/loaders/prisma/src/prisma-yml/utils/__snapshots__/parseEndpoint.test.ts.snap
+++ b/packages/loaders/prisma/src/prisma-yml/utils/__snapshots__/parseEndpoint.test.ts.snap
@@ -1,0 +1,131 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`parseEndpoint custom hosted url as ip in internet 1`] = `
+Object {
+  "clusterBaseUrl": "http://13.228.39.83:4466",
+  "clusterName": "default",
+  "isPrivate": true,
+  "local": false,
+  "service": "default",
+  "shared": false,
+  "stage": "default",
+  "workspaceSlug": null,
+}
+`;
+
+exports[`parseEndpoint custom hosted url in internet 1`] = `
+Object {
+  "clusterBaseUrl": "https://api-prisma.divyendusingh.com",
+  "clusterName": "default",
+  "isPrivate": true,
+  "local": false,
+  "service": "zebra-4069",
+  "shared": false,
+  "stage": "dev",
+  "workspaceSlug": null,
+}
+`;
+
+exports[`parseEndpoint local behind a proxy 1`] = `
+Object {
+  "clusterBaseUrl": "http://local.dev",
+  "clusterName": "default",
+  "isPrivate": true,
+  "local": false,
+  "service": "default",
+  "shared": false,
+  "stage": "default",
+  "workspaceSlug": null,
+}
+`;
+
+exports[`parseEndpoint private url 1`] = `
+Object {
+  "clusterBaseUrl": "https://test1_workspace.prisma.sh",
+  "clusterName": "test1",
+  "isPrivate": true,
+  "local": false,
+  "service": "tessst",
+  "shared": false,
+  "stage": "dev",
+  "workspaceSlug": "workspace",
+}
+`;
+
+exports[`parseEndpoint shared url 1`] = `
+Object {
+  "clusterBaseUrl": "https://eu1.prisma.sh",
+  "clusterName": "prisma-eu1",
+  "isPrivate": false,
+  "local": false,
+  "service": "tessst",
+  "shared": true,
+  "stage": "dev",
+  "workspaceSlug": "workspace-name",
+}
+`;
+
+exports[`parseEndpoint url on a subdomain 1`] = `
+Object {
+  "clusterBaseUrl": "https://db.cloud.prisma.sh",
+  "clusterName": "db.cloud.prisma.sh",
+  "isPrivate": true,
+  "local": false,
+  "service": "test-token",
+  "shared": false,
+  "stage": "test",
+  "workspaceSlug": null,
+}
+`;
+
+exports[`parseEndpoint work for minimal docker url 1`] = `
+Object {
+  "clusterBaseUrl": "http://prisma:4466",
+  "clusterName": "default",
+  "isPrivate": false,
+  "local": true,
+  "service": "default",
+  "shared": false,
+  "stage": "default",
+  "workspaceSlug": null,
+}
+`;
+
+exports[`parseEndpoint work for minimal url 1`] = `
+Object {
+  "clusterBaseUrl": "http://localhost:4466",
+  "clusterName": "local",
+  "isPrivate": false,
+  "local": true,
+  "service": "default",
+  "shared": false,
+  "stage": "default",
+  "workspaceSlug": null,
+}
+`;
+
+exports[`parseEndpoint work for url with service 1`] = `
+Object {
+  "clusterBaseUrl": "http://localhost:4466",
+  "clusterName": "local",
+  "isPrivate": false,
+  "local": true,
+  "service": "service-name",
+  "shared": false,
+  "stage": "default",
+  "workspaceSlug": null,
+}
+`;
+
+exports[`parseEndpoint work for url with service and stage 1`] = `
+Object {
+  "clusterBaseUrl": "http://localhost:4466",
+  "clusterName": "local",
+  "isPrivate": false,
+  "local": true,
+  "service": "service-name",
+  "shared": false,
+  "stage": "stage",
+  "workspaceSlug": null,
+}
+`;

--- a/packages/loaders/prisma/src/prisma-yml/utils/__snapshots__/yamlComment.test.ts.snap
+++ b/packages/loaders/prisma/src/prisma-yml/utils/__snapshots__/yamlComment.test.ts.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`migrateToEndpoint ignore when endpoint present 1`] = `
+Object {
+  "input": "endpoint: https://eu1.prisma.sh/public-asdf/my-service/dev
+datamodel: datamodel.prisma",
+  "output": "#endpoint: https://eu1.prisma.sh/public-asdf/my-service/dev
+endpoint: 
+datamodel: datamodel.prisma",
+}
+`;
+
+exports[`migrateToEndpoint work in simple case 1`] = `
+Object {
+  "input": "service: my-service
+stage: dev
+cluster: public-asdf/prisma-eu1
+datamodel: datamodel.prisma",
+  "output": "#service: my-service
+#stage: dev
+#cluster: public-asdf/prisma-eu1
+datamodel: datamodel.prisma
+endpoint: https://eu1.prisma.sh/public-asdf/my-service/dev
+",
+}
+`;
+
+exports[`migrateToEndpoint work with different order and respect comments 1`] = `
+Object {
+  "input": "# don't delete me
+stage: dev
+cluster: public-asdf/prisma-eu1
+
+service: my-service
+
+
+
+datamodel: datamodel.prisma",
+  "output": "# don't delete me
+#stage: dev
+#cluster: public-asdf/prisma-eu1
+
+#service: my-service
+
+
+
+datamodel: datamodel.prisma
+endpoint: https://eu1.prisma.sh/public-asdf/my-service/dev
+",
+}
+`;
+
+exports[`replaceYamlValue when comments already exist 1`] = `
+Object {
+  "input": "#anothercomment: asdasd
+endpoint: https://eu1.prisma.sh/public-asdf/my-service/dev
+
+#endpoint: asdasd
+datamodel: datamodel.prisma",
+  "output": "#anothercomment: asdasd
+#endpoint: https://eu1.prisma.sh/public-asdf/my-service/dev
+endpoint: http://localhost:4466
+
+#endpoint: asdasd
+datamodel: datamodel.prisma",
+}
+`;
+
+exports[`replaceYamlValue when document is clean 1`] = `
+Object {
+  "input": "endpoint: https://eu1.prisma.sh/public-asdf/my-service/dev
+datamodel: datamodel.prisma",
+  "output": "#endpoint: https://eu1.prisma.sh/public-asdf/my-service/dev
+endpoint: http://localhost:4466
+datamodel: datamodel.prisma",
+}
+`;
+
+exports[`replaceYamlValue when key does not yet exist 1`] = `
+Object {
+  "input": "datamodel: datamodel.prisma",
+  "output": "datamodel: datamodel.prisma
+endpoint: http://localhost:4466
+",
+}
+`;

--- a/packages/loaders/prisma/src/prisma-yml/utils/getProxyAgent.ts
+++ b/packages/loaders/prisma/src/prisma-yml/utils/getProxyAgent.ts
@@ -1,0 +1,103 @@
+'use strict';
+
+import HttpsProxyAgent from 'https-proxy-agent';
+import HttpProxyAgent from 'http-proxy-agent';
+import { Agent as HttpsAgent } from 'https';
+import { Agent as HttpAgent } from 'http';
+
+// code from https://raw.githubusercontent.com/request/request/5ba8eb44da7cd639ca21070ea9be20d611b85f66/lib/getProxyFromURI.js
+
+function formatHostname(hostname: any) {
+  // canonicalize the hostname, so that 'oogle.com' won't match 'google.com'
+  return hostname.replace(/^\.*/, '.').toLowerCase();
+}
+
+function parseNoProxyZone(zone: any) {
+  zone = zone.trim().toLowerCase();
+
+  const zoneParts = zone.split(':', 2);
+  const zoneHost = formatHostname(zoneParts[0]);
+  const zonePort = zoneParts[1];
+  const hasPort = zone.indexOf(':') > -1;
+
+  return { hostname: zoneHost, port: zonePort, hasPort: hasPort };
+}
+
+function uriInNoProxy(uri: any, noProxy: any) {
+  const port = uri.port || (uri.protocol === 'https:' ? '443' : '80');
+  const hostname = formatHostname(uri.hostname);
+  const noProxyList = noProxy.split(',');
+
+  // iterate through the noProxyList until it finds a match.
+  return noProxyList.map(parseNoProxyZone).some(function (noProxyZone: any) {
+    const isMatchedAt = hostname.indexOf(noProxyZone.hostname);
+    const hostnameMatched = isMatchedAt > -1 && isMatchedAt === hostname.length - noProxyZone.hostname.length;
+
+    if (noProxyZone.hasPort) {
+      return port === noProxyZone.port && hostnameMatched;
+    }
+
+    return hostnameMatched;
+  });
+}
+
+function getProxyFromURI(uri: any) {
+  // Decide the proper request proxy to use based on the request URI object and the
+  // environmental variables (NO_PROXY, HTTP_PROXY, etc.)
+  // respect NO_PROXY environment variables (see: http://lynx.isc.org/current/breakout/lynx_help/keystrokes/environments.html)
+
+  const noProxy = process.env.NO_PROXY || process.env.no_proxy || '';
+
+  // if the noProxy is a wildcard then return null
+
+  if (noProxy === '*') {
+    return null;
+  }
+
+  // if the noProxy is not empty and the uri is found return null
+
+  if (noProxy !== '' && uriInNoProxy(uri, noProxy)) {
+    return null;
+  }
+
+  // Check for HTTP or HTTPS Proxy in environment Else default to null
+
+  if (uri.protocol === 'http:') {
+    return process.env.HTTP_PROXY || process.env.http_proxy || null;
+  }
+
+  if (uri.protocol === 'https:') {
+    return (
+      process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy || null
+    );
+  }
+
+  // if none of that works, return null
+  // (What uri protocol are you using then?)
+
+  return null;
+}
+
+export function getProxyAgent(url: string): HttpAgent | HttpsAgent | undefined {
+  const uri = new URL(url);
+  const proxy = getProxyFromURI(uri);
+  if (!proxy) {
+    return undefined;
+  }
+
+  const proxyUri = new URL(proxy);
+
+  if (proxyUri.protocol === 'http:') {
+    // eslint-disable-next-line
+    // @ts-ignore
+    return new HttpProxyAgent(proxy) as HttpAgent;
+  }
+
+  if (proxyUri.protocol === 'https:') {
+    // eslint-disable-next-line
+    // @ts-ignore
+    return new HttpsProxyAgent(proxy) as HttpsAgent;
+  }
+
+  return undefined;
+}

--- a/packages/loaders/prisma/src/prisma-yml/utils/parseEndpoint.test.ts
+++ b/packages/loaders/prisma/src/prisma-yml/utils/parseEndpoint.test.ts
@@ -1,0 +1,36 @@
+import { parseEndpoint } from './parseEndpoint';
+
+describe('parseEndpoint', () => {
+  test('work for minimal url', () => {
+    expect(parseEndpoint('http://localhost:4466')).toMatchSnapshot();
+  });
+  test('work for minimal docker url', () => {
+    expect(parseEndpoint('http://prisma:4466')).toMatchSnapshot();
+  });
+  test('local behind a proxy', () => {
+    // This snapshot will be incorrect for now as URL does not have enough
+    // information to detemine if something is truly local
+    expect(parseEndpoint('http://local.dev')).toMatchSnapshot();
+  });
+  test('work for url with service', () => {
+    expect(parseEndpoint('http://localhost:4466/service-name')).toMatchSnapshot();
+  });
+  test('work for url with service and stage', () => {
+    expect(parseEndpoint('http://localhost:4466/service-name/stage')).toMatchSnapshot();
+  });
+  test('private url', () => {
+    expect(parseEndpoint('https://test1_workspace.prisma.sh/tessst/dev')).toMatchSnapshot();
+  });
+  test('shared url', () => {
+    expect(parseEndpoint('https://eu1.prisma.sh/workspace-name/tessst/dev')).toMatchSnapshot();
+  });
+  test('custom hosted url in internet', () => {
+    expect(parseEndpoint('https://api-prisma.divyendusingh.com/zebra-4069/dev')).toMatchSnapshot();
+  });
+  test('custom hosted url as ip in internet', () => {
+    expect(parseEndpoint('http://13.228.39.83:4466')).toMatchSnapshot();
+  });
+  test('url on a subdomain', () => {
+    expect(parseEndpoint('https://db.cloud.prisma.sh/test-token/test')).toMatchSnapshot();
+  });
+});

--- a/packages/loaders/prisma/src/prisma-yml/utils/parseEndpoint.ts
+++ b/packages/loaders/prisma/src/prisma-yml/utils/parseEndpoint.ts
@@ -1,0 +1,82 @@
+import { clusterEndpointMapReverse } from '../constants';
+import { URL } from 'url';
+
+function getClusterName(origin: any): string {
+  if (clusterEndpointMapReverse[origin]) {
+    return clusterEndpointMapReverse[origin];
+  }
+
+  if (origin.endsWith('prisma.sh')) {
+    return origin.split('_')[0].replace(/https?:\/\//, '');
+  }
+
+  if (isLocal(origin)) {
+    return 'local';
+  }
+
+  return 'default';
+}
+
+const getWorkspaceFromPrivateOrigin = (origin: string) => {
+  const split = origin.split('_');
+  if (split.length > 1) {
+    return split[1].split('.')[0];
+  }
+
+  return null;
+};
+
+const isLocal = (origin: any) => origin.includes('localhost') || origin.includes('127.0.0.1');
+
+export interface ParseEndpointResult {
+  service: string;
+  clusterBaseUrl: string;
+  stage: string;
+  isPrivate: boolean;
+  local: boolean;
+  shared: boolean;
+  workspaceSlug: string | null;
+  clusterName: string;
+}
+
+export function parseEndpoint(endpoint: string): ParseEndpointResult {
+  /*
+    Terminology:
+      local - hosted locally using docker and accessed using localhost or prisma or local web proxy like domain.dev
+      shared - demo server
+      isPrivate - private hosted by Prisma or private and self-hosted, important that in our terminology a local server is not private
+  */
+
+  const url = new URL(endpoint);
+  const splittedPath = url.pathname.split('/');
+  // assuming, that the pathname always starts with a leading /, we always can ignore the first element of the split array
+  const service = splittedPath.length > 3 ? splittedPath[2] : splittedPath[1] || 'default';
+  const stage = splittedPath.length > 3 ? splittedPath[3] : splittedPath[2] || 'default';
+
+  // This logic might break for self-hosted servers incorrectly yielding a "workspace" simply if the UX has
+  // enough "/"es like if https://custom.dev/not-a-workspace/ is the base Prisma URL then for default/default service/stage
+  // pair. This function would incorrectly return not-a-workspace as a workspace.
+  let workspaceSlug = splittedPath.length > 3 ? splittedPath[1] : null;
+
+  const shared = ['eu1.prisma.sh', 'us1.prisma.sh'].includes(url.host);
+
+  // When using localAliases, do an exact match because of 'prisma' option which is added for local docker networking access
+  const localAliases = ['localhost', '127.0.0.1', 'prisma'];
+  const isPrivate = !shared && !localAliases.includes(url.hostname);
+  const local = !shared && !isPrivate && !workspaceSlug;
+
+  if (isPrivate && !workspaceSlug) {
+    workspaceSlug = getWorkspaceFromPrivateOrigin(url.origin);
+  }
+
+  return {
+    clusterBaseUrl: url.origin,
+    service,
+    stage,
+    local,
+    isPrivate,
+    shared,
+    workspaceSlug,
+    clusterName: getClusterName(url.origin),
+  };
+}

--- a/packages/loaders/prisma/src/prisma-yml/utils/yamlComment.test.ts
+++ b/packages/loaders/prisma/src/prisma-yml/utils/yamlComment.test.ts
@@ -1,0 +1,76 @@
+import { replaceYamlValue, migrateToEndpoint } from './yamlComment';
+
+describe('replaceYamlValue', () => {
+  test('when document is clean', () => {
+    const input = `\
+endpoint: https://eu1.prisma.sh/public-asdf/my-service/dev
+datamodel: datamodel.prisma`;
+
+    const output = replaceYamlValue(input, 'endpoint', 'http://localhost:4466');
+
+    expect({ input, output }).toMatchSnapshot();
+  });
+
+  test('when comments already exist', () => {
+    const input = `\
+#anothercomment: asdasd
+endpoint: https://eu1.prisma.sh/public-asdf/my-service/dev
+
+#endpoint: asdasd
+datamodel: datamodel.prisma`;
+
+    const output = replaceYamlValue(input, 'endpoint', 'http://localhost:4466');
+
+    expect({ input, output }).toMatchSnapshot();
+  });
+
+  test('when key does not yet exist', () => {
+    const input = `\
+datamodel: datamodel.prisma`;
+
+    const output = replaceYamlValue(input, 'endpoint', 'http://localhost:4466');
+
+    expect({ input, output }).toMatchSnapshot();
+  });
+});
+
+describe('migrateToEndpoint', () => {
+  test('ignore when endpoint present', () => {
+    const input = `\
+endpoint: https://eu1.prisma.sh/public-asdf/my-service/dev
+datamodel: datamodel.prisma`;
+
+    const output = migrateToEndpoint(input, '');
+
+    expect({ input, output }).toMatchSnapshot();
+  });
+
+  test('work in simple case', () => {
+    const input = `\
+service: my-service
+stage: dev
+cluster: public-asdf/prisma-eu1
+datamodel: datamodel.prisma`;
+
+    const output = migrateToEndpoint(input, 'https://eu1.prisma.sh/public-asdf/my-service/dev');
+
+    expect({ input, output }).toMatchSnapshot();
+  });
+
+  test('work with different order and respect comments', () => {
+    const input = `\
+# don't delete me
+stage: dev
+cluster: public-asdf/prisma-eu1
+
+service: my-service
+
+
+
+datamodel: datamodel.prisma`;
+
+    const output = migrateToEndpoint(input, 'https://eu1.prisma.sh/public-asdf/my-service/dev');
+
+    expect({ input, output }).toMatchSnapshot();
+  });
+});

--- a/packages/loaders/prisma/src/prisma-yml/utils/yamlComment.ts
+++ b/packages/loaders/prisma/src/prisma-yml/utils/yamlComment.ts
@@ -1,0 +1,52 @@
+import * as yamlParser from 'yaml-ast-parser';
+/**
+ * Comments out the current entry of a specific key in a yaml document and creates a new value next to it
+ * @param key key in yaml document to comment out
+ * @param newValue new value to add in the document
+ */
+export function replaceYamlValue(input: any, key: any, newValue: any) {
+  const ast = yamlParser.safeLoad(input);
+  const position = getPosition(ast, key);
+  const newEntry = `${key}: ${newValue}\n`;
+  if (!position) {
+    return input + '\n' + newEntry;
+  }
+
+  return (
+    input.slice(0, position.start) +
+    '#' +
+    input.slice(position.start, position.end) +
+    newEntry +
+    input.slice(position.end)
+  );
+}
+
+function getPosition(ast: any, key: string): { start: number; end: number } | undefined {
+  const mapping = ast.mappings.find((m: any) => m.key.value === key);
+  if (!mapping) {
+    return undefined;
+  }
+  return {
+    start: mapping.startPosition,
+    end: mapping.endPosition + 1,
+  };
+}
+
+function commentOut(input: string, keys: string[]) {
+  let output = input;
+  for (const key of keys) {
+    const ast = yamlParser.safeLoad(output);
+    const position = getPosition(ast, key);
+
+    if (position) {
+      output = output.slice(0, position.start) + '#' + output.slice(position.start);
+    }
+  }
+
+  return output;
+}
+
+export function migrateToEndpoint(input: any, endpoint: any) {
+  const output = commentOut(input, ['service', 'stage', 'cluster']);
+  return replaceYamlValue(output, 'endpoint', endpoint);
+}

--- a/packages/loaders/prisma/src/prisma-yml/yaml.ts
+++ b/packages/loaders/prisma/src/prisma-yml/yaml.ts
@@ -1,0 +1,77 @@
+import Ajv from 'ajv';
+import * as yaml from 'js-yaml';
+import * as fs from 'fs-extra';
+import schema, { PrismaDefinition } from './prisma-json-schema';
+import { Variables } from './Variables';
+import { Args } from './types/common';
+import { Output, IOutput } from './Output';
+import stringify from 'json-stable-stringify';
+const debug = require('debug')('yaml');
+
+const ajv = new Ajv();
+
+const validate = ajv.compile(schema);
+// this is used by the playground, which accepts additional properties
+const validateGraceful = ajv.compile({ ...schema, additionalProperties: true });
+
+const cache = {};
+
+export async function readDefinition(
+  filePath: string,
+  args: Args,
+  out: IOutput = new Output(),
+  envVars?: any,
+  graceful?: boolean
+): Promise<{ definition: PrismaDefinition; rawJson: any }> {
+  if (!fs.pathExistsSync(filePath)) {
+    throw new Error(`${filePath} could not be found.`);
+  }
+  const file = fs.readFileSync(filePath, 'utf-8');
+  const json = yaml.safeLoad(file) as PrismaDefinition;
+  // we need this copy because populateJson runs inplace
+  const jsonCopy = { ...json };
+
+  const vars = new Variables(filePath, args, out, envVars);
+  const populatedJson = await vars.populateJson(json);
+  if (populatedJson.custom) {
+    delete populatedJson.custom;
+  }
+  const valid = graceful ? validateGraceful(populatedJson) : validate(populatedJson);
+  // TODO activate as soon as the backend sends valid yaml
+  if (!valid) {
+    const errorMessage =
+      `Invalid prisma.yml file` + '\n' + printErrors(graceful ? validateGraceful.errors! : validate.errors!);
+    throw new Error(errorMessage);
+  }
+
+  cache[file] = populatedJson;
+  return {
+    definition: populatedJson,
+    rawJson: jsonCopy,
+  };
+}
+
+function printErrors(errors: any, name = 'prisma.yml') {
+  return errors
+    .map((e: any) => {
+      const paramsKey = stringify(e.params);
+      if (betterMessagesByParams[paramsKey]) {
+        return betterMessagesByParams[paramsKey];
+      }
+      const params = Object.keys(e.params)
+        .map(key => `${key}: ${e.params[key]}`)
+        .join(', ');
+      debug(stringify(e.params));
+      return `${name}${e.dataPath} ${e.message}. ${params}`;
+    })
+    .join('\n');
+}
+
+const betterMessagesByParams = {
+  // this is not up-to-date, stages are in again!
+  // https://github.com/prisma/framework/issues/1461
+  '{"additionalProperty":"stages"}':
+    'prisma.yml should NOT have a "stages" property anymore. Stages are now just provided as CLI args.\nRead more here: https://goo.gl/SUD5i5',
+  '{"additionalProperty":"types"}':
+    'prisma.yml should NOT have a "types" property anymore. It has been renamed to "datamodel"',
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2022,6 +2022,11 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@tootallnate/once@1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
+  integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+
 "@types/accepts@*", "@types/accepts@^1.3.5":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/accepts/-/accepts-1.3.5.tgz#c34bec115cfc746e04fe5a059df4ce7e7b391575"
@@ -2213,6 +2218,13 @@
   resolved "https://registry.yarnpkg.com/@types/http-assert/-/http-assert-1.5.1.tgz#d775e93630c2469c2f980fc27e3143240335db3b"
   integrity sha512-PGAK759pxyfXE78NbKxyfRcWYA/KwW17X290cNev/qAsn9eQIxkH4shoNBafH37wewhDG/0p1cHPbK6+SzZjWQ==
 
+"@types/http-proxy-agent@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@types/http-proxy-agent/-/http-proxy-agent-2.0.2.tgz#942c1f35c7e1f0edd1b6ffae5d0f9051cfb32be1"
+  integrity sha512-2S6IuBRhqUnH1/AUx9k8KWtY3Esg4eqri946MnxTG5HwehF1S5mqLln8fcyMiuQkY72p2gH3W+rIPqp5li0LyQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/is-glob@4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/is-glob/-/is-glob-4.0.1.tgz#a93eec1714172c8eb3225a1cc5eb88c2477b7d00"
@@ -2246,15 +2258,32 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
+"@types/js-yaml@^3.12.5":
+  version "3.12.5"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-3.12.5.tgz#136d5e6a57a931e1cce6f9d8126aa98a9c92a6bb"
+  integrity sha512-JCcp6J0GV66Y4ZMDAQCXot4xprYB+Zfd3meK9+INSJeVZwJmHAW30BBEEkPzXswMXuiyReUGOP3GxrADc9wPww==
+
 "@types/json-schema@^7.0.3":
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
+"@types/json-stable-stringify@^1.0.32":
+  version "1.0.32"
+  resolved "https://registry.yarnpkg.com/@types/json-stable-stringify/-/json-stable-stringify-1.0.32.tgz#121f6917c4389db3923640b2e68de5fa64dda88e"
+  integrity sha512-q9Q6+eUEGwQkv4Sbst3J4PNgDOvpuVuKj79Hl/qnmBMEIPzB5QoFRUtjcgcg2xNUZyYUGXBk5wYIBKHt0A+Mxw==
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
+"@types/jsonwebtoken@^8.5.0":
+  version "8.5.0"
+  resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-8.5.0.tgz#2531d5e300803aa63279b232c014acf780c981c5"
+  integrity sha512-9bVao7LvyorRGZCw0VmH/dr7Og+NdjYSsKAxB43OQoComFbBgsEpoR9JW6+qSq/ogwVBg8GI2MfAlk4SYI4OLg==
+  dependencies:
+    "@types/node" "*"
 
 "@types/keygrip@*":
   version "1.0.2"
@@ -2765,12 +2794,12 @@ address@1.1.2, address@^1.0.1:
   resolved "https://registry.yarnpkg.com/address/-/address-1.1.2.tgz#bf1116c9c758c51b7a933d296b72c221ed9428b6"
   integrity sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==
 
-agent-base@4, agent-base@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"
-  integrity sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==
+agent-base@6:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.1.tgz#808007e4e5867decb0ab6ab2f928fbdb5a596db4"
+  integrity sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==
   dependencies:
-    es6-promisify "^5.0.0"
+    debug "4"
 
 aggregate-error@3.0.1, aggregate-error@^3.0.0:
   version "3.0.1"
@@ -2790,20 +2819,20 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.1.tgz#ef916e271c64ac12171fd8384eaae6b2345854da"
   integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
 
-ajv@5:
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
-  integrity sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=
-  dependencies:
-    co "^4.6.0"
-    fast-deep-equal "^1.0.0"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.3.0"
-
 ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.0, ajv@^6.5.5:
   version "6.12.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.2.tgz#c629c5eced17baf314437918d2da88c99d5958cd"
   integrity sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^6.12.3:
+  version "6.12.3"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.3.tgz#18c5af38a111ddeb4f2697bd78d68abc1cabd706"
+  integrity sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -3521,7 +3550,7 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
-bluebird@^3.5.1, bluebird@^3.5.5, bluebird@^3.7.1:
+bluebird@^3.5.5, bluebird@^3.7.1, bluebird@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -3985,7 +4014,7 @@ ccount@^1.0.0, ccount@^1.0.3:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-1.0.5.tgz#ac82a944905a65ce204eb03023157edf29425c17"
   integrity sha512-MOli1W+nfbPLlKEhInaxhRdp7KVLFxLN5ykwzHgLsLI3H3gs5jjFAK4Eoj3OzzcxCtumDaI8onoVDeQyWaNTkw==
 
-chalk@2.4.2, chalk@^2.0.0, chalk@^2.3.0, chalk@^2.4.1, chalk@^2.4.2:
+chalk@2.4.2, chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -4602,14 +4631,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-fetch@2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-2.2.2.tgz#a47ff4f7fc712daba8f6a695a11c948440d45723"
-  integrity sha1-pH/09/xxLauo9qaVoRyUhEDUVyM=
-  dependencies:
-    node-fetch "2.1.2"
-    whatwg-fetch "2.0.4"
-
 cross-fetch@3.0.5:
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.5.tgz#2739d2981892e7ab488a7ad03b92df2816e03f4c"
@@ -4936,24 +4957,17 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
-    ms "2.0.0"
+    ms "^2.1.1"
 
 debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 
@@ -5317,10 +5331,10 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
-dotenv@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
-  integrity sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=
+dotenv@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
 duplexer3@^0.1.4:
   version "0.1.4"
@@ -5517,18 +5531,6 @@ es6-iterator@~2.0.3:
     d "1"
     es5-ext "^0.10.35"
     es6-symbol "^3.1.1"
-
-es6-promise@^4.0.3:
-  version "4.2.8"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
-  integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
-
-es6-promisify@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
-  integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
-  dependencies:
-    es6-promise "^4.0.3"
 
 es6-symbol@^3.1.1, es6-symbol@~3.1.3:
   version "3.1.3"
@@ -6007,11 +6009,6 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fast-deep-equal@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
-  integrity sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=
-
 fast-deep-equal@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
@@ -6397,15 +6394,6 @@ fs-extra@9.0.1, fs-extra@^9.0.0:
     jsonfile "^6.0.1"
     universalify "^1.0.0"
 
-fs-extra@^7.0.0:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
-  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
 fs-minipass@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
@@ -6688,12 +6676,10 @@ graphql-extensions@^0.12.4:
     apollo-server-env "^2.4.5"
     apollo-server-types "^0.5.1"
 
-graphql-request@^1.5.0:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-1.8.2.tgz#398d10ae15c585676741bde3fc01d5ca948f8fbe"
-  integrity sha512-dDX2M+VMsxXFCmUX0Vo0TopIZIX4ggzOtiCsThgtrKR4niiaagsGTDIHj3fsOMFETpa064vzovI+4YV4QnMbcg==
-  dependencies:
-    cross-fetch "2.2.2"
+graphql-request@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-2.0.0.tgz#8dd12cf1eb2ce0c80f4114fd851741e091134862"
+  integrity sha512-Ww3Ax+G3l2d+mPT8w7HC9LfrKjutnCKtnDq7ZZp2ghVk5IQDjwAk3/arRF1ix17Ky15rm0hrSKVKxRhIVlSuoQ==
 
 graphql-scalars@1.2.2:
   version "1.2.2"
@@ -7155,13 +7141,14 @@ http-errors@~1.6.2:
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.4.10.tgz#92c9c1374c35085f75db359ec56cc257cbb93fa4"
   integrity sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=
 
-http-proxy-agent@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz#e4821beef5b2142a2026bd73926fe537631c5405"
-  integrity sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==
+http-proxy-agent@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz#8a8c8ef7f5932ccf953c296ca8291b95aa74aa3a"
+  integrity sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==
   dependencies:
-    agent-base "4"
-    debug "3.1.0"
+    "@tootallnate/once" "1"
+    agent-base "6"
+    debug "4"
 
 http-proxy-middleware@0.19.1:
   version "0.19.1"
@@ -7196,13 +7183,13 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-https-proxy-agent@^2.2.1:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz#4ee7a737abd92678a293d9b34a1af4d0d08c787b"
-  integrity sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==
+https-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
   dependencies:
-    agent-base "^4.3.0"
-    debug "^3.1.0"
+    agent-base "6"
+    debug "4"
 
 human-signals@^1.1.1:
   version "1.1.1"
@@ -8340,10 +8327,18 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@^3.10.0, js-yaml@^3.11.0, js-yaml@^3.13.1:
+js-yaml@^3.11.0, js-yaml@^3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@^3.14.0:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
+  integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -8404,11 +8399,6 @@ json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
-
-json-schema-traverse@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
-  integrity sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
@@ -8477,7 +8467,7 @@ jsonify@~0.0.0:
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
-jsonwebtoken@^8.1.0:
+jsonwebtoken@^8.5.1:
   version "8.5.1"
   resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
   integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
@@ -8921,7 +8911,7 @@ lodash.uniq@4.5.0, lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.19, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.5.2:
+lodash@4.17.19, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.5, lodash@^4.5.2:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
@@ -9485,11 +9475,6 @@ node-emoji@^1.10.0:
   integrity sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==
   dependencies:
     lodash.toarray "^4.4.0"
-
-node-fetch@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
-  integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
 
 node-fetch@2.6.0, node-fetch@^2.1.2, node-fetch@^2.2.0:
   version "2.6.0"
@@ -10960,35 +10945,6 @@ prism-react-renderer@^1.1.0:
   resolved "https://registry.yarnpkg.com/prism-react-renderer/-/prism-react-renderer-1.1.0.tgz#6fe1b33f1de1b23afbdb07663d135f9026eef4ad"
   integrity sha512-WZAw+mBoxk1qZDD1h1WOg0BVHgyk9zqbuIBFNgP+Z71i515jGL0WZIN1FIF8EgOyh06x8Rr7HAUXxsRsoUZKyg==
 
-prisma-json-schema@0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/prisma-json-schema/-/prisma-json-schema-0.1.3.tgz#6c302db8f464f8b92e8694d3f7dd3f41ac9afcbe"
-  integrity sha512-XZrf2080oR81mY8/OC8al68HiwBm0nXlFE727JIia0ZbNqwuV4MyRYk6E0+OIa6/9KEYxZrcAmoBs3EW1cCvnA==
-
-prisma-yml@1.34.10:
-  version "1.34.10"
-  resolved "https://registry.yarnpkg.com/prisma-yml/-/prisma-yml-1.34.10.tgz#0ef1ad3a125f54f200289cba56bdd9597f17f410"
-  integrity sha512-N9on+Cf/XQKFGUULk/681tnpfqiZ19UBTurFMm+/9rnml37mteDaFr2k8yz+K8Gt2xpEJ7kBu7ikG5PrXI1uoA==
-  dependencies:
-    ajv "5"
-    bluebird "^3.5.1"
-    chalk "^2.3.0"
-    debug "^3.1.0"
-    dotenv "^4.0.0"
-    fs-extra "^7.0.0"
-    graphql-request "^1.5.0"
-    http-proxy-agent "^2.1.0"
-    https-proxy-agent "^2.2.1"
-    isomorphic-fetch "^2.2.1"
-    js-yaml "^3.10.0"
-    json-stable-stringify "^1.0.1"
-    jsonwebtoken "^8.1.0"
-    lodash "^4.17.4"
-    prisma-json-schema "0.1.3"
-    replaceall "^0.1.6"
-    scuid "^1.0.2"
-    yaml-ast-parser "^0.0.40"
-
 prismjs@^1.20.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.20.0.tgz#9b685fc480a3514ee7198eac6a3bf5024319ff03"
@@ -12043,7 +11999,7 @@ schema-utils@^2.0.0, schema-utils@^2.6.5, schema-utils@^2.6.6:
     ajv "^6.12.0"
     ajv-keywords "^3.4.1"
 
-scuid@^1.0.2:
+scuid@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/scuid/-/scuid-1.1.0.tgz#d3f9f920956e737a60f72d0e4ad280bf324d5dab"
   integrity sha512-MuCAyrGZcTLfQoH2XoBlQ8C6bzwN88XT/0slOGz0pn8+gIP85BOAfYa44ZXQUTOwRwPU0QvgU+V+OSajl/59Xg==
@@ -14019,11 +13975,6 @@ whatwg-encoding@^1.0.5:
   dependencies:
     iconv-lite "0.4.24"
 
-whatwg-fetch@2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
-  integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
-
 whatwg-fetch@>=0.10.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
@@ -14256,10 +14207,10 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml-ast-parser@^0.0.40:
-  version "0.0.40"
-  resolved "https://registry.yarnpkg.com/yaml-ast-parser/-/yaml-ast-parser-0.0.40.tgz#08536d4e73d322b1c9ce207ab8dd70e04d20ae6e"
-  integrity sha1-CFNtTnPTIrHJziB6uN1w4E0grm4=
+yaml-ast-parser@^0.0.43:
+  version "0.0.43"
+  resolved "https://registry.yarnpkg.com/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz#e8a23e6fb4c38076ab92995c5dca33f3d3d7c9bb"
+  integrity sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==
 
 yaml@^1.7.2:
   version "1.9.2"


### PR DESCRIPTION
This PR looks to address #1813 wherein a high severity vulnerability is present in prisma-yml that isn't being patched. To fix this, the code from prisma-yml has been pulled into the prisma-loader package.

Some notes about this merge:
- There is some less than ideal code in here coming in from the downstream repo. I made it pass the build and ESLINT on this repo but had to do a lot of not so ideal things such as usage of `any`, eslint ignores, and ts-ignores
- I brought the tests from the downstream repo. I cannot vouch for their quality.

All tests passing:
![image](https://user-images.githubusercontent.com/4482878/88751010-ba216500-d124-11ea-934e-87b14bff7a5c.png)

Linted:
![image](https://user-images.githubusercontent.com/4482878/88751044-ce656200-d124-11ea-968f-00516babb3e3.png)

Vulnerability is mitigated:
![image](https://user-images.githubusercontent.com/4482878/88751117-f5239880-d124-11ea-8f87-60702f6ea645.png)



