### PR TITLE
Fixes for optimize package

### DIFF
--- a/.changeset/flat-monkeys-watch.md
+++ b/.changeset/flat-monkeys-watch.md
@@ -1,0 +1,5 @@
+---
+'graphql-tools': patch
+---
+
+Added export from new optimize package

--- a/.changeset/pink-eagles-cheer.md
+++ b/.changeset/pink-eagles-cheer.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/optimize': patch
+---
+
+Fix missing Directive AST when clearing empty nodes

--- a/packages/graphql-tools/package.json
+++ b/packages/graphql-tools/package.json
@@ -19,6 +19,7 @@
     "directory": "dist"
   },
   "dependencies": {
+    "@graphql-tools/optimize": "1.0.0",
     "@graphql-tools/batch-delegate": "^7.0.0",
     "@graphql-tools/batch-execute": "^7.0.0",
     "@graphql-tools/delegate": "^7.0.1",

--- a/packages/graphql-tools/src/index.ts
+++ b/packages/graphql-tools/src/index.ts
@@ -20,3 +20,4 @@ export * from '@graphql-tools/schema';
 export * from '@graphql-tools/stitch';
 export * from '@graphql-tools/utils';
 export * from '@graphql-tools/wrap';
+export * from '@graphql-tools/optimize';

--- a/packages/optimize/src/optimizers/remove-empty-nodes.ts
+++ b/packages/optimize/src/optimizers/remove-empty-nodes.ts
@@ -42,5 +42,6 @@ export const removeEmptyNodes: DocumentOptimizer = input => {
     FragmentSpread: transformNode,
     InlineFragment: transformNode,
     Name: transformNode,
+    Directive: transformNode,
   });
 };


### PR DESCRIPTION
- Added missing `Directive` handling for empty-nodes optimizer.
- Added export from root `graphql-tools` package.