### PR TITLE
Always auto-select batch delegate returnType

### DIFF
--- a/packages/batch-delegate/src/getLoader.ts
+++ b/packages/batch-delegate/src/getLoader.ts
@@ -1,5 +1,3 @@
-import { getNamedType, GraphQLOutputType, GraphQLList } from 'graphql';
-
 import DataLoader from 'dataloader';
 
 import { delegateToSchema } from '@graphql-tools/delegate';
@@ -13,11 +11,17 @@ function createBatchFn<K = any>(options: BatchDelegateOptions) {
   const { mapResultsFn, optionsFn } = options;
 
   return async (keys: ReadonlyArray<K>) => {
-    let results = await delegateToSchema({
-      returnType: new GraphQLList(getNamedType(options.info.returnType) as GraphQLOutputType),
+    const delegateOptions = {
       args: mapKeysFn(keys),
       ...(optionsFn != null ? optionsFn(options) : options),
-    });
+    };
+
+    delegateOptions.info = {
+      ...delegateOptions.info,
+      returnType: undefined,
+    };
+
+    let results = await delegateToSchema(delegateOptions);
 
     if (mapResultsFn != null) {
       results = mapResultsFn(results, keys);

--- a/packages/batch-delegate/tests/basic.example.test.ts
+++ b/packages/batch-delegate/tests/basic.example.test.ts
@@ -91,4 +91,113 @@ describe('batch delegation within basic stitching example', () => {
     expect(result.errors).toBeUndefined();
     expect(result.data.trendingChirps[0].chirpedAtUser.email).not.toBe(null);
   });
+
+  test('always selects return type based on delegated query return', async () => {
+    let numCalls = 0;
+
+    const sectionsSchema = makeExecutableSchema({
+      typeDefs: `
+        type Section {
+          id: Int!
+          title: String
+        }
+        type Query {
+          _sectionsForPosts(postIds: [Int]!): [[Section!]!]!
+        }
+      `,
+      resolvers: {
+        Query: {
+          _sectionsForPosts: (obj, args) => {
+            numCalls += 1;
+            return args.postIds.map(id => [
+              { id: id+1, title: `Section ${id+1}` },
+              { id: id+2, title: `Section ${id+2}` },
+            ]);
+          }
+        }
+      }
+    });
+
+    const postsSchema = makeExecutableSchema({
+      typeDefs: `
+        type Post {
+          id: Int!
+        }
+        type Query {
+          posts(ids: [Int!]!): [Post]!
+        }
+      `,
+      resolvers: {
+        Query: {
+          posts: (obj, args) => {
+            return args.ids.map(id => ({ id }));
+          }
+        }
+      }
+    });
+
+    const linkTypeDefs = `
+      extend type Post {
+        sections: [Section!]!
+      }
+    `;
+
+    const stitchedSchema = stitchSchemas({
+      subschemas: [sectionsSchema, postsSchema],
+      typeDefs: linkTypeDefs,
+      resolvers: {
+        Post: {
+          sections: {
+            selectionSet: `{ id }`,
+            resolve(post, _args, context, info) {
+              return batchDelegateToSchema({
+                schema: sectionsSchema,
+                operation: 'query',
+                fieldName: '_sectionsForPosts',
+                key: post.id,
+                mapKeysFn: (postIds) => ({ postIds }),
+                context,
+                info,
+              });
+            },
+          },
+        },
+      },
+    });
+
+    const query = `
+      query {
+        posts(ids: [1, 7]) {
+          id
+          sections {
+            id
+            # this field alias will break if returnType is misaligned
+            name: title
+          }
+        }
+      }
+    `;
+
+    const result = await graphql(stitchedSchema, query);
+
+    expect(numCalls).toEqual(1);
+    expect(result.data).toEqual({
+      posts: [
+        {
+          id: 1,
+          sections: [
+            { id: 2, name: 'Section 2' },
+            { id: 3, name: 'Section 3' }
+          ]
+        },
+        {
+          id: 7,
+          sections: [
+            { id: 8, name: 'Section 8' },
+            { id: 9, name: 'Section 9' }
+          ]
+        }
+      ]
+    });
+  });
 });

--- a/packages/delegate/src/delegateToSchema.ts
+++ b/packages/delegate/src/delegateToSchema.ts
@@ -137,7 +137,9 @@ export function delegateRequest({
     context,
     info,
     returnType:
-      returnType ?? info?.returnType ?? getDelegationReturnType(targetSchema, targetOperation, targetFieldName),
+      returnType ??
+      info?.returnType ??
+      getDelegationReturnType(transformedSchema ?? targetSchema, targetOperation, targetFieldName),
     transforms: allTransforms,
     transformedSchema: transformedSchema ?? targetSchema,
     skipTypeMerging,


### PR DESCRIPTION
When performing batch delegations, we can't make reliable assumptions about the shape of the list query that we're targeting. It could be something surprising, for example:

```graphql
type Query {
  _sectionsForPosts(postIds: [Int]!): [[Section!]!]!
}
```

Rather than guessing about how a list wrapper may be structured, the most reliable solution is to always read the return type from the query definition. Lo and behold, it appears that `delegateToSchema` already does this: https://github.com/ardatan/graphql-tools/blob/master/packages/delegate/src/delegateToSchema.ts#L61-L76

This clears the default `info.returnType` setting so that `delegateToSchema` will always perform a query-type lookup. It doesn't change passed delegate options so that you can still pass in a manual `returnType` if you really want to for some reason.

As for the test, you'll notice that the query includes a field alias. As mentioned in https://github.com/ardatan/graphql-tools/issues/1819, field aliases will break in stitched data if the `returnType` is not properly set. This test confirms that we're resolving the response against the correct return type.

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
