### PR TITLE
docs: Example of using graphql-transport-ws

### DIFF
--- a/website/docs/remote-schemas.md
+++ b/website/docs/remote-schemas.md
@@ -105,7 +105,7 @@ type Subscriber = (executionParams: ExecutionParams) => Promise<AsyncIterator<Ex
 ```
 
 #### Using `graphql-transport-ws`
-Learn more about [`graphql-transport-ws`](https://github.com/enisdenjo/graphql-transport-ws).
+For the following example to work, the server must implement the [library's transport protocol](https://github.com/enisdenjo/graphql-transport-ws/blob/master/PROTOCOL.md). Learn more about [`graphql-transport-ws`](https://github.com/enisdenjo/graphql-transport-ws).
 
 ```ts
 import { wrapSchema, introspectSchema } from '@graphql-tools/wrap';

--- a/website/docs/remote-schemas.md
+++ b/website/docs/remote-schemas.md
@@ -104,8 +104,8 @@ For subscriptions, we need to define a subscriber that returns `AsyncIterator`. 
 type Subscriber = (executionParams: ExecutionParams) => Promise<AsyncIterator<ExecutionResult>>;
 ```
 
-#### Using `subscriptions-transport-ws`
-You can learn more about [`subscriptions-transport-ws`](https://github.com/apollographql/subscriptions-transport-ws).
+#### Using `graphql-transport-ws`
+Learn more about [`graphql-transport-ws`](https://github.com/enisdenjo/graphql-transport-ws).
 
 ```ts
 import { wrapSchema, introspectSchema } from '@graphql-tools/wrap';
@@ -113,7 +113,7 @@ import { Executor, Subscriber } from '@graphql-tools/delegate';
 import { fetch } from 'cross-fetch';
 import { print } from 'graphql';
 import { observableToAsyncIterable } from '@graphql-tools/utils';
-import { SubscriptionClient } from 'subscriptions-transport-ws';
+import { createClient } from 'graphql-transport-ws';
 
 const HTTP_GRAPHQL_ENDPOINT = 'http://localhost:3000/graphql';
 const WS_GRAPHQL_ENDPOINT = 'ws://localhost:3000/graphql';
@@ -130,17 +130,36 @@ const executor: Executor = async ({ document, variables }) => {
   return fetchResult.json();
 };
 
-const subscriptionClient = new SubscriptionClient(WS_GRAPHQL_ENDPOINT, {
-  reconnect: true,
+const subscriptionClient = createClient({
+  url: WS_GRAPHQL_ENDPOINT,
 });
 
-const subscriber: Subscriber = ({ document, variables, context, info }) => observableToAsyncIterable(
-  subscriptionClient.request({
-    query: document,
-    variables,
-    context,
-  })
-);
+const subscriber: Subscriber = ({ document, variables }) =>
+  observableToAsyncIterable({
+    subscribe: observer => ({
+      unsubscribe: subscriptionClient.subscribe(
+        {
+          query: document,
+          variables,
+        },
+        {
+          next: data => observer.next && observer.next(data),
+          error: err => {
+            if (!observer.error) return;
+            if (err instanceof Error) {
+              observer.error(err);
+            } else if (err instanceof CloseEvent) {
+              observer.error(new Error(`Socket closed with event ${err.code}`));
+            } else {
+              // GraphQLError[]
+              observer.error(new Error(err.map(({ message }) => message).join(', ')));
+            }
+          },
+          complete: () => observer.complete && observer.complete(),
+        }
+      ),
+    }),
+  });
 
 export default async () => {
   const schema = wrapSchema({

--- a/website/docs/server-setup.md
+++ b/website/docs/server-setup.md
@@ -42,4 +42,48 @@ And you can test your queries using built-in [GraphiQL](https://github.com/graph
 ></iframe>
 
 ## Adding Subscriptions support
-> TODO
+[`graphql-transport-ws`](https://github.com/enisdenjo/graphql-transport-ws) offers a server and client implementation for transporting subscription events over WebSockets.
+
+```js
+const http = require('http');
+const express = require('express');
+const { graphqlHTTP } = require('express-graphql');
+const { execute, subscribe } = require('graphql');
+const { createServer } = require('graphql-transport-ws');
+
+const typeDefs = require('./graphql/types');
+const resolvers = require('./graphql/resolvers');
+
+const { makeExecutableSchema } = require('@graphql-tools/schema');
+
+const schema = makeExecutableSchema({
+  typeDefs,
+  resolvers,
+});
+
+const app = express();
+app.use(
+  '/graphql',
+  graphqlHTTP({
+    schema,
+    graphiql: true,
+  })
+);
+
+const server = http.createServer(app);
+
+server.listen(3000, () => {
+  createServer(
+    {
+      schema,
+      execute,
+      subscribe,
+    },
+    {
+      server,
+      path: '/graphql', // can be same path, just use the `ws` schema
+    }
+  );
+  console.info('Listening on http://localhost:3000/graphql');
+});
+```


### PR DESCRIPTION
👋,

this is a small PR showing how to leverage [`graphql-transport-ws`](https://github.com/enisdenjo/graphql-transport-ws) to add subscriptions support over WebSockets.
- [x] Usage with `express-graphql`
- [x] Client usage when wrapping a remote schema