### PR TITLE
Use graphql-ws name

### DIFF
--- a/website/docs/server-setup.md
+++ b/website/docs/server-setup.md
@@ -42,14 +42,14 @@ And you can test your queries using built-in [GraphiQL](https://github.com/graph
 ></iframe>
 
 ## Adding Subscriptions support
-[`graphql-transport-ws`](https://github.com/enisdenjo/graphql-transport-ws) offers a server and client implementation for transporting subscription events over WebSockets.
+[`graphql-ws`](https://github.com/enisdenjo/graphql-ws) offers a server and client implementation for transporting subscription events over WebSockets.
 
 ```js
 const http = require('http');
 const express = require('express');
 const { graphqlHTTP } = require('express-graphql');
 const { execute, subscribe } = require('graphql');
-const { createServer } = require('graphql-transport-ws');
+const { createServer } = require('graphql-ws');
 
 const typeDefs = require('./graphql/types');
 const resolvers = require('./graphql/resolvers');


### PR DESCRIPTION
The `graphql-transport-ws` library has been renamed recently, its called `graphql-ws` now. Just a small PR fixing the name and links 😄 .