### PR TITLE
Fix bad stitching docs link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This package provides a few useful ways to create a GraphQL schema:
 
 1. Use the GraphQL schema language to [generate a schema](https://graphql-tools.com/docs/generate-schema) with full support for resolvers, interfaces, unions, and custom scalars. The schema produced is completely compatible with [GraphQL.js](https://github.com/graphql/graphql-js).
 2. [Mock your GraphQL API](https://graphql-tools.com/docs/mocking) with fine-grained per-type mocking
-3. Automatically [stitch multiple schemas together](https://www.graphql-tools.com/docs/stitch-combining-schemas) into one larger API
+3. Automatically [stitch multiple schemas together](https://graphql-tools.com/docs/stitch-combining-schemas) into one larger API
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This package provides a few useful ways to create a GraphQL schema:
 
 1. Use the GraphQL schema language to [generate a schema](https://graphql-tools.com/docs/generate-schema) with full support for resolvers, interfaces, unions, and custom scalars. The schema produced is completely compatible with [GraphQL.js](https://github.com/graphql/graphql-js).
 2. [Mock your GraphQL API](https://graphql-tools.com/docs/mocking) with fine-grained per-type mocking
-3. Automatically [stitch multiple schemas together](https://graphql-tools.com/docs/schema-stitching) into one larger API
+3. Automatically [stitch multiple schemas together](https://www.graphql-tools.com/docs/stitch-combining-schemas) into one larger API
 
 ## Documentation
 


### PR DESCRIPTION
> 3. Automatically stitch multiple schemas together into one larger API

Old link, shows 404: https://graphql-tools.com/docs/schema-stitching
Proposed correction: https://graphql-tools.com/docs/stitch-combining-schemas

Alternately, the copy could be changed slightly and the link could go to https://www.graphql-tools.com/docs/schema-delegation , which gives a more general-purpose overview of schema delegation options provided by `graphql-tools`.

(PS: speaking of https://www.graphql-tools.com/docs/schema-delegation , it links to https://www.graphql-tools.com/docs/stitch-api ("Schema stitching - merging multiple schemas into one"), but maybe https://www.graphql-tools.com/docs/stitch-combining-schemas would be better?