### PR TITLE
enhance(stitch): simplify subschema sets

### DIFF
--- a/packages/delegate/src/Subschema.ts
+++ b/packages/delegate/src/Subschema.ts
@@ -2,14 +2,7 @@ import { GraphQLSchema } from 'graphql';
 
 import { Transform, applySchemaTransforms } from '@graphql-tools/utils';
 
-import {
-  SubschemaConfig,
-  MergedTypeConfig,
-  CreateProxyingResolverFn,
-  Subscriber,
-  Executor,
-  SubschemaSetConfig,
-} from './types';
+import { SubschemaConfig, MergedTypeConfig, CreateProxyingResolverFn, Subscriber, Executor } from './types';
 
 import { FIELD_SUBSCHEMA_MAP_SYMBOL, OBJECT_SUBSCHEMA_SYMBOL } from './symbols';
 
@@ -27,10 +20,6 @@ export function isSubschemaConfig(value: any): value is SubschemaConfig | Subsch
 }
 export function isSubschema(value: any): value is Subschema {
   return Boolean(value.transformedSchema);
-}
-
-export function isSubschemaSetConfig(value: any): value is SubschemaSetConfig {
-  return Boolean(value.permutations);
 }
 
 export class Subschema {

--- a/packages/delegate/src/index.ts
+++ b/packages/delegate/src/index.ts
@@ -3,7 +3,7 @@ export { createRequestFromInfo, createRequest } from './createRequest';
 export { defaultMergedResolver } from './defaultMergedResolver';
 export { createMergedResolver } from './createMergedResolver';
 export { handleResult } from './results/handleResult';
-export { Subschema, isSubschema, isSubschemaConfig, isSubschemaSetConfig, getSubschema } from './Subschema';
+export { Subschema, isSubschema, isSubschemaConfig, getSubschema } from './Subschema';
 
 export * from './delegationBindings';
 export * from './transforms';

--- a/packages/delegate/src/types.ts
+++ b/packages/delegate/src/types.ts
@@ -139,10 +139,6 @@ export interface Endpoint<K = any, V = any, C = K> {
   };
 }
 
-export interface NamedEndpoint extends Endpoint {
-  name: string;
-}
-
 export interface SubschemaPermutation {
   createProxyingResolver?: CreateProxyingResolverFn;
   transforms?: Array<Transform>;
@@ -151,13 +147,7 @@ export interface SubschemaPermutation {
 
 export interface SubschemaConfig<K = any, V = any, C = K> extends SubschemaPermutation, Endpoint<K, V, C> {
   schema: GraphQLSchema;
-  endpoint?: Endpoint | string;
-}
-
-export interface SubschemaSetConfig<K = any, V = any, C = K> extends Endpoint<K, V, C> {
-  schema: GraphQLSchema;
-  permutations: Array<SubschemaPermutation>;
-  endpoint: Endpoint;
+  endpoint?: Endpoint;
 }
 
 export interface MergedTypeConfig<K = any, V = any> {

--- a/packages/stitch/src/stitchSchemas.ts
+++ b/packages/stitch/src/stitchSchemas.ts
@@ -26,11 +26,10 @@ import {
 import { buildTypeCandidates, buildTypeMap } from './typeCandidates';
 import { createStitchingInfo, completeStitchingInfo, addStitchingInfo } from './stitchingInfo';
 import { IStitchSchemasOptions } from './types';
-import { SubschemaConfig, isSubschemaConfig, isSubschemaSetConfig } from '@graphql-tools/delegate';
+import { SubschemaConfig, isSubschemaConfig } from '@graphql-tools/delegate';
 
 export function stitchSchemas({
   subschemas = [],
-  endpoints = [],
   types = [],
   typeDefs,
   schemas = [],
@@ -55,18 +54,11 @@ export function stitchSchemas({
 
   let schemaLikeObjects: Array<GraphQLSchema | SubschemaConfig | DocumentNode | GraphQLNamedType> = [];
 
-  subschemas.forEach(subschema => {
-    if (isSubschemaSetConfig(subschema)) {
-      const { schema, permutations, endpoint } = subschema;
-      permutations.forEach(permutation => {
-        schemaLikeObjects.push({
-          schema,
-          ...permutation,
-          endpoint,
-        });
-      });
+  subschemas.forEach(subschemaOrSubschemaArray => {
+    if (Array.isArray(subschemaOrSubschemaArray)) {
+      schemaLikeObjects = schemaLikeObjects.concat(subschemaOrSubschemaArray);
     } else {
-      schemaLikeObjects.push(subschema);
+      schemaLikeObjects.push(subschemaOrSubschemaArray);
     }
   });
 
@@ -133,7 +125,7 @@ export function stitchSchemas({
     directives.push(directiveMap[directiveName]);
   });
 
-  let stitchingInfo = createStitchingInfo(transformedSchemas, typeCandidates, mergeTypes, endpoints);
+  let stitchingInfo = createStitchingInfo(transformedSchemas, typeCandidates, mergeTypes);
 
   const typeMap = buildTypeMap({
     typeCandidates,

--- a/packages/stitch/src/stitchingInfo.ts
+++ b/packages/stitch/src/stitchingInfo.ts
@@ -23,7 +23,7 @@ import {
   IFieldResolverOptions,
 } from '@graphql-tools/utils';
 
-import { delegateToSchema, isSubschemaConfig, SubschemaConfig, NamedEndpoint } from '@graphql-tools/delegate';
+import { delegateToSchema, isSubschemaConfig, SubschemaConfig } from '@graphql-tools/delegate';
 
 import { batchDelegateToSchema } from '@graphql-tools/batch-delegate';
 
@@ -32,8 +32,7 @@ import { MergeTypeCandidate, MergedTypeInfo, StitchingInfo, MergeTypeFilter } fr
 export function createStitchingInfo(
   transformedSchemas: Map<GraphQLSchema | SubschemaConfig, GraphQLSchema>,
   typeCandidates: Record<string, Array<MergeTypeCandidate>>,
-  mergeTypes?: boolean | Array<string> | MergeTypeFilter,
-  endpoints?: Array<NamedEndpoint>
+  mergeTypes?: boolean | Array<string> | MergeTypeFilter
 ): StitchingInfo {
   const mergedTypes = createMergedTypes(typeCandidates, mergeTypes);
   const selectionSetsByField: Record<string, Record<string, SelectionSetNode>> = Object.create(null);
@@ -88,10 +87,6 @@ export function createStitchingInfo(
     selectionSetsByField,
     dynamicSelectionSetsByField: undefined,
     mergedTypes,
-    endpoints: endpoints.reduce((acc, endpoint) => {
-      acc[endpoint.name] = endpoint;
-      return acc;
-    }, Object.create(null)),
   };
 }
 

--- a/packages/stitch/src/types.ts
+++ b/packages/stitch/src/types.ts
@@ -12,7 +12,7 @@ import {
   GraphQLInputObjectType,
 } from 'graphql';
 import { ITypeDefinitions, TypeMap } from '@graphql-tools/utils';
-import { SubschemaConfig, NamedEndpoint, Endpoint, SubschemaSetConfig } from '@graphql-tools/delegate';
+import { SubschemaConfig } from '@graphql-tools/delegate';
 import { IExecutableSchemaDefinition } from '@graphql-tools/schema';
 
 export interface MergeTypeCandidate {
@@ -55,14 +55,12 @@ export interface StitchingInfo {
   selectionSetsByField: Record<string, Record<string, SelectionSetNode>>;
   dynamicSelectionSetsByField: Record<string, Record<string, Array<(node: FieldNode) => SelectionSetNode>>>;
   mergedTypes: Record<string, MergedTypeInfo>;
-  endpoints: Record<string, Endpoint>;
 }
 
 export type SchemaLikeObject = SubschemaConfig | GraphQLSchema | string | DocumentNode | Array<GraphQLNamedType>;
 
 export interface IStitchSchemasOptions<TContext = any> extends Omit<IExecutableSchemaDefinition<TContext>, 'typeDefs'> {
-  subschemas?: Array<GraphQLSchema | SubschemaConfig | SubschemaSetConfig>;
-  endpoints?: Array<NamedEndpoint>;
+  subschemas?: Array<GraphQLSchema | SubschemaConfig | Array<SubschemaConfig>>;
   typeDefs?: ITypeDefinitions;
   types?: Array<GraphQLNamedType>;
   schemas?: Array<SchemaLikeObject>;


### PR DESCRIPTION
further simplified subschema config sets by simply using an array of SubschemaConfig objects

Named endpoints are no longer necessary, as common endpoints can simply be used by using identical (===) endpoint objects which will allow query batching across subschemas.

Technically, there is now no difference from including an array of SubschemaConfig objects within the `subschemas` property or simply spreading the arrray into the subschemas property, whatever is simpler for end-users.