### PR TITLE
test(stitch) enable isolateComputedFields test

### DIFF
--- a/packages/stitch/tests/isolateComputedFields.test.ts
+++ b/packages/stitch/tests/isolateComputedFields.test.ts
@@ -1,7 +1,6 @@
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { isolateComputedFields } from '@graphql-tools/stitch';
 import { Subschema } from '@graphql-tools/delegate';
-import { printSchema } from 'graphql';
 
 describe('isolateComputedFields', () => {
   describe('basic isolation', ()    => {


### PR DESCRIPTION
I noticed earlier that `isolateComputedFields` tests were missing the `.test` extension that makes them run as part of the automated test suite. This adds the `.test` extension, and then fixes some new errors in the coverage:

- Removes the SDL test. I believe SDLs are translated into static config before ever hitting this operation now.
- Updates a check on `Storefront` type presence in filtered schema. It looks like `pruneSchema` isn't doing everything it did before here and I'm not sure what the new expectations are. @yaacovCR?
