### PR TITLE
Fix duplication of scalar directives in merge

### DIFF
--- a/packages/merge/tests/merge-schemas.spec.ts
+++ b/packages/merge/tests/merge-schemas.spec.ts
@@ -1,5 +1,5 @@
 import { makeExecutableSchema } from '@graphql-tools/schema';
-import { graphql, buildSchema, GraphQLScalarType, Kind, GraphQLSchema, ListValueNode } from 'graphql';
+import { graphql, buildSchema, GraphQLScalarType, Kind, GraphQLSchema, ListValueNode, print } from 'graphql';
 import { mergeSchemas, mergeSchemasAsync } from '../src/merge-schemas';
 import { printSchemaWithDirectives } from '@graphql-tools/utils';
 
@@ -390,6 +390,15 @@ describe('Merge Schemas', () => {
         });
 
         expect(data.a).toEqual(now.toISOString());
+    });
+
+    it.only('should not duplicate directives of scalars', () => {
+        const schema = buildSchema(`
+            directive @sqlType(type: String!) on SCALAR
+            scalar JSON @sqlType(type: "json")
+        `);
+        const merged = mergeSchemas({ schemas: [schema] });
+        expect(print(merged.getType('JSON')!.astNode!)).toEqual('scalar JSON @sqlType(type: "json")');
     });
 
     it('should merge when directive uses enum', () => {

--- a/packages/utils/src/getResolversFromSchema.ts
+++ b/packages/utils/src/getResolversFromSchema.ts
@@ -1,4 +1,5 @@
 import {
+  GraphQLScalarType,
   GraphQLSchema,
   isScalarType,
   isEnumType,
@@ -10,8 +11,6 @@ import {
 
 import { IResolvers } from './Interfaces';
 
-import { cloneType } from './clone';
-
 export function getResolversFromSchema(schema: GraphQLSchema): IResolvers {
   const resolvers = Object.create({});
 
@@ -22,7 +21,9 @@ export function getResolversFromSchema(schema: GraphQLSchema): IResolvers {
 
     if (isScalarType(type)) {
       if (!isSpecifiedScalarType(type)) {
-        resolvers[typeName] = cloneType(type);
+        const config = type.toConfig();
+        delete config.astNode; // avoid AST duplication elsewhere
+        resolvers[typeName] = new GraphQLScalarType(config);
       }
     } else if (isEnumType(type)) {
       resolvers[typeName] = {};


### PR DESCRIPTION
Related #2031. getResolversFromSchema was cloning the entire scalar type, including the AST node, and addResolversToSchema was concatenating the directives from the original AST node and the cloned one. This fix changes getResolversFromSchema to omit the AST node from the cloned type. This seems reasonable, since none of the other types there have an AST node included.