### PR TITLE
enhance(website) stitching docs for cross-schema interfaces

### DIFF
--- a/website/docs/stitch-type-merging.md
+++ b/website/docs/stitch-type-merging.md
@@ -466,7 +466,7 @@ interface HomepageSlot {
 
 ### Interface extensions
 
-Merging alone may not be enough for a combined interface depending on how types are arranged across subschemas. For example:
+Merging alone may not be enough depending on how types are arranged across subschemas. For example:
 
 ```js
 const postsSchema = makeExecutableSchema({
@@ -503,7 +503,7 @@ const layoutsSchema = makeExecutableSchema({
 });
 ```
 
-In this case, Post and Section would ideally provide an interface of `{ id title url }`, however they only share an `id` in the service that defines the interface. This constraint can be overcome with a gateway-only schema extension that adds `{ title url }` into the combined interface:
+In this case, Post and Section would ideally provide an interface of `{ id title url }`, however they only share an `id` in the service that defines the interface. This constraint can be overcome with a gateway-level schema extension that adds `{ title url }` into the combined interface:
 
 ```js
 const gatewaySchema = stitchSchemas({


### PR DESCRIPTION
Adds stitching docs for cross-schema interface strategies. Promotes capabilities enabled by https://github.com/ardatan/graphql-tools/pull/1912 and https://github.com/ardatan/graphql-tools/pull/1917.

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
