### PR TITLE
fix(utils): observableToAsyncIterable return type

### DIFF
--- a/.changeset/wet-garlics-tickle.md
+++ b/.changeset/wet-garlics-tickle.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/utils': patch
+---
+
+fix(utils): revert to old observableToAsyncIterable return type

--- a/packages/utils/src/observableToAsyncIterable.ts
+++ b/packages/utils/src/observableToAsyncIterable.ts
@@ -14,7 +14,7 @@ export interface Observable<T> {
 
 export type Callback = (value?: any) => any;
 
-export function observableToAsyncIterable<T>(observable: Observable<T>): AsyncIterable<T> {
+export function observableToAsyncIterable<T>(observable: Observable<T>): AsyncIterableIterator<T> {
   const pullQueue: Array<Callback> = [];
   const pushQueue: Array<any> = [];
 
@@ -70,20 +70,19 @@ export function observableToAsyncIterable<T>(observable: Observable<T>): AsyncIt
   };
 
   return {
+    next() {
+      return listening ? pullValue() : this.return();
+    },
+    return() {
+      emptyQueue();
+      return Promise.resolve({ value: undefined, done: true });
+    },
+    throw(error) {
+      emptyQueue();
+      return Promise.reject(error);
+    },
     [Symbol.asyncIterator]() {
-      return {
-        next() {
-          return listening ? pullValue() : this.return();
-        },
-        return() {
-          emptyQueue();
-          return Promise.resolve({ value: undefined, done: true });
-        },
-        throw(error) {
-          emptyQueue();
-          return Promise.reject(error);
-        },
-      };
+      return this;
     },
   };
 }


### PR DESCRIPTION
revert to old behavior of returning an AsyncIterableIterator