### PR TITLE
Improved `parse` to support converting comments into descriptions

### DIFF
--- a/packages/load/src/load-typedefs/parse.ts
+++ b/packages/load/src/load-typedefs/parse.ts
@@ -1,6 +1,5 @@
-import { Source, printSchemaWithDirectives, fixSchemaAst } from '@graphql-tools/utils';
+import { Source, printSchemaWithDirectives, fixSchemaAst, parseGraphQLSDL } from '@graphql-tools/utils';
 import { printWithComments, resetComments } from '@graphql-tools/merge';
-import { parse, Source as GraphQLSource } from 'graphql';
 import { filterKind } from '../filter-document-kind';
 
 type Options = any;
@@ -67,7 +66,7 @@ function parseSchema(input: Input) {
 
 function parseRawSDL(input: Input) {
   if (input.source.rawSDL) {
-    input.source.document = parse(new GraphQLSource(input.source.rawSDL, input.source.location), input.options);
+    input.source.document = parseGraphQLSDL(input.source.location, input.source.rawSDL, input.options).document;
   }
 }
 

--- a/packages/loaders/graphql-file/src/index.ts
+++ b/packages/loaders/graphql-file/src/index.ts
@@ -116,6 +116,7 @@ export class GraphQLFileLoader implements UniversalLoader<GraphQLFileLoaderOptio
         },
       };
     }
-    return parseGraphQLSDL(pointer, rawSDL.trim(), options);
+
+    return parseGraphQLSDL(pointer, rawSDL, options);
   }
 }

--- a/packages/schema/src/buildSchemaFromTypeDefinitions.ts
+++ b/packages/schema/src/buildSchemaFromTypeDefinitions.ts
@@ -1,6 +1,6 @@
-import { parse, extendSchema, buildASTSchema, GraphQLSchema, DocumentNode, ASTNode } from 'graphql';
+import { extendSchema, buildASTSchema, GraphQLSchema, DocumentNode, ASTNode } from 'graphql';
 
-import { ITypeDefinitions, GraphQLParseOptions } from '@graphql-tools/utils';
+import { ITypeDefinitions, GraphQLParseOptions, parseGraphQLSDL } from '@graphql-tools/utils';
 
 import { extractExtensionDefinitions, filterExtensionDefinitions } from './extensionDefinitions';
 import { concatenateTypeDefs } from './concatenateTypeDefs';
@@ -33,9 +33,9 @@ export function buildDocumentFromTypeDefinitions(
 ): DocumentNode {
   let document: DocumentNode;
   if (typeof typeDefinitions === 'string') {
-    document = parse(typeDefinitions, parseOptions);
+    document = parseGraphQLSDL('', typeDefinitions, parseOptions).document;
   } else if (Array.isArray(typeDefinitions)) {
-    document = parse(concatenateTypeDefs(typeDefinitions), parseOptions);
+    document = parseGraphQLSDL('', concatenateTypeDefs(typeDefinitions), parseOptions).document;
   } else if (isDocumentNode(typeDefinitions)) {
     document = typeDefinitions;
   } else {

--- a/packages/utils/src/loaders.ts
+++ b/packages/utils/src/loaders.ts
@@ -1,5 +1,6 @@
-import { DocumentNode, GraphQLSchema, ParseOptions, BuildSchemaOptions } from 'graphql';
+import { DocumentNode, GraphQLSchema, BuildSchemaOptions } from 'graphql';
 import { GraphQLSchemaValidationOptions } from 'graphql/type/schema';
+import { ExtendedParseOptions } from './parse-graphql-sdl';
 
 export interface Source {
   document?: DocumentNode;
@@ -8,7 +9,7 @@ export interface Source {
   location?: string;
 }
 
-export type SingleFileOptions = ParseOptions &
+export type SingleFileOptions = ExtendedParseOptions &
   GraphQLSchemaValidationOptions &
   BuildSchemaOptions & {
     cwd?: string;

--- a/packages/utils/src/parse-graphql-json.ts
+++ b/packages/utils/src/parse-graphql-json.ts
@@ -1,8 +1,9 @@
-import { buildClientSchema, parse, ParseOptions } from 'graphql';
+import { buildClientSchema, ParseOptions } from 'graphql';
 import { GraphQLSchemaValidationOptions } from 'graphql/type/schema';
 import { printSchemaWithDirectives } from './print-schema-with-directives';
 import { Source } from './loaders';
 import { SchemaPrintOptions } from './types';
+import { parseGraphQLSDL } from './parse-graphql-sdl';
 
 function stripBOM(content: string): string {
   content = content.toString();
@@ -44,7 +45,7 @@ export function parseGraphQLJSON(
 
     return {
       location,
-      document: parse(rawSDL, options),
+      document: parseGraphQLSDL(location, rawSDL, options).document,
       rawSDL,
       schema,
     };

--- a/packages/utils/src/parse-graphql-sdl.ts
+++ b/packages/utils/src/parse-graphql-sdl.ts
@@ -1,9 +1,44 @@
-import { ParseOptions, DocumentNode, parse, Kind, Source as GraphQLSource } from 'graphql';
+import {
+  ParseOptions,
+  DocumentNode,
+  Kind,
+  TokenKind,
+  ASTNode,
+  parse,
+  Source as GraphQLSource,
+  visit,
+  isTypeSystemDefinitionNode,
+  StringValueNode,
+  print,
+} from 'graphql';
+import { dedentBlockStringValue } from 'graphql/language/blockString';
 
-export function parseGraphQLSDL(location: string, rawSDL: string, options: ParseOptions) {
+export interface ExtendedParseOptions extends ParseOptions {
+  /**
+   * Set to `true` in order to convert all GraphQL comments (marked with # sign) to descriptions (""")
+   * GraphQL has built-in support for transforming descriptions to comments (with `print`), but not while
+   * parsing. Turning the flag on will support the other way as well (`parse`)
+   */
+  commentDescriptions?: boolean;
+}
+
+export function parseGraphQLSDL(location: string, rawSDL: string, options: ExtendedParseOptions = {}) {
   let document: DocumentNode;
+  const sdl: string = rawSDL;
+
   try {
-    document = parse(new GraphQLSource(rawSDL, location), options);
+    if (options.commentDescriptions) {
+      document = transformCommentsToDescriptions(rawSDL, options);
+
+      // If noLocation=true, we need to make sure to print and parse it again, to remove locations,
+      // since `transformCommentsToDescriptions` must have locations set in order to transform the comments
+      // into descriptions.
+      if (options.noLocation) {
+        document = parse(print(document), options);
+      }
+    } else {
+      document = parse(new GraphQLSource(sdl, location), options);
+    }
   } catch (e) {
     if (e.message.includes('EOF')) {
       document = {
@@ -14,9 +49,101 @@ export function parseGraphQLSDL(location: string, rawSDL: string, options: Parse
       throw e;
     }
   }
+
   return {
     location,
     document,
-    rawSDL,
+    rawSDL: sdl,
   };
+}
+
+export function getLeadingCommentBlock(node: ASTNode): void | string {
+  const loc = node.loc;
+
+  if (!loc) {
+    return;
+  }
+
+  const comments = [];
+  let token = loc.startToken.prev;
+
+  while (
+    token != null &&
+    token.kind === TokenKind.COMMENT &&
+    token.next &&
+    token.prev &&
+    token.line + 1 === token.next.line &&
+    token.line !== token.prev.line
+  ) {
+    const value = String(token.value);
+    comments.push(value);
+    token = token.prev;
+  }
+
+  return comments.length > 0 ? comments.reverse().join('\n') : undefined;
+}
+
+export function transformCommentsToDescriptions(
+  sourceSdl: string,
+  options: ExtendedParseOptions = {}
+): DocumentNode | null {
+  if (sourceSdl.includes('#')) {
+    const parsedDoc = parse(sourceSdl, {
+      ...options,
+      noLocation: false,
+    });
+    const modifiedDoc = visit(parsedDoc, {
+      leave: (node: ASTNode) => {
+        if (isDescribable(node)) {
+          const rawValue = getLeadingCommentBlock(node);
+
+          if (rawValue !== undefined) {
+            const commentsBlock = dedentBlockStringValue('\n' + rawValue);
+            const isBlock = commentsBlock.includes('\n');
+
+            if (!node.description) {
+              return {
+                ...node,
+                description: {
+                  kind: Kind.STRING,
+                  value: commentsBlock,
+                  block: isBlock,
+                },
+              };
+            } else {
+              return {
+                ...node,
+                description: {
+                  ...node.description,
+                  value: node.description.value + '\n' + commentsBlock,
+                  block: true,
+                },
+              };
+            }
+          }
+        }
+      },
+    });
+
+    return modifiedDoc;
+  }
+
+  return null;
+}
+
+type DiscriminateUnion<T, U> = T extends U ? T : never;
+type DescribableASTNodes = DiscriminateUnion<
+  ASTNode,
+  {
+    description?: StringValueNode;
+  }
+>;
+
+export function isDescribable(node: ASTNode): node is DescribableASTNodes {
+  return (
+    isTypeSystemDefinitionNode(node) ||
+    node.kind === Kind.FIELD_DEFINITION ||
+    node.kind === Kind.INPUT_VALUE_DEFINITION ||
+    node.kind === Kind.ENUM_VALUE_DEFINITION
+  );
 }

--- a/packages/utils/tests/__snapshots__/parse-graphql-sdl.spec.ts.snap
+++ b/packages/utils/tests/__snapshots__/parse-graphql-sdl.spec.ts.snap
@@ -1,0 +1,107 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`parse sdl comment parsing should transform comments to descriptions correctly on all available nodes 1`] = `
+"\\"test type comment\\"
+type Type {
+  \\"test field comment\\"
+  f1: String!
+  \\"\\"\\"
+   Line 1
+  Line 2
+  \\"\\"\\"
+  f2: String!
+  \\"\\"\\"
+  line 2
+  Line 1
+  \\"\\"\\"
+  f3: String!
+}
+
+extend type Type {
+  \\"test extension field comment\\"
+  f4: String!
+}
+
+type OtherType implements Node {
+  id: ID!
+  f: String!
+}
+
+\\"input test\\"
+input Input {
+  \\"Input field test\\"
+  f: String
+}
+
+\\"Enum test\\"
+enum Enum {
+  \\"Enum value test\\"
+  V1
+  V2
+}
+
+\\"Union test\\"
+union Union = Type | OtherType
+
+\\"Inferface test\\"
+interface Node {
+  id: ID!
+}
+
+\\"Custom scalar test\\"
+scalar Date
+"
+`;
+
+exports[`parse sdl comment parsing should transform comments to descriptions correctly on all available nodes with noLocation=true 1`] = `
+"\\"test type comment\\"
+type Type {
+  \\"test field comment\\"
+  f1: String!
+  \\"\\"\\"
+   Line 1
+  Line 2
+  \\"\\"\\"
+  f2: String!
+  \\"\\"\\"
+  line 2
+  Line 1
+  \\"\\"\\"
+  f3: String!
+}
+
+extend type Type {
+  \\"test extension field comment\\"
+  f4: String!
+}
+
+type OtherType implements Node {
+  id: ID!
+  f: String!
+}
+
+\\"input test\\"
+input Input {
+  \\"Input field test\\"
+  f: String
+}
+
+\\"Enum test\\"
+enum Enum {
+  \\"Enum value test\\"
+  V1
+  V2
+}
+
+\\"Union test\\"
+union Union = Type | OtherType
+
+\\"Inferface test\\"
+interface Node {
+  id: ID!
+}
+
+\\"Custom scalar test\\"
+scalar Date
+"
+`;

--- a/packages/utils/tests/parse-graphql-sdl.spec.ts
+++ b/packages/utils/tests/parse-graphql-sdl.spec.ts
@@ -1,0 +1,86 @@
+import { transformCommentsToDescriptions, parseGraphQLSDL } from "../src/parse-graphql-sdl";
+import { Kind, print, ObjectTypeDefinitionNode } from 'graphql';
+
+describe('parse sdl', () => {
+  describe('parseGraphQLSDL', () => {
+    it('Should work correctly with empty document (everything is commented out)', () => {
+      const doc = /* GraphQL */`
+        #query test {
+        #  id
+        #}
+      `;
+
+      expect(parseGraphQLSDL('a.graphql', doc).document).toEqual({
+        kind: Kind.DOCUMENT,
+        definitions: [],
+      });
+    });
+  });
+
+  describe('comment parsing', () => {
+    const ast = /* GraphQL */`
+      # test type comment
+      type Type {
+        # test field comment
+        f1: String!
+        # Line 1
+        #Line 2
+        f2: String!
+        # Line 1
+        "line 2"
+        f3: String!
+      }
+
+      # test extension
+      extend type Type {
+        # test extension field comment
+        f4: String!
+      }
+
+      type OtherType implements Node {
+        id: ID!
+        f: String!
+      }
+
+      # input test
+      input Input {
+        # Input field test
+        f: String
+      }
+
+      # Enum test
+      enum Enum {
+        # Enum value test
+        V1
+        V2
+      }
+
+      # Union test
+      union Union = Type | OtherType
+
+      # Inferface test
+      interface Node {
+        id: ID!
+      }
+
+      # Custom scalar test
+      scalar Date
+    `;
+
+    it('should transform comments to descriptions correctly on all available nodes', () => {
+      const transformed = transformCommentsToDescriptions(ast);
+      const printed = print(transformed);
+
+      expect(printed).toMatchSnapshot();
+    });
+
+    it('should transform comments to descriptions correctly on all available nodes with noLocation=true', () => {
+      const transformed = parseGraphQLSDL('test.graphql', ast, { noLocation: true, commentDescriptions: true });
+      const type = transformed.document.definitions.find(d => (d as any)?.name?.value === 'Type');
+      expect((type as ObjectTypeDefinitionNode).description.value).toBe('test type comment');
+      expect((type as ObjectTypeDefinitionNode).loc).not.toBeDefined();
+      const printed = print(transformed.document);
+      expect(printed).toMatchSnapshot();
+    });
+  });
+});


### PR DESCRIPTION
The PR includes fixes for:
- Allow transforming old GraphQL comments into GraphQL descriptions (during `parse`), using the same `commentDescriptions` configuration flag (it's a workaround for https://github.com/graphql/graphql-js/issues/2241) 
- Use custom `parse` in all relevant pieces of code. 
- Ensure empty document isn't throwing errors during parsing. 
