### PR TITLE
feat(mergeMocks): support Promise

### DIFF
--- a/packages/mock/src/mocking.ts
+++ b/packages/mock/src/mocking.ts
@@ -336,6 +336,9 @@ function mergeMocks(genericMockFunction: () => any, customMock: any): any {
   if (Array.isArray(customMock)) {
     return customMock.map((el: any) => mergeMocks(genericMockFunction, el));
   }
+  if (customMock instanceof Promise) {
+    return customMock.then((res: any) => mergeObjects(genericMockFunction(), res));
+  }
   if (isObject(customMock)) {
     return mergeObjects(genericMockFunction(), customMock);
   }


### PR DESCRIPTION
In my opinion it's a bug fix : mergeMocks function signature accept **any** type, so Promise type should be covered.

- [x] add Promise support on **mergeMocks**
- [x] add test to cover it

### Context
In our application, we use the mocks with Promise result.
That gives us the possibility to test the "pending" and "error" state of a query or a mutation more easily. (and also the optimistic UI part can also be covered during pending state)
Actually it's really working fine and it's way easier to use on Frontend side compare to other mock utilities (for example the "mock" request system of apollo is awful)

We discover that if we define a custom mock + use Promise the custom mock override the expected result.
It's because of this test:
```js
  if (isObject(customMock)) {
    return mergeObjects(genericMockFunction(), customMock);
  }
```
Promise is an object, but you can merge it as an object ...

--

- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass
