### PR TITLE
Replace fs-extra with native methods

### DIFF
--- a/.changeset/honest-oranges-tie.md
+++ b/.changeset/honest-oranges-tie.md
@@ -1,0 +1,10 @@
+---
+'@graphql-tools/import': patch
+'@graphql-tools/load-files': patch
+'@graphql-tools/code-file-loader': patch
+'@graphql-tools/graphql-file-loader': patch
+'@graphql-tools/json-file-loader': patch
+'@graphql-tools/prisma-loader': patch
+---
+
+Replace fs-extra with native methods

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "devDependencies": {
     "patch-package": "^6.2.2",
     "@changesets/cli": "2.10.3",
-    "@types/fs-extra": "9.0.4",
     "@types/jest": "26.0.15",
     "@types/node": "14.14.8",
     "@typescript-eslint/eslint-plugin": "4.8.1",
@@ -57,7 +56,6 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-promise": "4.2.1",
     "eslint-plugin-standard": "4.1.0",
-    "fs-extra": "9.0.1",
     "graphql": "15.4.0",
     "husky": "4.3.0",
     "jest": "26.6.3",

--- a/packages/import/package.json
+++ b/packages/import/package.json
@@ -20,7 +20,6 @@
     "directory": "dist"
   },
   "dependencies": {
-    "fs-extra": "9.0.1",
     "resolve-from": "5.0.0",
     "tslib": "~2.0.1"
   }

--- a/packages/import/src/index.ts
+++ b/packages/import/src/index.ts
@@ -34,7 +34,7 @@ import {
   ScalarTypeDefinitionNode,
   ScalarTypeExtensionNode,
 } from 'graphql';
-import { readFileSync, realpathSync } from 'fs-extra';
+import { readFileSync, realpathSync } from 'fs';
 import { dirname, join, isAbsolute } from 'path';
 import resolveFrom from 'resolve-from';
 

--- a/packages/load-files/package.json
+++ b/packages/load-files/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "globby": "11.0.1",
     "unixify": "1.0.0",
-    "fs-extra": "9.0.1",
     "tslib": "~2.0.1"
   },
   "publishConfig": {

--- a/packages/load-files/src/index.ts
+++ b/packages/load-files/src/index.ts
@@ -1,7 +1,9 @@
 import globby, { sync as globbySync, GlobbyOptions } from 'globby';
 import unixify from 'unixify';
 import { extname } from 'path';
-import { readFile, stat, statSync, readFileSync } from 'fs-extra';
+import { statSync, readFileSync, promises as fsPromises } from 'fs';
+
+const { readFile, stat } = fsPromises;
 
 const DEFAULT_IGNORED_EXTENSIONS = ['spec', 'test', 'd', 'map'];
 const DEFAULT_EXTENSIONS = ['gql', 'graphql', 'graphqls', 'ts', 'js'];

--- a/packages/loaders/code-file/package.json
+++ b/packages/loaders/code-file/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "@graphql-tools/utils": "^7.0.0",
     "@graphql-tools/graphql-tag-pluck": "^6.2.6",
-    "fs-extra": "9.0.1",
     "tslib": "~2.0.1"
   },
   "publishConfig": {

--- a/packages/loaders/code-file/src/index.ts
+++ b/packages/loaders/code-file/src/index.ts
@@ -18,8 +18,10 @@ import {
 } from '@graphql-tools/graphql-tag-pluck';
 import { tryToLoadFromExport, tryToLoadFromExportSync } from './load-from-module';
 import { isAbsolute, resolve } from 'path';
-import { readFileSync, readFile, pathExists, pathExistsSync } from 'fs-extra';
 import { cwd } from 'process';
+import { readFileSync, accessSync, promises as fsPromises } from 'fs';
+
+const { readFile, access } = fsPromises;
 
 /**
  * Additional options for loading from a code file
@@ -59,7 +61,12 @@ export class CodeFileLoader implements UniversalLoader<CodeFileLoaderOptions> {
     if (isValidPath(pointer)) {
       if (FILE_EXTENSIONS.find(extension => pointer.endsWith(extension))) {
         const normalizedFilePath = isAbsolute(pointer) ? pointer : resolve(options.cwd || cwd(), pointer);
-        return pathExists(normalizedFilePath);
+        try {
+          await access(normalizedFilePath);
+          return true;
+        } catch {
+          return false;
+        }
       }
     }
 
@@ -70,7 +77,12 @@ export class CodeFileLoader implements UniversalLoader<CodeFileLoaderOptions> {
     if (isValidPath(pointer)) {
       if (FILE_EXTENSIONS.find(extension => pointer.endsWith(extension))) {
         const normalizedFilePath = isAbsolute(pointer) ? pointer : resolve(options.cwd || cwd(), pointer);
-        return pathExistsSync(normalizedFilePath);
+        try {
+          accessSync(normalizedFilePath);
+          return true;
+        } catch {
+          return false;
+        }
       }
     }
 

--- a/packages/loaders/graphql-file/package.json
+++ b/packages/loaders/graphql-file/package.json
@@ -21,7 +21,6 @@
   "dependencies": {
     "@graphql-tools/import": "^6.2.4",
     "@graphql-tools/utils": "^7.0.0",
-    "fs-extra": "9.0.1",
     "tslib": "~2.0.1"
   },
   "publishConfig": {

--- a/packages/loaders/graphql-file/src/index.ts
+++ b/packages/loaders/graphql-file/src/index.ts
@@ -8,11 +8,13 @@ import {
   SingleFileOptions,
 } from '@graphql-tools/utils';
 import { isAbsolute, resolve } from 'path';
-import { readFile, readFileSync, pathExists, pathExistsSync } from 'fs-extra';
+import { readFileSync, accessSync, promises as fsPromises } from 'fs';
 import { cwd as processCwd } from 'process';
 import { isExecutableDefinitionNode, Kind } from 'graphql';
 import { processImport } from '@graphql-tools/import';
 import { mergeTypeDefs } from '@graphql-tools/merge';
+
+const { readFile, access } = fsPromises;
 
 const FILE_EXTENSIONS = ['.gql', '.gqls', '.graphql', '.graphqls'];
 
@@ -66,7 +68,12 @@ export class GraphQLFileLoader implements UniversalLoader<GraphQLFileLoaderOptio
     if (isValidPath(pointer)) {
       if (FILE_EXTENSIONS.find(extension => pointer.endsWith(extension))) {
         const normalizedFilePath = isAbsolute(pointer) ? pointer : resolve(options.cwd || processCwd(), pointer);
-        return pathExists(normalizedFilePath);
+        try {
+          await access(normalizedFilePath);
+          return true;
+        } catch {
+          return false;
+        }
       }
     }
 
@@ -77,7 +84,12 @@ export class GraphQLFileLoader implements UniversalLoader<GraphQLFileLoaderOptio
     if (isValidPath(pointer)) {
       if (FILE_EXTENSIONS.find(extension => pointer.endsWith(extension))) {
         const normalizedFilePath = isAbsolute(pointer) ? pointer : resolve(options.cwd || processCwd(), pointer);
-        return pathExistsSync(normalizedFilePath);
+        try {
+          accessSync(normalizedFilePath);
+          return true;
+        } catch {
+          return false;
+        }
       }
     }
 

--- a/packages/loaders/json-file/package.json
+++ b/packages/loaders/json-file/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "@graphql-tools/utils": "^7.0.0",
-    "fs-extra": "9.0.1",
     "tslib": "~2.0.1"
   },
   "publishConfig": {

--- a/packages/loaders/json-file/src/index.ts
+++ b/packages/loaders/json-file/src/index.ts
@@ -7,8 +7,10 @@ import {
   SingleFileOptions,
 } from '@graphql-tools/utils';
 import { isAbsolute, resolve } from 'path';
-import { readFile, readFileSync, pathExists, pathExistsSync } from 'fs-extra';
+import { readFileSync, accessSync, promises as fsPromises } from 'fs';
 import { cwd } from 'process';
+
+const { readFile, access } = fsPromises;
 
 const FILE_EXTENSIONS = ['.json'];
 
@@ -49,7 +51,12 @@ export class JsonFileLoader implements DocumentLoader {
     if (isValidPath(pointer)) {
       if (FILE_EXTENSIONS.find(extension => pointer.endsWith(extension))) {
         const normalizedFilePath = isAbsolute(pointer) ? pointer : resolve(options.cwd || cwd(), pointer);
-        return pathExists(normalizedFilePath);
+        try {
+          await access(normalizedFilePath);
+          return true;
+        } catch {
+          return false;
+        }
       }
     }
 
@@ -61,7 +68,12 @@ export class JsonFileLoader implements DocumentLoader {
       if (FILE_EXTENSIONS.find(extension => pointer.endsWith(extension))) {
         const normalizedFilePath = isAbsolute(pointer) ? pointer : resolve(options.cwd || cwd(), pointer);
 
-        return pathExistsSync(normalizedFilePath);
+        try {
+          accessSync(normalizedFilePath);
+          return true;
+        } catch {
+          return false;
+        }
       }
     }
 

--- a/packages/loaders/prisma/package.json
+++ b/packages/loaders/prisma/package.json
@@ -27,7 +27,6 @@
     "chalk": "^4.1.0",
     "debug": "^4.2.0",
     "dotenv": "^8.2.0",
-    "fs-extra": "9.0.1",
     "graphql-request": "^3.3.0",
     "http-proxy-agent": "^4.0.1",
     "https-proxy-agent": "^5.0.0",

--- a/packages/loaders/prisma/src/index.ts
+++ b/packages/loaders/prisma/src/index.ts
@@ -1,9 +1,11 @@
 import { UrlLoader, LoadFromUrlOptions } from '@graphql-tools/url-loader';
 import { PrismaDefinitionClass, Environment } from './prisma-yml';
 import { join } from 'path';
-import { pathExists } from 'fs-extra';
+import { promises as fsPromises } from 'fs';
 import { homedir } from 'os';
 import { cwd } from 'process';
+
+const { access } = fsPromises;
 
 /**
  * additional options for loading from a `prisma.yml` file
@@ -25,7 +27,12 @@ export class PrismaLoader extends UrlLoader {
   async canLoad(prismaConfigFilePath: string, options: PrismaLoaderOptions): Promise<boolean> {
     if (typeof prismaConfigFilePath === 'string' && prismaConfigFilePath.endsWith('prisma.yml')) {
       const joinedYmlPath = join(options.cwd || cwd(), prismaConfigFilePath);
-      return pathExists(joinedYmlPath);
+      try {
+        await access(joinedYmlPath);
+        return true;
+      } catch {
+        return false;
+      }
     }
     return false;
   }

--- a/packages/loaders/prisma/src/prisma-yml/Environment.test.ts
+++ b/packages/loaders/prisma/src/prisma-yml/Environment.test.ts
@@ -1,6 +1,6 @@
 import { Environment } from './Environment';
 import { getTmpDir } from './test/getTmpDir';
-import * as fs from 'fs-extra';
+import * as fs from 'fs';
 import { Cluster } from './Cluster';
 import { Output } from './Output';
 

--- a/packages/loaders/prisma/src/prisma-yml/PrismaDefinition.test.ts
+++ b/packages/loaders/prisma/src/prisma-yml/PrismaDefinition.test.ts
@@ -1,5 +1,5 @@
 import { PrismaDefinitionClass } from './PrismaDefinition';
-import * as fs from 'fs-extra';
+import * as fs from 'fs';
 import * as path from 'path';
 import { getTmpDir } from './test/getTmpDir';
 import { makeEnv } from './Environment.test';
@@ -129,7 +129,8 @@ type User @model {
     const { definition, env } = makeDefinition(yml, datamodel, {});
     const envPath = path.join(definition.definitionDir, '.env');
 
-    fs.outputFileSync(envPath, `MY_DOT_ENV_SECRET=this-is-very-secret,and-comma,seperated`);
+    fs.mkdirSync(path.dirname(envPath), { recursive: true });
+    fs.writeFileSync(envPath, `MY_DOT_ENV_SECRET=this-is-very-secret,and-comma,seperated`);
 
     await env.load();
 
@@ -242,7 +243,8 @@ type User @model {
     const { definition, env } = makeDefinition(yml, datamodel);
     const envPath = path.join(definition.definitionDir, '.env');
 
-    fs.outputFileSync(envPath, `MY_DOT_ENV_SECRET=this-is-very-secret,and-comma,seperated`);
+    fs.mkdirSync(path.dirname(envPath), { recursive: true });
+    fs.writeFileSync(envPath, `MY_DOT_ENV_SECRET=this-is-very-secret,and-comma,seperated`);
 
     await env.load();
     try {

--- a/packages/loaders/prisma/src/prisma-yml/PrismaDefinition.ts
+++ b/packages/loaders/prisma/src/prisma-yml/PrismaDefinition.ts
@@ -1,6 +1,6 @@
 import { readDefinition } from './yaml';
 import { PrismaDefinition } from './prisma-json-schema';
-import * as fs from 'fs-extra';
+import * as fs from 'fs';
 import * as dotenv from 'dotenv';
 import * as path from 'path';
 // eslint-disable-next-line
@@ -48,7 +48,9 @@ export class PrismaDefinitionClass {
     if (args.project) {
       const flagPath = path.resolve(args.project as string);
 
-      if (!fs.pathExistsSync(flagPath)) {
+      try {
+        fs.accessSync(flagPath);
+      } catch {
         throw new Error(`Prisma definition path specified by --project '${flagPath}' does not exist`);
       }
 
@@ -61,11 +63,15 @@ export class PrismaDefinitionClass {
     }
 
     if (envPath) {
-      if (!fs.pathExistsSync(envPath)) {
+      try {
+        fs.accessSync(envPath);
+      } catch {
         envPath = path.join(process.cwd(), envPath);
       }
 
-      if (!fs.pathExistsSync(envPath)) {
+      try {
+        fs.accessSync(envPath);
+      } catch {
         throw new Error(`--env-file path '${envPath}' does not exist`);
       }
     }
@@ -251,10 +257,11 @@ and execute ${chalk.bold.green('prisma deploy')} again, to get that value auto-f
     let allTypes = '';
     typesPaths.forEach(unresolvedTypesPath => {
       const typesPath = path.join(this.definitionDir, unresolvedTypesPath!);
-      if (fs.existsSync(typesPath)) {
+      try {
+        fs.accessSync(typesPath);
         const types = fs.readFileSync(typesPath, 'utf-8');
         allTypes += types + '\n';
-      } else {
+      } catch {
         throw new Error(`The types definition file "${typesPath}" could not be found.`);
       }
     });
@@ -291,7 +298,9 @@ and execute ${chalk.bold.green('prisma deploy')} again, to get that value auto-f
         let query = subscription.query;
         if (subscription.query.endsWith('.graphql')) {
           const queryPath = path.join(this.definitionDir, subscription.query);
-          if (!fs.pathExistsSync(queryPath)) {
+          try {
+            fs.accessSync(queryPath);
+          } catch {
             throw new Error(
               `Subscription query ${queryPath} provided in subscription "${name}" in prisma.yml does not exist.`
             );

--- a/packages/loaders/prisma/src/prisma-yml/test/getTmpDir.ts
+++ b/packages/loaders/prisma/src/prisma-yml/test/getTmpDir.ts
@@ -3,10 +3,10 @@ import * as os from 'os';
 // @ts-ignore
 import cuid from 'scuid';
 import * as path from 'path';
-import * as fs from 'fs-extra';
+import * as fs from 'fs';
 
 export const getTmpDir = () => {
   const dir = path.join(os.tmpdir(), cuid() + '/');
-  fs.mkdirpSync(dir);
+  fs.mkdirSync(dir, { recursive: true });
   return dir;
 };

--- a/packages/loaders/prisma/src/prisma-yml/yaml.ts
+++ b/packages/loaders/prisma/src/prisma-yml/yaml.ts
@@ -1,6 +1,6 @@
 import Ajv from 'ajv';
 import * as yaml from 'js-yaml';
-import * as fs from 'fs-extra';
+import * as fs from 'fs';
 import schema, { PrismaDefinition } from './prisma-json-schema';
 import { Variables } from './Variables';
 import { Args } from './types/common';
@@ -23,7 +23,9 @@ export async function readDefinition(
   envVars?: any,
   graceful?: boolean
 ): Promise<{ definition: PrismaDefinition; rawJson: any }> {
-  if (!fs.pathExistsSync(filePath)) {
+  try {
+    fs.accessSync(filePath);
+  } catch {
     throw new Error(`${filePath} could not be found.`);
   }
   const file = fs.readFileSync(filePath, 'utf-8');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2730,13 +2730,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/fs-extra@9.0.4":
-  version "9.0.4"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-9.0.4.tgz#12553138cf0438db9a31cdc8b0a3aa9332eb67aa"
-  integrity sha512-50GO5ez44lxK5MDH90DYHFFfqxH7+fTqEEnvguQRzJ/tY9qFrMSHLiYHite+F3SNmf7+LHC1eMXojuD+E3Qcyg==
-  dependencies:
-    "@types/node" "*"
-
 "@types/glob@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
@@ -7291,16 +7284,6 @@ fs-extra@9.0.0:
     jsonfile "^6.0.1"
     universalify "^1.0.0"
 
-fs-extra@9.0.1, fs-extra@^9.0.0:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.1.tgz#910da0062437ba4c39fedd863f1675ccfefcb9fc"
-  integrity sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==
-  dependencies:
-    at-least-node "^1.0.0"
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^1.0.0"
-
 fs-extra@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
@@ -7318,6 +7301,16 @@ fs-extra@^7.0.1:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
+
+fs-extra@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.1.tgz#910da0062437ba4c39fedd863f1675ccfefcb9fc"
+  integrity sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^1.0.0"
 
 fs-minipass@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
Node 10 added support for promisified methods out of the box
and recursive flag for mkdir method. pathExists can be replaced with
fs.access methods which though throws error instead of returning
boolean.

<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
