### PR TITLE
enhance(stitch) Test merge conflicts

### DIFF
--- a/packages/stitch/tests/mergeConflicts.test.ts
+++ b/packages/stitch/tests/mergeConflicts.test.ts
@@ -1,0 +1,82 @@
+import { graphql } from 'graphql';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { stitchSchemas } from '@graphql-tools/stitch';
+
+describe('type merging with only field selection sets', () => {
+  const listings1Schema = makeExecutableSchema({
+    typeDefs: `
+      "ignore! - do not document here"
+      type Listing implements IListing {
+        "type identifier"
+        id: ID!
+      }
+      interface IListing {
+        "interface identifier"
+        id: ID!
+      }
+      "An input"
+      input ListingInput {
+        "input identifier"
+        id: ID!
+      }
+    `
+  });
+
+  const listings2Schema = makeExecutableSchema({
+    typeDefs: `
+      "A type"
+      type Listing implements IListing {
+        "ignore! - do not document here"
+        id: ID!
+      }
+      "An interface"
+      interface IListing {
+        id: ID!
+      }
+      input ListingInput {
+        "ignore! - do not document here"
+        id: ID!
+      }
+    `
+  });
+
+  it('does stuff', () => {
+    const gatewaySchema = stitchSchemas({
+      subschemas: [
+        { schema: listings1Schema },
+        { schema: listings2Schema },
+      ],
+      typeMergingOptions: {
+        typeDescriptionsMerger(candidates) {
+          const candidate = candidates.find(({ type }) => {
+            const description = (type.description || '').trim();
+            return description.length && !description.startsWith('ignore!');
+          }) || candidates[candidates.length-1];
+          return candidate.type.description;
+        },
+        fieldConfigMerger(candidates) {
+          const fieldConfigs = candidates.map(c => c.fieldConfig);
+          return fieldConfigs.find(({ description }) => {
+            description = (description || '').trim();
+            return description && !description.startsWith('ignore!');
+          }) || fieldConfigs[fieldConfigs.length-1];
+        },
+        inputFieldConfigMerger(candidates) {
+          const inputFieldConfig = candidates.map(c => c.inputFieldConfig);
+          return inputFieldConfig.find(({ description }) => {
+            description = (description || '').trim();
+            return description && !description.startsWith('ignore!');
+          }) || inputFieldConfig[inputFieldConfig.length-1];
+        }
+      },
+      mergeTypes: true
+    });
+
+    expect(gatewaySchema.getType('Listing').description).toEqual('A type');
+    expect(gatewaySchema.getType('IListing').description).toEqual('An interface');
+    expect(gatewaySchema.getType('ListingInput').description).toEqual('An input');
+    expect(gatewaySchema.getType('Listing').getFields().id.description).toEqual('type identifier');
+    expect(gatewaySchema.getType('IListing').getFields().id.description).toEqual('interface identifier');
+    expect(gatewaySchema.getType('ListingInput').getFields().id.description).toEqual('input identifier');
+  });
+});

--- a/packages/stitch/tests/mergeConflicts.test.ts
+++ b/packages/stitch/tests/mergeConflicts.test.ts
@@ -1,4 +1,3 @@
-import { graphql } from 'graphql';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { stitchSchemas } from '@graphql-tools/stitch';
 

--- a/packages/stitch/tests/mergeConflicts.test.ts
+++ b/packages/stitch/tests/mergeConflicts.test.ts
@@ -1,7 +1,7 @@
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { stitchSchemas } from '@graphql-tools/stitch';
 
-describe('type merging with only field selection sets', () => {
+describe('merge conflict handlers', () => {
   const listings1Schema = makeExecutableSchema({
     typeDefs: `
       "ignore! - do not document here"
@@ -39,7 +39,7 @@ describe('type merging with only field selection sets', () => {
     `
   });
 
-  it('does stuff', () => {
+  it('handles description merges', () => {
     const gatewaySchema = stitchSchemas({
       subschemas: [
         { schema: listings1Schema },


### PR DESCRIPTION
Adds tests for merge conflicts. These work well enough, although they're pretty opaque for an extremely common use case like picking the right docstring. It'd be nice if there was some way to provide a friendly facade for this type of setup along the lines of:

```js
combineDescriptions({ delimiter: '\n', ignorePrefix: 'ignore!' });
```

Obviously, we wouldn't want that to interfere with the ability to still take advantage of these merge handlers for other truly specialized use cases. Any ideas for how something like this could be cleanly packaged?

Either way, these tests hit merge handlers so provide worthwhile coverage!

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
