### PR TITLE
Make batch delegate send key arrays to loadMany

### DIFF
--- a/packages/batch-delegate/src/batchDelegateToSchema.ts
+++ b/packages/batch-delegate/src/batchDelegateToSchema.ts
@@ -2,7 +2,14 @@ import { BatchDelegateOptions } from './types';
 
 import { getLoader } from './getLoader';
 
+const emptyKeys = [null, undefined];
+
 export function batchDelegateToSchema(options: BatchDelegateOptions): any {
+  if (emptyKeys.includes(options.key)) {
+    return null;
+  } else if (Array.isArray(options.key) && !options.key.length) {
+    return [];
+  }
   const loader = getLoader(options);
-  return loader.load(options.key);
+  return Array.isArray(options.key) ? loader.loadMany(options.key) : loader.load(options.key);
 }

--- a/packages/batch-delegate/src/batchDelegateToSchema.ts
+++ b/packages/batch-delegate/src/batchDelegateToSchema.ts
@@ -2,10 +2,8 @@ import { BatchDelegateOptions } from './types';
 
 import { getLoader } from './getLoader';
 
-const emptyKeys = [null, undefined];
-
 export function batchDelegateToSchema(options: BatchDelegateOptions): any {
-  if (emptyKeys.includes(options.key)) {
+  if (options.key === undefined || options.key === null) {
     return null;
   } else if (Array.isArray(options.key) && !options.key.length) {
     return [];

--- a/packages/batch-delegate/src/batchDelegateToSchema.ts
+++ b/packages/batch-delegate/src/batchDelegateToSchema.ts
@@ -3,11 +3,12 @@ import { BatchDelegateOptions } from './types';
 import { getLoader } from './getLoader';
 
 export function batchDelegateToSchema(options: BatchDelegateOptions): any {
-  if (options.key === undefined || options.key === null) {
+  const key = options.key;
+  if (key == null) {
     return null;
-  } else if (Array.isArray(options.key) && !options.key.length) {
+  } else if (Array.isArray(key) && !key.length) {
     return [];
   }
   const loader = getLoader(options);
-  return Array.isArray(options.key) ? loader.loadMany(options.key) : loader.load(options.key);
+  return Array.isArray(key) ? loader.loadMany(key) : loader.load(key);
 }

--- a/packages/batch-delegate/tests/basic.example.test.ts
+++ b/packages/batch-delegate/tests/basic.example.test.ts
@@ -5,7 +5,7 @@ import { batchDelegateToSchema } from '@graphql-tools/batch-delegate';
 import { stitchSchemas } from '@graphql-tools/stitch';
 
 describe('batch delegation within basic stitching example', () => {
-  test('works', async () => {
+  test('works with single keys', async () => {
     let numCalls = 0;
 
     const chirpSchema = makeExecutableSchema({
@@ -90,5 +90,113 @@ describe('batch delegation within basic stitching example', () => {
     expect(numCalls).toEqual(1);
     expect(result.errors).toBeUndefined();
     expect(result.data.trendingChirps[0].chirpedAtUser.email).not.toBe(null);
+  });
+
+  test('works with key arrays', async () => {
+    let numCalls = 0;
+
+    const postsSchema = makeExecutableSchema({
+      typeDefs: `
+        type Post {
+          id: ID!
+          title: String
+        }
+
+        type Query {
+          posts(ids: [ID]!): [Post]!
+        }
+      `,
+      resolvers: {
+        Query: {
+          posts: (obj, args) => {
+            numCalls += 1;
+            return args.ids.map(id => ({ id, title: `Post ${id}` }));
+          }
+        }
+      }
+    });
+
+    const usersSchema = makeExecutableSchema({
+      typeDefs: `
+        type User {
+          id: ID!
+          postIds: [ID]!
+        }
+
+        type Query {
+          users(ids: [ID!]!): [User]!
+        }
+      `,
+      resolvers: {
+        Query: {
+          users: (obj, args) => {
+            return args.ids.map(id => {
+              return { id, postIds: [Number(id)+1, Number(id)+2] };
+            });
+          }
+        }
+      }
+    });
+
+    const linkTypeDefs = `
+      extend type User {
+        posts: [Post]!
+      }
+    `;
+
+    const stitchedSchema = stitchSchemas({
+      subschemas: [postsSchema, usersSchema],
+      typeDefs: linkTypeDefs,
+      resolvers: {
+        User: {
+          posts: {
+            selectionSet: `{ postIds }`,
+            resolve(user, _args, context, info) {
+              return batchDelegateToSchema({
+                schema: postsSchema,
+                operation: 'query',
+                fieldName: 'posts',
+                key: user.postIds,
+                context,
+                info,
+              });
+            },
+          },
+        },
+      },
+    });
+
+    const query = `
+      query {
+        users(ids: [1, 7]) {
+          id
+          posts {
+            id
+            title
+          }
+        }
+      }
+    `;
+
+    const result = await graphql(stitchedSchema, query);
+    expect(numCalls).toEqual(1);
+    expect(result.data).toEqual({
+      users: [
+        {
+          id: '1',
+          posts: [
+            { id: '2', title: 'Post 2' },
+            { id: '3', title: 'Post 3' }
+          ]
+        },
+        {
+          id: '7',
+          posts: [
+            { id: '8', title: 'Post 8' },
+            { id: '9', title: 'Post 9' }
+          ]
+        }
+      ]
+    });
   });
 });


### PR DESCRIPTION
It's not uncommon for a model to posses an array of keys to be stitched from another service, for example:

```graphql
type Post {
  networkIds: [ID!]!
}
```

In these cases, the array of keys are delegated through `DataLoader.loadMany` so that the results return an array of mapped models. This PR adds this behavior. While at it, I've added eager returns for skipping delegation entirely when a key or key set is empty.

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
