### PR TITLE
Test demonstrating merging failure in extension delegate subtrees

### DIFF
--- a/packages/stitch/tests/typeMerging.test.ts
+++ b/packages/stitch/tests/typeMerging.test.ts
@@ -332,6 +332,7 @@ describe('merging using type merging', () => {
       typeDefs: `
         type Image {
           id: Int!
+          url: String!
           network: Network!
         }
         type Network {
@@ -344,7 +345,7 @@ describe('merging using type merging', () => {
       resolvers: {
         Query: {
           image(obj, args) {
-            return { id: args.id, networkId: 1 };
+            return { id: args.id, networkId: 1, url: 'https://domain.com/img.jpg' };
           }
         },
         Image: {
@@ -430,7 +431,7 @@ describe('merging using type merging', () => {
         }
         extended: post(id: 1) {
           image {
-            id
+            url
           }
         }
         both: post(id: 1) {
@@ -452,7 +453,7 @@ describe('merging using type merging', () => {
         },
         extended: {
           image: {
-            id: 1
+            url: 'https://domain.com/img.jpg'
           }
         },
         both: {


### PR DESCRIPTION
This is a failing test for the issue described in https://github.com/ardatan/graphql-tools/issues/1848 (type merging fails within the subtree of schema extension delegates).

@yaacovCR – here's the failure. Thanks for having a look!
