### PR TITLE
Support scalar extensions by merging directives

### DIFF
--- a/packages/merge/src/typedefs-mergers/merge-nodes.ts
+++ b/packages/merge/src/typedefs-mergers/merge-nodes.ts
@@ -17,6 +17,7 @@ import {
 } from './utils';
 import { mergeType } from './type';
 import { mergeEnum } from './enum';
+import { mergeScalar } from './scalar';
 import { mergeUnion } from './union';
 import { mergeInputType } from './input-type';
 import { mergeInterface } from './interface';
@@ -49,7 +50,7 @@ export function mergeGraphQLNodes(nodes: ReadonlyArray<DefinitionNode>, config?:
       } else if (isGraphQLUnion(nodeDefinition) || isGraphQLUnionExtension(nodeDefinition)) {
         prev[name] = mergeUnion(nodeDefinition, prev[name] as any, config);
       } else if (isGraphQLScalar(nodeDefinition) || isGraphQLScalarExtension(nodeDefinition)) {
-        prev[name] = nodeDefinition;
+        prev[name] = mergeScalar(nodeDefinition, prev[name] as any, config);
       } else if (isGraphQLInputType(nodeDefinition) || isGraphQLInputTypeExtension(nodeDefinition)) {
         prev[name] = mergeInputType(nodeDefinition, prev[name] as any, config);
       } else if (isGraphQLInterface(nodeDefinition) || isGraphQLInterfaceExtension(nodeDefinition)) {

--- a/packages/merge/src/typedefs-mergers/scalar.ts
+++ b/packages/merge/src/typedefs-mergers/scalar.ts
@@ -1,0 +1,31 @@
+import { ScalarTypeDefinitionNode, ScalarTypeExtensionNode } from 'graphql';
+import { mergeDirectives } from './directives';
+import { Config } from './merge-typedefs';
+
+export function mergeScalar(
+  node: ScalarTypeDefinitionNode | ScalarTypeExtensionNode,
+  existingNode: ScalarTypeDefinitionNode | ScalarTypeExtensionNode,
+  config?: Config
+): ScalarTypeDefinitionNode | ScalarTypeExtensionNode {
+  if (existingNode) {
+    return {
+      name: node.name,
+      description: node['description'] || existingNode['description'],
+      kind:
+        (config && config.convertExtensions) ||
+        node.kind === 'ScalarTypeDefinition' ||
+        existingNode.kind === 'ScalarTypeDefinition'
+          ? 'ScalarTypeDefinition'
+          : 'ScalarTypeExtension',
+      loc: node.loc,
+      directives: mergeDirectives(node.directives, existingNode.directives, config),
+    } as any;
+  }
+
+  return config && config.convertExtensions
+    ? {
+        ...node,
+        kind: 'ScalarTypeDefinition',
+      }
+    : node;
+}

--- a/packages/merge/tests/merge-typedefs.spec.ts
+++ b/packages/merge/tests/merge-typedefs.spec.ts
@@ -272,6 +272,24 @@ describe('Merge TypeDefs', () => {
       expect(schema.getType('UniqueId')).toBeDefined();
     });
 
+    it('should merge scalar directives', () => {
+      const merged = mergeTypeDefs([
+        `
+        scalar JSON
+        directive @sqlType(type: String!) on SCALAR
+        extend scalar JSON @sqlType(type: "json")
+        `
+      ]);
+
+      expect(stripWhitespaces(print(merged))).toBe(
+        stripWhitespaces(/* GraphQL */`
+          scalar JSON @sqlType(type: "json")
+
+          directive @sqlType(type: String!) on SCALAR
+          `
+        ));
+    });
+
     it('should merge descriptions', () => {
       const merged = mergeTypeDefs([
         `


### PR DESCRIPTION
Minor change to support [scalar extensions](https://spec.graphql.org/June2018/#sec-Scalar-Extensions) by merging scalar directives. Based on the logic from merging enums. Lint and tests pass.