### PR TITLE
Increase maxBuffer to 1MB

### DIFF
--- a/packages/loaders/git/src/load-git.ts
+++ b/packages/loaders/git/src/load-git.ts
@@ -13,7 +13,7 @@ const createCommand = ({ ref, path }: Input) => {
 export async function loadFromGit(input: Input): Promise<string | never> {
   try {
     return await new Promise((resolve, reject) => {
-      exec(createCommand(input), { encoding: 'utf-8' }, (error, stdout) => {
+      exec(createCommand(input), { encoding: 'utf-8', maxBuffer: 1024 * 1024 * 1024 }, (error, stdout) => {
         if (error) {
           reject(error);
         } else {


### PR DESCRIPTION
This is bug fix

My `graphql.schema.json` grown to 1.5KB, and my schema validation broke:
```
graphql-inspector diff git:origin/master:graphql.schema.json ./graphql.schema.json
```

The error I'm getting is:  `Error: Unable to load file from git: RangeError [ERR_CHILD_PROCESS_STDIO_MAXBUFFER]: stdout maxBuffer length exceeded`

Fix is easy: increase buffer size to 1MB (default value was 1KB)

