### PR TITLE
enable batch execution

### DIFF
--- a/packages/batch-delegate/tests/typeMerging.example.test.ts
+++ b/packages/batch-delegate/tests/typeMerging.example.test.ts
@@ -227,7 +227,8 @@ describe('merging using type merging', () => {
             fieldName: '_userById',
             args: ({ id }) => ({ id })
           }
-        }
+        },
+        batch: true,
       },
       {
         schema: inventorySchema,
@@ -242,7 +243,8 @@ describe('merging using type merging', () => {
             fieldName: '_productByRepresentation',
             args: ({ upc, weight, price }) => ({ product: { upc, weight, price } }),
           }
-        }
+        },
+        batch: true,
       },
       {
         schema: productsSchema,
@@ -252,7 +254,8 @@ describe('merging using type merging', () => {
             fieldName: '_productByUpc',
             args: ({ upc }) => ({ upc }),
           }
-        }
+        },
+        batch: true,
       },
       {
         schema: reviewsSchema,
@@ -268,7 +271,8 @@ describe('merging using type merging', () => {
             fieldName: '_productByUpc',
             args: ({ upc }) => ({ upc }),
           },
-        }
+        },
+        batch: true,
       }],
     mergeTypes: true,
   });
@@ -284,6 +288,8 @@ describe('merging using type merging', () => {
           }
         }
       `,
+      undefined,
+      {},
     );
 
     const expectedResult = {
@@ -315,6 +321,8 @@ describe('merging using type merging', () => {
           }
         }
       `,
+      undefined,
+      {},
     );
 
     const expectedResult: ExecutionResult = {
@@ -348,6 +356,8 @@ describe('merging using type merging', () => {
           }
         }
       `,
+      undefined,
+      {},
     );
 
     const expectedResult: ExecutionResult = {
@@ -393,6 +403,8 @@ describe('merging using type merging', () => {
           }
         }
       `,
+      undefined,
+      {},
     );
 
     const expectedResult: ExecutionResult = {

--- a/packages/delegate/package.json
+++ b/packages/delegate/package.json
@@ -21,6 +21,7 @@
     "@graphql-tools/schema": "6.1.0",
     "@graphql-tools/utils": "6.1.0",
     "@ardatan/aggregate-error": "0.0.1",
+    "dataloader": "2.0.0",
     "is-promise": "4.0.0",
     "tslib": "~2.0.1"
   },

--- a/packages/delegate/src/delegateToSchema.ts
+++ b/packages/delegate/src/delegateToSchema.ts
@@ -24,6 +24,7 @@ import { createRequestFromInfo, getDelegatingOperation } from './createRequest';
 import { Transformer } from './Transformer';
 
 import AggregateError from '@ardatan/aggregate-error';
+import { getBatchingExecutor } from './getBatchingExecutor';
 
 export function delegateToSchema(options: IDelegateToSchemaOptions | GraphQLSchema): any {
   if (isSchema(options)) {
@@ -154,8 +155,12 @@ export function delegateRequest({
   }
 
   if (targetOperation === 'query' || targetOperation === 'mutation') {
-    const executor =
+    let executor =
       subschemaConfig?.executor || createDefaultExecutor(targetSchema, subschemaConfig?.rootValue || targetRootValue);
+
+    if (subschemaConfig?.batch) {
+      executor = getBatchingExecutor(context, subschemaConfig, executor);
+    }
 
     const executionResult = executor({
       document: processedRequest.document,

--- a/packages/delegate/src/delegateToSchema.ts
+++ b/packages/delegate/src/delegateToSchema.ts
@@ -163,8 +163,7 @@ export function delegateRequest({
     }
 
     const executionResult = executor({
-      document: processedRequest.document,
-      variables: processedRequest.variables,
+      ...processedRequest,
       context,
       info,
     });
@@ -179,8 +178,7 @@ export function delegateRequest({
     subschemaConfig?.subscriber || createDefaultSubscriber(targetSchema, subschemaConfig?.rootValue || targetRootValue);
 
   return subscriber({
-    document: processedRequest.document,
-    variables: processedRequest.variables,
+    ...processedRequest,
     context,
     info,
   }).then((subscriptionResult: AsyncIterableIterator<ExecutionResult> | ExecutionResult) => {

--- a/packages/delegate/src/getBatchingExecutor.ts
+++ b/packages/delegate/src/getBatchingExecutor.ts
@@ -1,0 +1,74 @@
+import { getOperationAST } from 'graphql';
+
+import isPromise from 'is-promise';
+
+import DataLoader from 'dataloader';
+
+import { ExecutionResult } from '@graphql-tools/utils';
+
+import { SubschemaConfig, ExecutionParams } from './types';
+import { memoize2of3 } from './memoize';
+import { mergeExecutionParams } from './mergeExecutionParams';
+import { splitResult } from './splitResult';
+
+export const getBatchingExecutor = memoize2of3(function (
+  _context: Record<string, any>,
+  subschemaConfig: SubschemaConfig,
+  executor: ({ document, context, variables, info }: ExecutionParams) => ExecutionResult | Promise<ExecutionResult>
+) {
+  const loader = new DataLoader(
+    createLoadFn(executor ?? subschemaConfig.executor),
+    subschemaConfig.batchingOptions?.dataLoaderOptions
+  );
+  return (executionParams: ExecutionParams) => loader.load(executionParams);
+});
+
+function createLoadFn(
+  executor: ({ document, context, variables, info }: ExecutionParams) => ExecutionResult | Promise<ExecutionResult>
+) {
+  return async (execs: Array<ExecutionParams>): Promise<Array<ExecutionResult>> => {
+    const execBatches: Array<Array<ExecutionParams>> = [];
+    let index = 0;
+    const exec = execs[index];
+    let currentBatch: Array<ExecutionParams> = [exec];
+    execBatches.push(currentBatch);
+    const operationType = getOperationAST(exec.document, undefined).operation;
+    while (++index < execs.length) {
+      const currentOperationType = getOperationAST(execs[index].document, undefined).operation;
+      if (operationType === currentOperationType) {
+        currentBatch.push(execs[index]);
+      } else {
+        currentBatch = [execs[index]];
+        execBatches.push(currentBatch);
+      }
+    }
+
+    let containsPromises = false;
+    const executionResults: Array<ExecutionResult | Promise<ExecutionResult>> = [];
+    execBatches.forEach(execBatch => {
+      const mergedExecutionParams = mergeExecutionParams(execBatch);
+      const executionResult = executor(mergedExecutionParams);
+
+      if (isPromise(executionResult)) {
+        containsPromises = true;
+      }
+      executionResults.push(executionResult);
+    });
+
+    if (containsPromises) {
+      return Promise.all(executionResults).then(resultBatches => {
+        let results: Array<ExecutionResult> = [];
+        resultBatches.forEach((resultBatch, index) => {
+          results = results.concat(splitResult(resultBatch, execBatches[index].length));
+        });
+        return results;
+      });
+    }
+
+    let results: Array<ExecutionResult> = [];
+    (executionResults as Array<ExecutionResult>).forEach((resultBatch, index) => {
+      results = results.concat(splitResult(resultBatch, execBatches[index].length));
+    });
+    return results;
+  };
+}

--- a/packages/delegate/src/memoize.ts
+++ b/packages/delegate/src/memoize.ts
@@ -211,3 +211,43 @@ export function memoize2<T1 extends Record<string, any>, T2 extends Record<strin
 
   return memoized;
 }
+
+export function memoize2of3<
+  T1 extends Record<string, any>,
+  T2 extends Record<string, any>,
+  T3 extends any,
+  R extends any
+>(fn: (A1: T1, A2: T2, A3: T3) => R): (A1: T1, A2: T2, A3: T3) => R {
+  let cache1: WeakMap<T1, WeakMap<T2, R>>;
+
+  function memoized(a1: T1, a2: T2, a3: T3) {
+    if (!cache1) {
+      cache1 = new WeakMap();
+      const cache2: WeakMap<T2, R> = new WeakMap();
+      cache1.set(a1, cache2);
+      const newValue = fn(a1, a2, a3);
+      cache2.set(a2, newValue);
+      return newValue;
+    }
+
+    let cache2 = cache1.get(a1);
+    if (!cache2) {
+      cache2 = new WeakMap();
+      cache1.set(a1, cache2);
+      const newValue = fn(a1, a2, a3);
+      cache2.set(a2, newValue);
+      return newValue;
+    }
+
+    const cachedValue = cache2.get(a2);
+    if (cachedValue === undefined) {
+      const newValue = fn(a1, a2, a3);
+      cache2.set(a2, newValue);
+      return newValue;
+    }
+
+    return cachedValue;
+  }
+
+  return memoized;
+}

--- a/packages/delegate/src/mergeExecutionParams.ts
+++ b/packages/delegate/src/mergeExecutionParams.ts
@@ -55,11 +55,15 @@ import { ExecutionParams } from './types';
  *     }
  *   }
  */
-export function mergeExecutionParams(execs: Array<ExecutionParams>): ExecutionParams {
+export function mergeExecutionParams(
+  execs: Array<ExecutionParams>,
+  extensionsReducer: (mergedExtensions: Record<string, any>, executionParams: ExecutionParams) => Record<string, any>
+): ExecutionParams {
   const mergedVariables: Record<string, any> = Object.create(null);
   const mergedVariableDefinitions: Array<VariableDefinitionNode> = [];
   const mergedSelections: Array<SelectionNode> = [];
   const mergedFragmentDefinitions: Array<FragmentDefinitionNode> = [];
+  let mergedExtensions: Record<string, any> = Object.create(null);
 
   let operation: OperationTypeNode;
 
@@ -77,6 +81,7 @@ export function mergeExecutionParams(execs: Array<ExecutionParams>): ExecutionPa
       }
     });
     Object.assign(mergedVariables, prefixedExecutionParams.variables);
+    mergedExtensions = extensionsReducer(mergedExtensions, executionParams);
   });
 
   const mergedOperationDefinition: OperationDefinitionNode = {
@@ -95,6 +100,7 @@ export function mergeExecutionParams(execs: Array<ExecutionParams>): ExecutionPa
       definitions: [mergedOperationDefinition, ...mergedFragmentDefinitions],
     },
     variables: mergedVariables,
+    extensions: mergedExtensions,
     context: execs[0].context,
     info: execs[0].info,
   };

--- a/packages/delegate/src/mergeExecutionParams.ts
+++ b/packages/delegate/src/mergeExecutionParams.ts
@@ -1,0 +1,278 @@
+// adapted from https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-graphql/src/batching/merge-queries.js
+
+import {
+  visit,
+  Kind,
+  DefinitionNode,
+  OperationDefinitionNode,
+  DocumentNode,
+  FragmentDefinitionNode,
+  VariableDefinitionNode,
+  SelectionNode,
+  FragmentSpreadNode,
+  VariableNode,
+  VisitorKeyMap,
+  ASTKindToNode,
+  InlineFragmentNode,
+  FieldNode,
+  OperationTypeNode,
+} from 'graphql';
+
+import { createPrefix } from './prefix';
+import { ExecutionParams } from './types';
+
+/**
+ * Merge multiple queries into a single query in such a way that query results
+ * can be split and transformed as if they were obtained by running original queries.
+ *
+ * Merging algorithm involves several transformations:
+ *  1. Replace top-level fragment spreads with inline fragments (... on Query {})
+ *  2. Add unique aliases to all top-level query fields (including those on inline fragments)
+ *  3. Prefix all variable definitions and variable usages
+ *  4. Prefix names (and spreads) of fragments
+ *
+ * i.e transform:
+ *   [
+ *     `query Foo($id: ID!) { foo, bar(id: $id), ...FooQuery }
+ *     fragment FooQuery on Query { baz }`,
+ *
+ *    `query Bar($id: ID!) { foo: baz, bar(id: $id), ... on Query { baz } }`
+ *   ]
+ * to:
+ *   query (
+ *     $graphqlTools1_id: ID!
+ *     $graphqlTools2_id: ID!
+ *   ) {
+ *     graphqlTools1_foo: foo,
+ *     graphqlTools1_bar: bar(id: $graphqlTools1_id)
+ *     ... on Query {
+ *       graphqlTools1__baz: baz
+ *     }
+ *     graphqlTools1__foo: baz
+ *     graphqlTools1__bar: bar(id: $graphqlTools1__id)
+ *     ... on Query {
+ *       graphqlTools1__baz: baz
+ *     }
+ *   }
+ */
+export function mergeExecutionParams(execs: Array<ExecutionParams>): ExecutionParams {
+  const mergedVariables: Record<string, any> = Object.create(null);
+  const mergedVariableDefinitions: Array<VariableDefinitionNode> = [];
+  const mergedSelections: Array<SelectionNode> = [];
+  const mergedFragmentDefinitions: Array<FragmentDefinitionNode> = [];
+
+  let operation: OperationTypeNode;
+
+  execs.forEach((executionParams, index) => {
+    const prefixedExecutionParams = prefixExecutionParams(createPrefix(index), executionParams);
+
+    prefixedExecutionParams.document.definitions.forEach(def => {
+      if (isOperationDefinition(def)) {
+        operation = def.operation;
+        mergedSelections.push(...def.selectionSet.selections);
+        mergedVariableDefinitions.push(...(def.variableDefinitions ?? []));
+      }
+      if (isFragmentDefinition(def)) {
+        mergedFragmentDefinitions.push(def);
+      }
+    });
+    Object.assign(mergedVariables, prefixedExecutionParams.variables);
+  });
+
+  const mergedOperationDefinition: OperationDefinitionNode = {
+    kind: Kind.OPERATION_DEFINITION,
+    operation,
+    variableDefinitions: mergedVariableDefinitions,
+    selectionSet: {
+      kind: Kind.SELECTION_SET,
+      selections: mergedSelections,
+    },
+  };
+
+  return {
+    document: {
+      kind: Kind.DOCUMENT,
+      definitions: [mergedOperationDefinition, ...mergedFragmentDefinitions],
+    },
+    variables: mergedVariables,
+    context: execs[0].context,
+    info: execs[0].info,
+  };
+}
+
+function prefixExecutionParams(prefix: string, executionParams: ExecutionParams): ExecutionParams {
+  let document = aliasTopLevelFields(prefix, executionParams.document);
+  const variableNames = Object.keys(executionParams.variables);
+
+  if (variableNames.length === 0) {
+    return { ...executionParams, document };
+  }
+
+  document = visit(document, {
+    [Kind.VARIABLE]: (node: VariableNode) => prefixNodeName(node, prefix),
+    [Kind.FRAGMENT_DEFINITION]: (node: FragmentDefinitionNode) => prefixNodeName(node, prefix),
+    [Kind.FRAGMENT_SPREAD]: (node: FragmentSpreadNode) => prefixNodeName(node, prefix),
+  });
+
+  const prefixedVariables = variableNames.reduce((acc, name) => {
+    acc[prefix + name] = executionParams.variables[name];
+    return acc;
+  }, Object.create(null));
+
+  return {
+    document,
+    variables: prefixedVariables,
+  };
+}
+
+/**
+ * Adds prefixed aliases to top-level fields of the query.
+ *
+ * @see aliasFieldsInSelection for implementation details
+ */
+function aliasTopLevelFields(prefix: string, document: DocumentNode): DocumentNode {
+  const transformer = {
+    [Kind.OPERATION_DEFINITION]: (def: OperationDefinitionNode) => {
+      const { selections } = def.selectionSet;
+      return {
+        ...def,
+        selectionSet: {
+          ...def.selectionSet,
+          selections: aliasFieldsInSelection(prefix, selections, document),
+        },
+      };
+    },
+  };
+  return visit(document, transformer, ({ [Kind.DOCUMENT]: [`definitions`] } as unknown) as VisitorKeyMap<
+    ASTKindToNode
+  >);
+}
+
+/**
+ * Add aliases to fields of the selection, including top-level fields of inline fragments.
+ * Fragment spreads are converted to inline fragments and their top-level fields are also aliased.
+ *
+ * Note that this method is shallow. It adds aliases only to the top-level fields and doesn't
+ * descend to field sub-selections.
+ *
+ * For example, transforms:
+ *   {
+ *     foo
+ *     ... on Query { foo }
+ *     ...FragmentWithBarField
+ *   }
+ * To:
+ *   {
+ *     graphqlTools1_foo: foo
+ *     ... on Query { graphqlTools1_foo: foo }
+ *     ... on Query { graphqlTools1_bar: bar }
+ *   }
+ */
+function aliasFieldsInSelection(
+  prefix: string,
+  selections: ReadonlyArray<SelectionNode>,
+  document: DocumentNode
+): Array<SelectionNode> {
+  return selections.map(selection => {
+    switch (selection.kind) {
+      case Kind.INLINE_FRAGMENT:
+        return aliasFieldsInInlineFragment(prefix, selection, document);
+      case Kind.FRAGMENT_SPREAD: {
+        const inlineFragment = inlineFragmentSpread(selection, document);
+        return aliasFieldsInInlineFragment(prefix, inlineFragment, document);
+      }
+      case Kind.FIELD:
+      default:
+        return aliasField(selection, prefix);
+    }
+  });
+}
+
+/**
+ * Add aliases to top-level fields of the inline fragment.
+ * Returns new inline fragment node.
+ *
+ * For Example, transforms:
+ *   ... on Query { foo, ... on Query { bar: foo } }
+ * To
+ *   ... on Query { graphqlTools1_foo: foo, ... on Query { graphqlTools1_bar: foo } }
+ */
+function aliasFieldsInInlineFragment(
+  prefix: string,
+  fragment: InlineFragmentNode,
+  document: DocumentNode
+): InlineFragmentNode {
+  const { selections } = fragment.selectionSet;
+  return {
+    ...fragment,
+    selectionSet: {
+      ...fragment.selectionSet,
+      selections: aliasFieldsInSelection(prefix, selections, document),
+    },
+  };
+}
+
+/**
+ * Replaces fragment spread with inline fragment
+ *
+ * Example:
+ *   query { ...Spread }
+ *   fragment Spread on Query { bar }
+ *
+ * Transforms to:
+ *   query { ... on Query { bar } }
+ */
+function inlineFragmentSpread(spread: FragmentSpreadNode, document: DocumentNode): InlineFragmentNode {
+  const fragment = document.definitions.find(
+    def => isFragmentDefinition(def) && def.name.value === spread.name.value
+  ) as FragmentDefinitionNode;
+  if (!fragment) {
+    throw new Error(`Fragment ${spread.name.value} does not exist`);
+  }
+  const { typeCondition, selectionSet } = fragment;
+  return {
+    kind: Kind.INLINE_FRAGMENT,
+    typeCondition,
+    selectionSet,
+    directives: spread.directives,
+  };
+}
+
+function prefixNodeName<T extends VariableNode | FragmentDefinitionNode | FragmentSpreadNode>(
+  namedNode: T,
+  prefix: string
+): T {
+  return {
+    ...namedNode,
+    name: {
+      ...namedNode.name,
+      value: prefix + namedNode.name.value,
+    },
+  };
+}
+
+/**
+ * Returns a new FieldNode with prefixed alias
+ *
+ * Example. Given prefix === "graphqlTools1_" transforms:
+ *   { foo } -> { graphqlTools1_foo: foo }
+ *   { foo: bar } -> { graphqlTools1_foo: bar }
+ */
+function aliasField(field: FieldNode, aliasPrefix: string): FieldNode {
+  const aliasNode = field.alias ? field.alias : field.name;
+  return {
+    ...field,
+    alias: {
+      ...aliasNode,
+      value: aliasPrefix + aliasNode.value,
+    },
+  };
+}
+
+function isOperationDefinition(def: DefinitionNode): def is OperationDefinitionNode {
+  return def.kind === Kind.OPERATION_DEFINITION;
+}
+
+function isFragmentDefinition(def: DefinitionNode): def is FragmentDefinitionNode {
+  return def.kind === Kind.FRAGMENT_DEFINITION;
+}

--- a/packages/delegate/src/prefix.ts
+++ b/packages/delegate/src/prefix.ts
@@ -1,0 +1,13 @@
+// adapted from https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-graphql/src/batching/merge-queries.js
+
+export function createPrefix(index: number): string {
+  return `graphqlTools${index}_`;
+}
+
+export function parseKey(prefixedKey: string): { index: number; originalKey: string } {
+  const match = /^graphqlTools([\d]+)_(.*)$/.exec(prefixedKey);
+  if (match && match.length === 3 && !isNaN(Number(match[1])) && match[2]) {
+    return { index: Number(match[1]), originalKey: match[2] };
+  }
+  return null;
+}

--- a/packages/delegate/src/splitResult.ts
+++ b/packages/delegate/src/splitResult.ts
@@ -1,0 +1,63 @@
+// adapted from https://github.com/gatsbyjs/gatsby/blob/master/packages/gatsby-source-graphql/src/batching/merge-queries.js
+
+import { ExecutionResult, GraphQLError } from 'graphql';
+
+import { relocatedError } from '@graphql-tools/utils';
+
+import { parseKey } from './prefix';
+
+/**
+ * Split and transform result of the query produced by the `merge` function
+ */
+export function splitResult(mergedResult: ExecutionResult, numResults: number): Array<ExecutionResult> {
+  const splitResults: Array<ExecutionResult> = [];
+  for (let i = 0; i < numResults; i++) {
+    splitResults.push({});
+  }
+
+  const data = mergedResult.data;
+  if (data) {
+    Object.keys(data).forEach(prefixedKey => {
+      const { index, originalKey } = parseKey(prefixedKey);
+      if (!splitResults[index].data) {
+        splitResults[index].data = { [originalKey]: data[prefixedKey] };
+      } else {
+        splitResults[index].data[originalKey] = data[prefixedKey];
+      }
+    });
+  }
+
+  const errors = mergedResult.errors;
+  if (errors) {
+    const newErrors: Record<string, Array<GraphQLError>> = Object.create(null);
+    errors.forEach(error => {
+      if (error.path) {
+        const parsedKey = parseKey(error.path[0] as string);
+        if (parsedKey) {
+          const { index, originalKey } = parsedKey;
+          const newError = relocatedError(error, [originalKey, ...error.path.slice(1)]);
+          if (!newErrors[index]) {
+            newErrors[index] = [newError];
+          } else {
+            newErrors[index].push(newError);
+          }
+          return;
+        }
+      }
+
+      splitResults.forEach((_splitResult, index) => {
+        if (!newErrors[index]) {
+          newErrors[index] = [error];
+        } else {
+          newErrors[index].push(error);
+        }
+      });
+    });
+
+    Object.keys(newErrors).forEach(index => {
+      splitResults[index].errors = newErrors[index];
+    });
+  }
+
+  return splitResults;
+}

--- a/packages/delegate/src/types.ts
+++ b/packages/delegate/src/types.ts
@@ -95,6 +95,7 @@ export interface MergedTypeInfo {
 export interface ExecutionParams<TArgs = Record<string, any>, TContext = any> {
   document: DocumentNode;
   variables?: TArgs;
+  extensions?: Record<string, any>;
   context?: TContext;
   info?: GraphQLResolveInfo;
 }
@@ -134,6 +135,10 @@ export interface SubschemaConfig<K = any, V = any, C = K> {
   merge?: Record<string, MergedTypeConfig>;
   batch?: boolean;
   batchingOptions?: {
+    extensionsReducer?: (
+      mergedExtensions: Record<string, any>,
+      executionParams: ExecutionParams
+    ) => Record<string, any>;
     dataLoaderOptions?: DataLoader.Options<K, V, C>;
   };
 }

--- a/packages/delegate/src/types.ts
+++ b/packages/delegate/src/types.ts
@@ -16,6 +16,7 @@ import {
 import { Operation, Transform, Request, TypeMap, ExecutionResult } from '@graphql-tools/utils';
 
 import { Subschema } from './Subschema';
+import DataLoader from 'dataloader';
 
 export interface DelegationContext {
   subschema: GraphQLSchema | SubschemaConfig;
@@ -123,7 +124,7 @@ export interface ICreateProxyingResolverOptions {
 
 export type CreateProxyingResolverFn = (options: ICreateProxyingResolverOptions) => GraphQLFieldResolver<any, any>;
 
-export interface SubschemaConfig {
+export interface SubschemaConfig<K = any, V = any, C = K> {
   schema: GraphQLSchema;
   rootValue?: Record<string, any>;
   executor?: Executor;
@@ -131,6 +132,10 @@ export interface SubschemaConfig {
   createProxyingResolver?: CreateProxyingResolverFn;
   transforms?: Array<Transform>;
   merge?: Record<string, MergedTypeConfig>;
+  batch?: boolean;
+  batchingOptions?: {
+    dataLoaderOptions?: DataLoader.Options<K, V, C>;
+  };
 }
 
 export interface MergedTypeConfig<K = any, V = any> {

--- a/packages/delegate/tests/batchExecution.test.ts
+++ b/packages/delegate/tests/batchExecution.test.ts
@@ -1,0 +1,61 @@
+import { graphql, execute, ExecutionResult } from 'graphql';
+
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { delegateToSchema, SubschemaConfig, ExecutionParams, SyncExecutor } from '../src';
+
+describe('batch execution', () => {
+  it('should batch', async () => {
+    const innerSchema = makeExecutableSchema({
+      typeDefs: `
+        type Query {
+          field1: String
+          field2: String
+        }
+      `,
+      resolvers: {
+        Query: {
+          field1: () => 'test1',
+          field2: () => 'test2',
+        },
+      },
+    });
+
+    let executions = 0;
+
+    const innerSubschemaConfig: SubschemaConfig = {
+      schema: innerSchema,
+      batch: true,
+      executor: ((params: ExecutionParams): ExecutionResult => {
+        executions++;
+        return execute(innerSchema, params.document, undefined, params.context, params.variables) as ExecutionResult;
+      }) as SyncExecutor
+    }
+
+    const outerSchema = makeExecutableSchema({
+      typeDefs: `
+        type Query {
+          field1: String
+          field2: String
+        }
+      `,
+      resolvers: {
+        Query: {
+          field1: (_parent, _args, context, info) => delegateToSchema({ schema: innerSubschemaConfig, context, info }),
+          field2: (_parent, _args, context, info) => delegateToSchema({ schema: innerSubschemaConfig, context, info }),
+        },
+      },
+    });
+
+    const expectedResult = {
+      data: {
+        field1: 'test1',
+        field2: 'test2',
+      },
+    };
+
+    const result = await graphql(outerSchema, '{ field1 field2 }', undefined, {});
+
+    expect(result).toEqual(expectedResult);
+    expect(executions).toEqual(1);
+  });
+});

--- a/packages/stitch/tests/alternateStitchSchemas.test.ts
+++ b/packages/stitch/tests/alternateStitchSchemas.test.ts
@@ -147,14 +147,17 @@ describe('merge schemas through transforms', () => {
     const propertySubschema = {
       schema: propertySchema,
       transforms: propertySchemaTransforms,
+      batch: true,
     };
     const bookingSubschema = {
       ...bookingSubschemaConfig,
       transforms: bookingSchemaTransforms,
+      batch: true,
     };
     const subscriptionSubschema = {
       schema: subscriptionSchema,
       transforms: subscriptionSchemaTransforms,
+      batch: true,
     };
 
     stitchedSchema = stitchSchemas({

--- a/packages/stitch/tests/fixtures/schemas.ts
+++ b/packages/stitch/tests/fixtures/schemas.ts
@@ -724,6 +724,7 @@ export async function makeSchemaRemote(
     schema: clientSchema,
     executor,
     subscriber,
+    batch: true,
   };
 }
 

--- a/packages/stitch/tests/stitchSchemas.test.ts
+++ b/packages/stitch/tests/stitchSchemas.test.ts
@@ -588,6 +588,8 @@ testCombinations.forEach((combination) => {
               test3: jsonTest(input: "6")
             }
           `,
+          undefined,
+          {},
         );
 
         expect(propertyResult).toEqual({
@@ -628,6 +630,8 @@ testCombinations.forEach((combination) => {
               }
             }
           `,
+          undefined,
+          {},
         );
 
         expect(scalarResult).toEqual({
@@ -714,6 +718,8 @@ testCombinations.forEach((combination) => {
               }
             }
           `,
+          undefined,
+          {},
         );
 
         expect(enumResult).toEqual({
@@ -783,9 +789,11 @@ bookingById(id: "b1") {
         const stitchedResult = await graphql(
           stitchedSchema,
           `query {
-      ${propertyFragment}
-      ${bookingFragment}
-    }`,
+            ${propertyFragment}
+            ${bookingFragment}
+          }`,
+          undefined,
+          {},
         );
         expect(stitchedResult).toEqual({
           data: {
@@ -977,6 +985,8 @@ bookingById(id: "b1") {
               }
             }
           `,
+          undefined,
+          {},
         );
 
         expect(stitchedResult).toEqual({
@@ -1043,7 +1053,7 @@ bookingById(id: "b1") {
           }
         `;
         const propertyResult = await graphql(localPropertySchema, query);
-        const stitchedResult = await graphql(stitchedSchema, query);
+        const stitchedResult = await graphql(stitchedSchema, query, undefined, {});
 
         expect(propertyResult).toEqual({
           data: {
@@ -1078,7 +1088,7 @@ bookingById(id: "b1") {
           }
         `;
 
-        const mergedDelegate = await graphql(stitchedSchema, delegateQuery);
+        const mergedDelegate = await graphql(stitchedSchema, delegateQuery, undefined, {});
 
         expect(mergedDelegate).toEqual({
           data: {
@@ -1112,6 +1122,8 @@ bookingById(id: "b1") {
               }
             }
           `,
+          undefined,
+          {},
         );
 
         expect(stitchedResult).toEqual({
@@ -1146,6 +1158,8 @@ bookingById(id: "b1") {
               }
             }
           `,
+          undefined,
+          {},
         );
 
         expect(stitchedResult).toEqual({
@@ -1189,7 +1203,7 @@ bookingById(id: "b1") {
             }
           }
         `;
-        const stitchedResult = await graphql(stitchedSchema, query);
+        const stitchedResult = await graphql(stitchedSchema, query, undefined, {});
         expect(stitchedResult).toEqual({
           data: {
             test1: {
@@ -1228,6 +1242,8 @@ bookingById(id: "b1") {
               }
             }
           `,
+          undefined,
+          {},
         );
 
         expect(stitchedResult).toEqual({
@@ -1270,6 +1286,8 @@ bookingById(id: "b1") {
               __typename
             }
           `,
+          undefined,
+          {},
         );
 
         expect(stitchedResult).toEqual({
@@ -1292,6 +1310,8 @@ bookingById(id: "b1") {
               two: defaultInputTest(input: { test: "Bar" })
             }
           `,
+          undefined,
+          {},
         );
 
         expect(stitchedResult).toEqual({
@@ -1323,6 +1343,8 @@ bookingById(id: "b1") {
               }
             }
           `,
+          undefined,
+          {},
         );
 
         expect(stitchedResult).toEqual({
@@ -1364,6 +1386,8 @@ bookingById(id: "b1") {
               }
             }
           `,
+          undefined,
+          {},
         );
 
         expect(stitchedResult).toEqual({
@@ -1578,6 +1602,8 @@ bookingById(id: "b1") {
               test3: jsonTest(input: "6")
             }
           `,
+          undefined,
+          {},
         );
         const expected = {
           data: {
@@ -1652,6 +1678,8 @@ fragment BookingFragment on Booking {
               }
             }
           `,
+          undefined,
+          {},
         );
 
         expect(stitchedResult).toEqual({
@@ -1697,9 +1725,11 @@ bookingById(id: "b1") {
         const stitchedResult = await graphql(
           stitchedSchema,
           `query {
-      ${propertyFragment}
-      ${bookingFragment}
-    }`,
+            ${propertyFragment}
+            ${bookingFragment}
+          }`,
+          undefined,
+          {},
         );
 
         expect(stitchedResult).toEqual({
@@ -1741,6 +1771,8 @@ bookingById(id: "b1") {
               name
             }
           `,
+          undefined,
+          {},
         );
 
         expect(stitchedResult).toEqual({
@@ -1838,6 +1870,8 @@ fragment BookingFragment on Booking {
               }
             }
           `,
+          undefined,
+          {},
         );
 
         expect(stitchedResult).toEqual({
@@ -1881,6 +1915,8 @@ fragment BookingFragment on Booking {
               }
             }
           `,
+          undefined,
+          {},
         );
 
         expect(stitchedResult).toEqual({
@@ -1938,6 +1974,8 @@ fragment BookingFragment on Booking {
               }
             }
           `,
+          undefined,
+          {},
         );
 
         expect(stitchedResult).toEqual({
@@ -1989,6 +2027,8 @@ fragment BookingFragment on Booking {
               }
             }
           `,
+          undefined,
+          {},
         );
 
         expect(stitchedResult).toEqual({
@@ -2153,6 +2193,8 @@ fragment BookingFragment on Booking {
               }
             }
           `,
+          undefined,
+          {},
         );
 
         expect(result).toEqual({
@@ -2222,6 +2264,8 @@ fragment BookingFragment on Booking {
               }
             }
           `,
+          undefined,
+          {},
         );
 
         expect(result).toEqual({
@@ -2292,6 +2336,8 @@ fragment BookingFragment on Booking {
             ${propertyFragment}
             ${bookingFragment}
           }`,
+          undefined,
+          {},
         );
         expect(stitchedResult.data).toEqual({
           ...propertyResult.data,
@@ -2304,11 +2350,13 @@ fragment BookingFragment on Booking {
         const stitchedResult2 = await graphql(
           stitchedSchema,
           `
-                query {
-                  errorTestNonNull
-                  ${bookingFragment}
-                }
-              `,
+            query {
+              errorTestNonNull
+              ${bookingFragment}
+            }
+          `,
+          undefined,
+          {},
         );
 
         expect(stitchedResult2.data).toBe(null);
@@ -2336,6 +2384,8 @@ fragment BookingFragment on Booking {
               }
             }
           `,
+          undefined,
+          {},
         );
 
         expect(result.data).toEqual({
@@ -2422,7 +2472,7 @@ fragment BookingFragment on Booking {
             propertyQuery,
           );
 
-          const stitchedResult = await graphql(stitchedSchema, propertyQuery);
+          const stitchedResult = await graphql(stitchedSchema, propertyQuery, undefined, {});
 
           [propertyResult, stitchedResult].forEach((result) => {
             expect(result.errors).toBeDefined();
@@ -2496,6 +2546,8 @@ fragment BookingFragment on Booking {
               }
             }
           `,
+          undefined,
+          {},
         );
 
         expect(result).toEqual({
@@ -2694,6 +2746,8 @@ fragment BookingFragment on Booking {
               }
             }
           `,
+          undefined,
+          {},
         );
 
         expect(result).toEqual({
@@ -2727,6 +2781,8 @@ fragment BookingFragment on Booking {
               }
             }
           `,
+          undefined,
+          {},
         );
 
         expect(result).toEqual({
@@ -2763,6 +2819,8 @@ fragment BookingFragment on Booking {
               }
             }
           `,
+          undefined,
+          {},
         );
 
         expect(result).toEqual({
@@ -2817,6 +2875,8 @@ fragment BookingFragment on Booking {
               }
             }
           `,
+          undefined,
+          {},
         );
 
         expect(result).toEqual({
@@ -2840,6 +2900,8 @@ fragment BookingFragment on Booking {
               }
             }
           `,
+          undefined,
+          {},
         );
 
         expect(result).toEqual({

--- a/packages/stitch/tests/typeMerging.test.ts
+++ b/packages/stitch/tests/typeMerging.test.ts
@@ -60,6 +60,7 @@ describe('merging using type merging', () => {
               selectionSet: '{ id }',
             },
           },
+          batch: true,
         },
         {
           schema: authorSchema,
@@ -70,6 +71,7 @@ describe('merging using type merging', () => {
               selectionSet: '{ id }',
             },
           },
+          batch: true,
         },
       ],
       mergeTypes: true,
@@ -96,7 +98,12 @@ describe('merging using type merging', () => {
       }
     `;
 
-    const result = await graphql(stitchedSchema, query);
+    const result = await graphql(
+      stitchedSchema,
+      query,
+      undefined,
+      {},
+    );
 
     expect(result.errors).toBeUndefined();
     expect(result.data.userById.__typename).toBe('User');
@@ -148,7 +155,8 @@ describe('merging using type merging', () => {
               selectionSet: '{ id }',
               args: (originalResult) => ({ id: originalResult.id }),
             }
-          }
+          },
+          batch: true,
         },
         {
           schema: userSchema,
@@ -158,7 +166,8 @@ describe('merging using type merging', () => {
               selectionSet: '{ id }',
               args: (originalResult) => ({ id: originalResult.id }),
             }
-          }
+          },
+          batch: true,
         },
       ],
       mergeTypes: true
@@ -170,7 +179,12 @@ describe('merging using type merging', () => {
       }
     `;
 
-    const result = await graphql(stitchedSchema, query);
+    const result = await graphql(
+      stitchedSchema,
+      query,
+      undefined,
+      {},
+    );
 
     expect(result.errors).not.toBeUndefined();
     expect(result.data).toMatchObject({ userById: { fail: null }});
@@ -235,6 +249,7 @@ describe('merging using type merging', () => {
       subschemas: [
         {
           schema: resultSchema,
+          batch: true,
         },
         {
           schema: containerSchemaA,
@@ -245,6 +260,7 @@ describe('merging using type merging', () => {
               selectionSet: '{ id }',
             },
           },
+          batch: true,
         },
         {
           schema: containerSchemaB,
@@ -255,6 +271,7 @@ describe('merging using type merging', () => {
               selectionSet: '{ id }',
             },
           },
+          batch: true,
         },
       ],
       mergeTypes: true,
@@ -294,6 +311,8 @@ describe('merging using type merging', () => {
           }
         }
       `,
+      undefined,
+      {},
     );
 
     const expectedResult = {


### PR DESCRIPTION
When `batch` is set to true for a given subschemaConfig, batches all delegated root fields into a combined request passed to the executor. Moreover, batches all requests to a given subschema into the minimum number of requests, collecting queries and mutations separately, preserving operation order. Distributes properly pathed errors to the originating requests.

Adapted from Gatsby query batcher by @vladar.

Caveats:
* Uses a Dataloader under the hood, which is created anew upon each request -- relies on a unique context argument per request to make this happen!
* Passed `info` argument from first executor call to the batched executor call, making info argument unreliable.

Related:

https://github.com/gatsbyjs/gatsby/pull/22347#issuecomment-609727851
https://github.com/ardatan/graphql-tools/issues/1710#issuecomment-652355934
https://github.com/ardatan/graphql-tools/issues/1959#issuecomment-683336594
https://github.com/ardatan/graphql-tools/issues/1954