### PR TITLE
Remove $ from invalidPathRegex

### DIFF
--- a/.changeset/odd-moons-hunt.md
+++ b/.changeset/odd-moons-hunt.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/utils': patch
+---
+
+fix(utils): Remove \$ from invalidPathRegex

--- a/packages/utils/src/helpers.ts
+++ b/packages/utils/src/helpers.ts
@@ -42,7 +42,7 @@ export function isDocumentString(str: string): boolean {
   return false;
 }
 
-const invalidPathRegex = /[‘“!$%&^<=>`]/;
+const invalidPathRegex = /[‘“!%&^<=>`]/;
 export function isValidPath(str: string): boolean {
   return typeof str === 'string' && !invalidPathRegex.test(str);
 }


### PR DESCRIPTION
Problem: `@graphql-codegen` silently ignore paths with `$`.
Solution: remove `$` from `invalidPathRegex`

<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
