### PR TITLE
enhance(stitch) eager return handler for merged types

### DIFF
--- a/packages/delegate/src/types.ts
+++ b/packages/delegate/src/types.ts
@@ -159,7 +159,7 @@ export interface MergedTypeConfig<K = any, V = any> {
   key?: (originalResult: any) => K;
   argsFromKeys?: (keys: ReadonlyArray<K>) => Record<string, any>;
   valuesFromResults?: (results: any, keys: ReadonlyArray<K>) => Array<V>;
-  eagerReturn?: (originalResult: any, key?: any) => any;
+  eagerReturn?: (originalResult: any, key?: K) => any;
 }
 
 export interface MergedFieldConfig {

--- a/packages/delegate/src/types.ts
+++ b/packages/delegate/src/types.ts
@@ -159,6 +159,7 @@ export interface MergedTypeConfig<K = any, V = any> {
   key?: (originalResult: any) => K;
   argsFromKeys?: (keys: ReadonlyArray<K>) => Record<string, any>;
   valuesFromResults?: (results: any, keys: ReadonlyArray<K>) => Array<V>;
+  eagerReturn?: (originalResult: any, key?: any) => any;
 }
 
 export interface MergedFieldConfig {

--- a/packages/stitch/tests/eagerReturn.test.ts
+++ b/packages/stitch/tests/eagerReturn.test.ts
@@ -1,0 +1,152 @@
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { stitchSchemas } from '@graphql-tools/stitch';
+import { graphql } from 'graphql';
+
+describe('eager returns', () => {
+  let metadataRequests = 0;
+
+  const posts = [
+    { id: '1', productDealId: null, restaurantId: null },
+    { id: '2', productDealId: null, restaurantId: '2' },
+  ];
+
+  const postsSchema = makeExecutableSchema({
+    typeDefs: `
+      type Post {
+        id: ID!
+        productDealId: ID
+        restaurantId: ID
+      }
+      type Query {
+        post(id: ID!): Post
+      }
+    `,
+    resolvers: {
+      Query: {
+        post: (root, { id }) => posts.find(post => post.id === id),
+      }
+    }
+  });
+
+  const metadataSchema = makeExecutableSchema({
+    typeDefs: `
+      type ProductDeal {
+        id: ID!
+      }
+      type Restaurant {
+        id: ID!
+      }
+      type Post {
+        id: ID!
+        productDeal: ProductDeal
+        restaurant: Restaurant
+      }
+      input PostInput {
+        id: ID!
+        productDealId: ID
+        restaurantId: ID
+      }
+      type Query {
+        _posts(representations: [PostInput!]!): [Post]!
+      }
+    `,
+    resolvers: {
+      Query: {
+        _posts: (root, { representations }) => {
+          metadataRequests += 1;
+          return representations.map(({ id, productDealId, restaurantId }) => ({
+            id,
+            productDeal: productDealId ? { id: productDealId } : null,
+            restaurant: restaurantId ? { id: restaurantId } : null,
+          }));
+        },
+      }
+    }
+  });
+
+  const gatewaySchema = stitchSchemas({
+    subschemas: [
+      {
+        schema: postsSchema,
+        merge: {
+          Post: {
+            selectionSet: '{ id }',
+            fieldName: 'post',
+            args: ({ id }) => ({ id }),
+          },
+        },
+      },
+      {
+        schema: metadataSchema,
+        merge: {
+          Post: {
+            selectionSet: '{ id }',
+            fields: {
+              productDeal: { selectionSet: '{ productDealId }' },
+              restaurant: { selectionSet: '{ restaurantId }' },
+            },
+            fieldName: '_posts',
+            key: ({ id, productDealId, restaurantId }) => ({ id, productDealId, restaurantId }),
+            argsFromKeys: (representations) => ({ representations }),
+            eagerReturn: (originalObject, key) => {
+              return ['productDealId', 'restaurantId'].every(k => key[k] == null) ? originalObject : null;
+            },
+          },
+        },
+      },
+    ],
+    mergeTypes: true
+  });
+
+  beforeEach(() => {
+    metadataRequests = 0;
+  });
+
+  it('allows early return of empty keys', async () => {
+    const result = await graphql(gatewaySchema, `
+      query {
+        post(id: 1) {
+          id
+          productDeal {
+            id
+          }
+          restaurant {
+            id
+          }
+        }
+      }
+    `);
+
+    expect(metadataRequests).toEqual(0);
+    expect(result.data.post).toEqual({
+      id: '1',
+      productDeal: null,
+      restaurant: null,
+    });
+  });
+
+  it('proceeds as normal when eagerReturn passes', async () => {
+    const result = await graphql(gatewaySchema, `
+      query {
+        post(id: 2) {
+          id
+          productDeal {
+            id
+          }
+          restaurant {
+            id
+          }
+        }
+      }
+    `);
+
+    expect(metadataRequests).toEqual(1);
+    expect(result.data.post).toEqual({
+      id: '2',
+      productDeal: null,
+      restaurant: {
+        id: '2',
+      },
+    });
+  });
+});

--- a/website/docs/stitch-type-merging.md
+++ b/website/docs/stitch-type-merging.md
@@ -188,7 +188,12 @@ const gatewaySchema = stitchSchemas({
 });
 ```
 
-A `valuesFromResults` method may also be provided to map the raw query result into the batched set. With this array optimization in place, we'll now only perform one query per merged field. However, multiple merged fields will still perform a query each. To optimize this further, we can now enable query-level batching (as of GraphQL Tools v6.2):
+Additional batching functions may also be provided:
+
+- `eagerReturn`: accepts `originalObject` and `key`, and may eagerly return a modified object without triggering a batch request.
+- `valuesFromResults`: accepts `results` and `keys`, and may be used to map the raw query result into the batched set.
+
+With this array optimization in place, we'll now only perform one query per merged field. However, multiple merged fields will still perform a query each. To optimize this further, we can now enable query-level batching (as of GraphQL Tools v6.2):
 
 ```js
 {


### PR DESCRIPTION
Merge queries may implement non-primitive keys when passing input between services, for example:

**Primitive key**: `23` or `null`
**Input key**: `{ restaurantId: 23 }` or `{ restaurantId: null }`

The quirk of non-primitive keys is that they always constitute a truthy value, even when their input value is empty. This makes delegation always trigger networking to resolve the empty result, even though it is recognizably empty. To address this, this PR adds an `eagerReturn` handler to MergedTypeConfig:

```ts
eagerReturn?: (originalResult: any, key?: K) => any;
```

Eager return allows the original object and the (batched) object key to be examined prior to triggering delegation. This provides the opportunity to recognize an empty key and return direct modifications to the original object rather than triggering a delegation/request. An empty eager return will proceed with delegation as usual.

This intentionally places `eagerReturn` handling into the default MergedTypeConfig resolver functions rather than wiring it into delegation packages. When using `delegateToSchema` or `batchDelegateToSchema` directly, you'd do this type of preflight within your own implementation code. Thus, the `eagerReturn` handler is really only a courtesy to the merged types implementation.

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
