### PR TITLE
Executor should run once per GraphQL Operation

### DIFF
--- a/packages/wrap/tests/wrapSchema.test.ts
+++ b/packages/wrap/tests/wrapSchema.test.ts
@@ -1,0 +1,84 @@
+import { execute, parse } from 'graphql';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { wrapSchema } from '../src/wrapSchema';
+
+const typeDefs = /* GraphQL */`
+  type Query {
+    boo: String!
+  }
+`
+
+const resolvers = {
+  Query: {
+    boo() {
+      return 'boo';
+    },
+  },
+};
+
+test('should run executor once on a single root field', async () => {
+  const query = parse(/* GraphQL */`
+    {
+      boo
+    }
+  `);
+
+  const executor = jest.fn();
+  const innerSchema = makeExecutableSchema({
+    resolvers,
+    typeDefs,
+  });
+  const schema = wrapSchema({
+    schema: innerSchema,
+    executor({ document, context, variables }) {
+      executor();
+      return execute({
+        schema: innerSchema,
+        document,
+        contextValue: context,
+        variableValues: variables
+      }) as any;
+    }
+  })
+
+  await execute({
+    schema,
+    document: query,
+  });
+
+  expect(executor).toBeCalledTimes(1);
+});
+
+test('should run executor once on multiple root fields', async () => {
+  const query = parse(/* GraphQL */`
+  {
+    foo: boo
+    bar: boo
+  }
+`);
+
+  const executor = jest.fn();
+  const innerSchema = makeExecutableSchema({
+    resolvers,
+    typeDefs,
+  });
+  const schema = wrapSchema({
+    schema: innerSchema,
+    executor({ document, context, variables }) {
+      executor();
+      return execute({
+        schema: innerSchema,
+        document,
+        contextValue: context,
+        variableValues: variables
+      }) as any;
+    }
+  })
+
+  await execute({
+    schema,
+    document: query,
+  });
+
+  expect(executor).toBeCalledTimes(1);
+});


### PR DESCRIPTION
It happens because we wrap all root-level resolvers with `defaultCreateProxyingResolver` and call `delegateToSchema` on resolver level and it's `delegateToSchema` that runs `executor` function.