### PR TITLE
Fix type error with `arguments` being undefined

### DIFF
--- a/.changeset/cool-ads-sin.md
+++ b/.changeset/cool-ads-sin.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/delegate': patch
+---
+
+fix(delegate): Fix type error with `arguments` being undefined

--- a/.changeset/itchy-pillows-trade.md
+++ b/.changeset/itchy-pillows-trade.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/url-loader': patch
+---
+
+fix(url-loader): fix typing mismatch

--- a/packages/delegate/src/transforms/AddArgumentsAsVariables.ts
+++ b/packages/delegate/src/transforms/AddArgumentsAsVariables.ts
@@ -79,7 +79,7 @@ function addVariablesToRootField(
 
     operation.selectionSet.selections.forEach((selection: SelectionNode) => {
       if (selection.kind === Kind.FIELD) {
-        const argumentNodes = selection.arguments;
+        const argumentNodes = selection.arguments || [];
         const argumentNodeMap: Record<string, ArgumentNode> = argumentNodes.reduce(
           (prev, argument) => ({
             ...prev,

--- a/packages/delegate/src/transforms/AddArgumentsAsVariables.ts
+++ b/packages/delegate/src/transforms/AddArgumentsAsVariables.ts
@@ -79,7 +79,7 @@ function addVariablesToRootField(
 
     operation.selectionSet.selections.forEach((selection: SelectionNode) => {
       if (selection.kind === Kind.FIELD) {
-        const argumentNodes = selection.arguments || [];
+        const argumentNodes = selection.arguments ?? [];
         const argumentNodeMap: Record<string, ArgumentNode> = argumentNodes.reduce(
           (prev, argument) => ({
             ...prev,


### PR DESCRIPTION
This fixes a type error in the `addVariablesToRootField` function.

The interface for the `FieldNode` type has the `arguments` field as an optional type, whereas the original code treats it like the array is always present:

```typescript
export interface FieldNode {
  readonly kind: 'Field';
  readonly loc?: Location;
  readonly alias?: NameNode;
  readonly name: NameNode;
  readonly arguments?: ReadonlyArray<ArgumentNode>;
  readonly directives?: ReadonlyArray<DirectiveNode>;
  readonly selectionSet?: SelectionSetNode;
}
```


This resolves the original #820 issue, which is that delegating to remote schema fails.

The selection this is tripping up on has the following shape:

```js
{ kind: 'Field', name: { kind: 'Name', value: '__typename' }
```