### PR TITLE
feat(stitch): allow subschemas to not provide queries for merging

### DIFF
--- a/packages/delegate/src/results/mergeFields.ts
+++ b/packages/delegate/src/results/mergeFields.ts
@@ -23,12 +23,7 @@ const sortSubschemasByProxiability = memoize3(function (
     ? sourceSubschemaOrSourceSubschemas
     : [sourceSubschemaOrSourceSubschemas];
   targetSubschemas.forEach(t => {
-    if (
-      sourceSubschemas.some(s => {
-        const selectionSet = mergedTypeInfo.selectionSets.get(t);
-        return mergedTypeInfo.containsSelectionSet.get(s).get(selectionSet);
-      })
-    ) {
+    if (sourceSubschemas.some(s => mergedTypeInfo.containsSelectionSet.get(s).get(t))) {
       proxiableSubschemas.push(t);
     } else {
       nonProxiableSubschemas.push(t);

--- a/packages/delegate/src/types.ts
+++ b/packages/delegate/src/types.ts
@@ -86,8 +86,7 @@ export interface MergedTypeInfo {
   uniqueFields: Record<string, SubschemaConfig>;
   nonUniqueFields: Record<string, Array<SubschemaConfig>>;
   typeMaps: Map<SubschemaConfig, TypeMap>;
-  selectionSets: Map<SubschemaConfig, SelectionSetNode>;
-  containsSelectionSet: Map<SubschemaConfig, Map<SelectionSetNode, boolean>>;
+  containsSelectionSet: Map<SubschemaConfig, Map<SubschemaConfig, boolean>>;
 }
 
 export interface ExecutionParams<TArgs = Record<string, any>, TContext = any> {

--- a/packages/delegate/src/types.ts
+++ b/packages/delegate/src/types.ts
@@ -81,12 +81,12 @@ export interface ICreateRequest {
 }
 
 export interface MergedTypeInfo {
-  targetSubschemas: Map<SubschemaConfig, Array<SubschemaConfig>>;
+  targetSubschemas: Map<GraphQLSchema | SubschemaConfig, Array<SubschemaConfig>>;
   selectionSet?: SelectionSetNode;
   uniqueFields: Record<string, SubschemaConfig>;
   nonUniqueFields: Record<string, Array<SubschemaConfig>>;
-  typeMaps: Map<SubschemaConfig, TypeMap>;
-  containsSelectionSet: Map<SubschemaConfig, Map<SubschemaConfig, boolean>>;
+  typeMaps: Map<GraphQLSchema | SubschemaConfig, TypeMap>;
+  containsSelectionSet: Map<GraphQLSchema | SubschemaConfig, Map<SubschemaConfig, boolean>>;
 }
 
 export interface ExecutionParams<TArgs = Record<string, any>, TContext = any> {

--- a/packages/stitch/src/types.ts
+++ b/packages/stitch/src/types.ts
@@ -26,8 +26,7 @@ export interface MergedTypeInfo {
   uniqueFields: Record<string, SubschemaConfig>;
   nonUniqueFields: Record<string, Array<SubschemaConfig>>;
   typeMaps: Map<SubschemaConfig, TypeMap>;
-  selectionSets: Map<SubschemaConfig, SelectionSetNode>;
-  containsSelectionSet: Map<SubschemaConfig, Map<SelectionSetNode, boolean>>;
+  containsSelectionSet: Map<SubschemaConfig, Map<SubschemaConfig, boolean>>;
 }
 
 export interface StitchingInfo {

--- a/packages/stitch/src/types.ts
+++ b/packages/stitch/src/types.ts
@@ -21,12 +21,12 @@ export type MergeTypeCandidate = {
 export type MergeTypeFilter = (mergeTypeCandidates: Array<MergeTypeCandidate>, typeName: string) => boolean;
 
 export interface MergedTypeInfo {
-  targetSubschemas: Map<SubschemaConfig, Array<SubschemaConfig>>;
+  targetSubschemas: Map<GraphQLSchema | SubschemaConfig, Array<SubschemaConfig>>;
   requiredSelections: Array<SelectionNode>;
   uniqueFields: Record<string, SubschemaConfig>;
   nonUniqueFields: Record<string, Array<SubschemaConfig>>;
-  typeMaps: Map<SubschemaConfig, TypeMap>;
-  containsSelectionSet: Map<SubschemaConfig, Map<SubschemaConfig, boolean>>;
+  typeMaps: Map<GraphQLSchema | SubschemaConfig, TypeMap>;
+  containsSelectionSet: Map<GraphQLSchema | SubschemaConfig, Map<SubschemaConfig, boolean>>;
 }
 
 export interface StitchingInfo {


### PR DESCRIPTION
Use case is a subschema in which the only defined fields are the key, so that merging is neither required nor really possible.

see #1839 