### PR TITLE
chore(packaging): allow patches of local packages

### DIFF
--- a/.changeset/heavy-peas-begin.md
+++ b/.changeset/heavy-peas-begin.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/links': patch
+---
+
+links should behave like other packages when releasing and not publish new versions with minor updates of internal dependencies

--- a/packages/links/package.json
+++ b/packages/links/package.json
@@ -30,8 +30,8 @@
     "graphql-upload": "11.0.0"
   },
   "dependencies": {
-    "@graphql-tools/delegate": "7.0.2",
-    "@graphql-tools/utils": "7.0.1",
+    "@graphql-tools/delegate": "^7.0.2",
+    "@graphql-tools/utils": "^7.0.1",
     "apollo-upload-client": "14.1.2",
     "cross-fetch": "3.0.6",
     "form-data": "3.0.0",


### PR DESCRIPTION
`links` should behave like other packages when releasing and not publish new versions with minor updates of internal dependencies