### PR TITLE
fix(stitch): mergeExternalObjects regressions

### DIFF
--- a/.changeset/honest-taxis-fix.md
+++ b/.changeset/honest-taxis-fix.md
@@ -1,0 +1,8 @@
+---
+'@graphql-tools/delegate': patch
+'@graphql-tools/stitch': patch
+---
+
+fix(stitch): fix mergeExternalObject regressions
+
+v7 introduced a regression in the merging of ExternalObjects that causes type merging to fail when undergoing multiple rounds of merging.


### PR DESCRIPTION
v7 introduced a regression in the merging of ExternalObjects that causes type merging to fail when undergoing multiple rounds of merging.

#2157