### PR TITLE
fix (Prisma): Don't initialize env vars with empty object

### DIFF
--- a/.changeset/poor-ears-sip.md
+++ b/.changeset/poor-ears-sip.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/prisma-loader': patch
+---
+
+Don't initialize env vars with an empty object, so it can fall back on process.env

--- a/packages/loaders/prisma/src/index.ts
+++ b/packages/loaders/prisma/src/index.ts
@@ -31,7 +31,7 @@ export class PrismaLoader extends UrlLoader {
   }
 
   async load(prismaConfigFilePath: string, options: PrismaLoaderOptions) {
-    const { graceful, envVars = {} } = options;
+    const { graceful, envVars } = options;
     const home = homedir();
     const env = new Environment(home);
     await env.load();


### PR DESCRIPTION
As exposed in #2208 , env vars in prisma.yml are not correctly resolved by `graphql-tools`.

This PR implements the workaround described in the above issue. We have been using this patch locally in our codebase without issues so far.