### PR TITLE
feat(utils): check if type has a list type

### DIFF
--- a/packages/utils/src/hasListType.ts
+++ b/packages/utils/src/hasListType.ts
@@ -1,0 +1,16 @@
+import { GraphQLOutputType, isWrappingType, isListType } from 'graphql';
+
+/**
+ * Return true if the output type is wrapped by a GraphQLList.
+ *
+ * @param {GraphQLOutputType} outputType - the output type which might be wrapped by a list.
+ */
+export function hasListType(outputType: GraphQLOutputType): boolean {
+  if (isListType(outputType)) {
+    return true;
+  } else if (isWrappingType(outputType)) {
+    return hasListType(outputType.ofType);
+  }
+
+  return false;
+}

--- a/packages/utils/tests/hasListType.test.ts
+++ b/packages/utils/tests/hasListType.test.ts
@@ -1,0 +1,29 @@
+import { GraphQLNonNull, GraphQLList, GraphQLFloat } from 'graphql';
+import { hasListType } from '../src/hasListType';
+
+describe('hasListType', () => {
+  test('should return false for plain output type', () => {
+    const outputType = GraphQLFloat;
+    const hasList = hasListType(outputType);
+    expect(hasList).toBeFalsy();
+  });
+
+  test('should return false for wrapped output type', () => {
+    const outputType = GraphQLNonNull(GraphQLFloat);
+    const hasList = hasListType(outputType);
+    expect(hasList).toBeFalsy();
+  });
+
+  test('should return true for list output type', () => {
+    const outputType = GraphQLList(GraphQLFloat);
+    const hasList = hasListType(outputType);
+    expect(hasList).toBeDefined();
+  });
+
+  test('should return true for wrapped list', () => {
+    const outputType = GraphQLNonNull(GraphQLList(GraphQLFloat));
+    const hasList = hasListType(outputType);
+    expect(hasList).toBeDefined();
+  });
+
+})


### PR DESCRIPTION
This is a util function I use and thought it might be convenient to have in graphql-tools!

To my knowledge, There is no native ability in GraphQL.js to check if a type is wrapped by a `GraphQLList`.

```graphql
field: [String]! ✔️
field: [String!]! ✔️
field: [String] ✔️
field: [String!] ✔️
field: String ✖️
```

✔️ - Has a list type
✖️ - Is not wrapped by list