### PR TITLE
Handle recursive input types when pruning schemas

### DIFF
--- a/packages/utils/src/prune.ts
+++ b/packages/utils/src/prune.ts
@@ -167,6 +167,7 @@ function visitInputType(
   }
 
   pruningContext.unusedTypes[type.name] = false;
+  visitedTypes[type.name] = true;
 
   if (isInputObjectType(type)) {
     const fields = type.getFields();
@@ -176,8 +177,6 @@ function visitInputType(
       visitInputType(visitedTypes, pruningContext, namedType);
     });
   }
-
-  visitedTypes[type.name] = true;
 }
 
 function visitTypes(pruningContext: PruningContext, schema: GraphQLSchema): void {

--- a/packages/utils/tests/prune.test.ts
+++ b/packages/utils/tests/prune.test.ts
@@ -1,0 +1,18 @@
+import { buildSchema } from 'graphql';
+
+import { pruneSchema } from '../src/prune';
+
+describe('prune', () => {
+  test('can handle recursive input types', () => {
+    const schema = buildSchema(`
+      input Input {
+        moreInput: Input
+      }
+
+      type Query {
+        someQuery(input: Input): Boolean
+      }
+      `);
+    pruneSchema(schema);
+  });
+});


### PR DESCRIPTION
When pruning schema with recursive types, a `RangeError: Maximum call stack size exceeded` error would be thrown