### PR TITLE
Update `links` package to use `@apollo/client/links`

### DIFF
--- a/.changeset/new-pears-compete.md
+++ b/.changeset/new-pears-compete.md
@@ -1,0 +1,8 @@
+---
+'@graphql-tools/links': major
+---
+
+feat(links): AC3 support
+
+`apollo-link` has been deprecated so this package now uses `@apollo/client` as peer dependency;
+You can [see more on migration guide.](https://www.apollographql.com/docs/react/migrating/apollo-client-3-migration/#apollo-link-and-apollo-link-http)

--- a/.changeset/thin-ways-wave.md
+++ b/.changeset/thin-ways-wave.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/utils': patch
+---
+
+fix(utils): fix typing mismatch between linkToSubscriber and observableToAsyncIterable

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -37,7 +37,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-15-15-yarn-
       - name: Install Dependencies using Yarn
-        run: yarn install && git checkout yarn.lock
+        run: yarn install --ignore-engines && git checkout yarn.lock
       - name: Release Canary
         id: canary
         uses: 'kamilkisiela/release-canary@master'

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Use Node
         uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: '15.x'
       - name: Configure Git Credentials
         run: |
           git config --global user.email "theguild-bot@users.noreply.github.com"
@@ -33,9 +33,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-14-15-yarn-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-15-15-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-14-15-yarn-
+            ${{ runner.os }}-15-15-yarn-
       - name: Install Dependencies using Yarn
         run: yarn install && git checkout yarn.lock
       - name: Release Canary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node
         uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: '15.x'
       - name: Setup NPM credentials
         run: echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> ~/.npmrc
         env:
@@ -36,9 +36,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-14-15-yarn-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-15-15-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-14-15-yarn-
+            ${{ runner.os }}-15-15-yarn-
       - name: Install Dependencies using Yarn
         run: yarn install && git checkout yarn.lock
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-15-15-yarn-
       - name: Install Dependencies using Yarn
-        run: yarn install && git checkout yarn.lock
+        run: yarn install --ignore-engines && git checkout yarn.lock
       - name: Build
         run: yarn build
       - name: Create Release Pull Request or Publish to npm

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{matrix.node_version}}-${{matrix.graphql_version}}-yarn
       - name: Install Dependencies using Yarn
-        run: yarn install && git checkout yarn.lock
+        run: yarn install --ignore-engines && git checkout yarn.lock
       - name: Lint
         run: yarn lint
   build:
@@ -59,7 +59,7 @@ jobs:
       - name: Use GraphQL v${{matrix.graphql_version}}
         run: node ./scripts/match-graphql.js ${{matrix.graphql_version}}
       - name: Install Dependencies using Yarn
-        run: yarn install && git checkout yarn.lock
+        run: yarn install --ignore-engines && git checkout yarn.lock
       - name: Build
         run: yarn ts:transpile
   test:
@@ -90,7 +90,7 @@ jobs:
       - name: Use GraphQL v${{matrix.graphql_version}}
         run: node ./scripts/match-graphql.js ${{matrix.graphql_version}}
       - name: Install Dependencies using Yarn
-        run: yarn install && git checkout yarn.lock
+        run: yarn install --ignore-engines && git checkout yarn.lock
       - name: Cache Jest
         uses: actions/cache@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - name: Checkout Master
         uses: actions/checkout@v1
-      - name: Use Node 14
+      - name: Use Node 15
         uses: actions/setup-node@master
         with:
-          node-version: 14
+          node-version: 15
       - name: Get yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -45,7 +45,7 @@ jobs:
       - name: Use Node 14
         uses: actions/setup-node@master
         with:
-          node-version: 14
+          node-version: 15
       - name: Get yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -68,7 +68,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node_version: [10, 14]
+        node_version: [10, 15]
         graphql_version: [14, 15]
     steps:
       - name: Checkout Master

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -39,7 +39,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-15-15-yarn-
       - name: Install Dependencies using Yarn
-        run: yarn install && git checkout yarn.lock
+        run: yarn install --ignore-engines && git checkout yarn.lock
       - name: Deploy 🚀
         run: yarn deploy:website
         env:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Use Node
         uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: '15.x'
       - name: Get yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
@@ -35,9 +35,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-14-15-yarn-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-15-15-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-14-15-yarn-
+            ${{ runner.os }}-15-15-yarn-
       - name: Install Dependencies using Yarn
         run: yarn install && git checkout yarn.lock
       - name: Deploy 🚀

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "ts-jest": "26.4.1",
     "typedoc": "0.17.0-3",
     "typedoc-plugin-markdown": "2.3.1",
-    "typescript": "4.0.3"
+    "typescript": "4.0.5"
   },
   "husky": {
     "hooks": {

--- a/packages/links/package.json
+++ b/packages/links/package.json
@@ -16,7 +16,12 @@
     "@apollo/client": "~3.2.5"
   },
   "buildOptions": {
-    "input": "./src/index.ts"
+    "input": "./src/index.ts",
+    "external": [
+      "@apollo/client/link/core",
+      "@apollo/client/link/utils",
+      "@apollo/client/utilities"
+    ]
   },
   "devDependencies": {
     "@apollo/client": "3.2.5",

--- a/packages/links/package.json
+++ b/packages/links/package.json
@@ -12,19 +12,20 @@
     "definition": "dist/index.d.ts"
   },
   "peerDependencies": {
-    "graphql": "^14.0.0 || ^15.0.0"
+    "graphql": "^14.0.0 || ^15.0.0",
+    "@apollo/client": "~3.2.5"
   },
   "buildOptions": {
     "input": "./src/index.ts"
   },
   "devDependencies": {
+    "@apollo/client": "3.2.5",
     "@types/graphql-upload": "8.0.4",
     "express-graphql": "0.11.0",
     "graphql-upload": "11.0.0"
   },
   "dependencies": {
-    "@graphql-tools/utils": "^7.0.0",
-    "apollo-link": "1.2.14",
+    "@graphql-tools/utils": "7.0.0",
     "apollo-upload-client": "14.1.2",
     "cross-fetch": "3.0.6",
     "form-data": "3.0.0",

--- a/packages/links/src/AwaitVariablesLink.ts
+++ b/packages/links/src/AwaitVariablesLink.ts
@@ -1,4 +1,5 @@
-import { ApolloLink, Operation, NextLink, Observable, FetchResult } from 'apollo-link';
+import { ApolloLink, FetchResult, NextLink, Operation } from '@apollo/client/link/core';
+import { Observable } from '@apollo/client/utilities';
 
 function getFinalPromise(object: any): Promise<any> {
   return Promise.resolve(object).then(resolvedObject => {

--- a/packages/links/src/createServerHttpLink.ts
+++ b/packages/links/src/createServerHttpLink.ts
@@ -1,4 +1,4 @@
-import { concat } from 'apollo-link';
+import { concat } from '@apollo/client/link/core';
 import { createUploadLink, formDataAppendFile, isExtractableFile } from 'apollo-upload-client';
 import FormData, { AppendOptions } from 'form-data';
 import { fetch } from 'cross-fetch';

--- a/packages/links/src/linkToExecutor.ts
+++ b/packages/links/src/linkToExecutor.ts
@@ -1,4 +1,6 @@
-import { ApolloLink, toPromise, execute, Observable, FetchResult } from 'apollo-link';
+import { ApolloLink, execute, FetchResult } from '@apollo/client/link/core';
+import { Observable } from '@apollo/client/utilities';
+import { toPromise } from '@apollo/client/link/utils';
 import { DocumentNode, GraphQLResolveInfo } from 'graphql';
 
 export const linkToExecutor = (link: ApolloLink) => <TReturn, TArgs, TContext>({

--- a/packages/links/src/linkToSubscriber.ts
+++ b/packages/links/src/linkToSubscriber.ts
@@ -1,4 +1,5 @@
-import { ApolloLink, execute, FetchResult, Observable } from 'apollo-link';
+import { ApolloLink, execute, FetchResult } from '@apollo/client/link/core';
+import { Observable } from '@apollo/client/utilities';
 import { observableToAsyncIterable } from '@graphql-tools/utils';
 import { GraphQLResolveInfo, DocumentNode } from 'graphql';
 

--- a/packages/loaders/url/src/index.ts
+++ b/packages/loaders/url/src/index.ts
@@ -148,7 +148,7 @@ export class UrlLoader implements DocumentLoader<LoadFromUrlOptions> {
           query: document,
           variables,
         })
-      ) as AsyncIterator<ExecutionResult<TReturn>>;
+      ) as AsyncIterableIterator<ExecutionResult<TReturn>>;
     };
   }
 

--- a/packages/utils/src/observableToAsyncIterable.ts
+++ b/packages/utils/src/observableToAsyncIterable.ts
@@ -14,11 +14,7 @@ export interface Observable<T> {
 
 export type Callback = (value?: any) => any;
 
-export function observableToAsyncIterable<T>(
-  observable: Observable<T>
-): AsyncIterator<T> & {
-  [Symbol.asyncIterator]: () => AsyncIterator<T>;
-} {
+export function observableToAsyncIterable<T>(observable: Observable<T>): AsyncIterable<T> {
   const pullQueue: Array<Callback> = [];
   const pushQueue: Array<any> = [];
 
@@ -74,19 +70,20 @@ export function observableToAsyncIterable<T>(
   };
 
   return {
-    next() {
-      return listening ? pullValue() : this.return();
-    },
-    return() {
-      emptyQueue();
-      return Promise.resolve({ value: undefined, done: true });
-    },
-    throw(error) {
-      emptyQueue();
-      return Promise.reject(error);
-    },
     [Symbol.asyncIterator]() {
-      return this;
+      return {
+        next() {
+          return listening ? pullValue() : this.return();
+        },
+        return() {
+          emptyQueue();
+          return Promise.resolve({ value: undefined, done: true });
+        },
+        throw(error) {
+          emptyQueue();
+          return Promise.reject(error);
+        },
+      };
     },
   };
 }

--- a/packages/wrap/src/transforms/HoistField.ts
+++ b/packages/wrap/src/transforms/HoistField.ts
@@ -119,14 +119,14 @@ export default class HoistField implements Transform {
 
     Object.keys(targetField.args).forEach(argName => {
       const argConfig = targetField.args[argName];
-      const arg: GraphQLArgument = {
+      const arg = {
         ...argConfig,
         name: argName,
         description: argConfig.description,
         defaultValue: argConfig.defaultValue,
         extensions: argConfig.extensions,
         astNode: argConfig.astNode,
-      };
+      } as GraphQLArgument;
       if (this.argFilters[level](arg)) {
         argsMap[argName] = arg;
         this.argLevels[arg.name] = level;

--- a/yarn.lock
+++ b/yarn.lock
@@ -106,6 +106,25 @@
     "@algolia/logger-common" "4.5.1"
     "@algolia/requester-common" "4.5.1"
 
+"@apollo/client@3.2.5":
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.2.5.tgz#24e0a6faa1d231ab44807af237c6227410c75c4d"
+  integrity sha512-zpruxnFMz6K94gs2pqc3sidzFDbQpKT5D6P/J/I9s8ekHZ5eczgnRp6pqXC86Bh7+44j/btpmOT0kwiboyqTnA==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.0.0"
+    "@types/zen-observable" "^0.8.0"
+    "@wry/context" "^0.5.2"
+    "@wry/equality" "^0.2.0"
+    fast-json-stable-stringify "^2.0.0"
+    graphql-tag "^2.11.0"
+    hoist-non-react-statics "^3.3.2"
+    optimism "^0.13.0"
+    prop-types "^15.7.2"
+    symbol-observable "^2.0.0"
+    ts-invariant "^0.4.4"
+    tslib "^1.10.0"
+    zen-observable "^0.8.14"
+
 "@apollo/client@^3.1.5":
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.2.2.tgz#fe5cad4d53373979f13a925e9da02d8743e798a5"
@@ -1731,69 +1750,6 @@
   resolved "https://registry.yarnpkg.com/@francoischalifour/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.0.0-alpha.28.tgz#a5ad7996f42e43e4acbb4e0010d663746d0e9997"
   integrity sha512-bprfNmYt1opFUFEtD2XfY/kEsm13bzHQgU80uMjhuK0DJ914IjolT1GytpkdM6tJ4MBvyiJPP+bTtWO+BZ7c7w==
 
-"@graphql-tools/delegate@^6.2.4":
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/delegate/-/delegate-6.2.4.tgz#db553b63eb9512d5eb5bbfdfcd8cb1e2b534699c"
-  integrity sha512-mXe6DfoWmq49kPcDrpKHgC2DSWcD5q0YCaHHoXYPAOlnLH8VMTY8BxcE8y/Do2eyg+GLcwAcrpffVszWMwqw0w==
-  dependencies:
-    "@ardatan/aggregate-error" "0.0.6"
-    "@graphql-tools/schema" "^6.2.4"
-    "@graphql-tools/utils" "^6.2.4"
-    dataloader "2.0.0"
-    is-promise "4.0.0"
-    tslib "~2.0.1"
-
-"@graphql-tools/mock@^6.2.4":
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/mock/-/mock-6.2.4.tgz#205323c51f89dd855d345d130c7713d0420909ea"
-  integrity sha512-O5Zvq/mcDZ7Ptky0IZ4EK9USmxV6FEVYq0Jxv2TI80kvxbCjt0tbEpZ+r1vIt1gZOXlAvadSHYyzWnUPh+1vkQ==
-  dependencies:
-    "@graphql-tools/schema" "^6.2.4"
-    "@graphql-tools/utils" "^6.2.4"
-    tslib "~2.0.1"
-
-"@graphql-tools/schema@6.2.4", "@graphql-tools/schema@^6.2.4":
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-6.2.4.tgz#cc4e9f5cab0f4ec48500e666719d99fc5042481d"
-  integrity sha512-rh+14lSY1q8IPbEv2J9x8UBFJ5NrDX9W5asXEUlPp+7vraLp/Tiox4GXdgyA92JhwpYco3nTf5Bo2JDMt1KnAQ==
-  dependencies:
-    "@graphql-tools/utils" "^6.2.4"
-    tslib "~2.0.1"
-
-"@graphql-tools/stitch@6.2.4", "@graphql-tools/stitch@^6.2.4":
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/stitch/-/stitch-6.2.4.tgz#acfa6a577a33c0f02e4940ffff04753b23b87fd6"
-  integrity sha512-0C7PNkS7v7iAc001m7c1LPm5FUB0/DYw+s3OyCii6YYYHY8NwdI0roeOyeDGFJkFubWBQfjc3hoSyueKtU73mw==
-  dependencies:
-    "@graphql-tools/batch-delegate" "^6.2.4"
-    "@graphql-tools/delegate" "^6.2.4"
-    "@graphql-tools/merge" "^6.2.4"
-    "@graphql-tools/schema" "^6.2.4"
-    "@graphql-tools/utils" "^6.2.4"
-    "@graphql-tools/wrap" "^6.2.4"
-    is-promise "4.0.0"
-    tslib "~2.0.1"
-
-"@graphql-tools/utils@6.2.4", "@graphql-tools/utils@^6.2.4":
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-6.2.4.tgz#38a2314d2e5e229ad4f78cca44e1199e18d55856"
-  integrity sha512-ybgZ9EIJE3JMOtTrTd2VcIpTXtDrn2q6eiYkeYMKRVh3K41+LZa6YnR2zKERTXqTWqhobROwLt4BZbw2O3Aeeg==
-  dependencies:
-    "@ardatan/aggregate-error" "0.0.6"
-    camel-case "4.1.1"
-    tslib "~2.0.1"
-
-"@graphql-tools/wrap@^6.2.4":
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/wrap/-/wrap-6.2.4.tgz#2709817da6e469753735a9fe038c9e99736b2c57"
-  integrity sha512-cyQgpybolF9DjL2QNOvTS1WDCT/epgYoiA8/8b3nwv5xmMBQ6/6nYnZwityCZ7njb7MMyk7HBEDNNlP9qNJDcA==
-  dependencies:
-    "@graphql-tools/delegate" "^6.2.4"
-    "@graphql-tools/schema" "^6.2.4"
-    "@graphql-tools/utils" "^6.2.4"
-    is-promise "4.0.0"
-    tslib "~2.0.1"
-
 "@graphql-typed-document-node/core@^3.0.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.0.tgz#0eee6373e11418bfe0b5638f654df7a4ca6a3950"
@@ -3406,7 +3362,7 @@ apollo-graphql@^0.6.0:
     apollo-env "^0.6.5"
     lodash.sortby "^4.7.0"
 
-apollo-link@1.2.14, apollo-link@^1.2.14:
+apollo-link@^1.2.14:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.14.tgz#3feda4b47f9ebba7f4160bef8b977ba725b684d9"
   integrity sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==
@@ -10613,6 +10569,13 @@ optimism@^0.12.1:
   version "0.12.2"
   resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.12.2.tgz#de9dc3d2c914d7b34e08957a768967c0605beda9"
   integrity sha512-k7hFhlmfLl6HNThIuuvYMQodC1c+q6Uc6V9cLVsMWyW514QuaxVJH/khPu2vLRIoDTpFdJ5sojlARhg1rzyGbg==
+  dependencies:
+    "@wry/context" "^0.5.2"
+
+optimism@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.13.0.tgz#c08904e1439a0eb9e7f86183dafa06cc715ff351"
+  integrity sha512-6JAh3dH+YUE4QUdsgUw8nUQyrNeBKfAEKOHMlLkQ168KhIYFIxzPsHakWrRXDnTO+x61RJrS3/2uEt6W0xlocA==
   dependencies:
     "@wry/context" "^0.5.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14257,10 +14257,10 @@ typedoc@0.17.0-3:
     shelljs "^0.8.3"
     typedoc-default-themes "0.8.0-0"
 
-typescript@4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
-  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
+typescript@4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
+  integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
 
 typescript@^3.0.0:
   version "3.9.7"


### PR DESCRIPTION
After Apollo Client v3 got released, `apollo-link` and `apollo-link-http` have been deprecated. So `@graphql-tools/links` package now uses `@apollo/client/links` directly as a peer dependency to prevent `instanceof` and typing issues.
This PR also fixes typing mismatch between `observableToAsyncIterator` and `linkToSubscriber`.
See #2111 and https://github.com/ardatan/graphql-tools/issues/2105#issuecomment-715382726