### PR TITLE
fix(stitch) Add selectionSets to abstract types

### DIFF
--- a/packages/delegate/src/delegationBindings.ts
+++ b/packages/delegate/src/delegationBindings.ts
@@ -16,9 +16,9 @@ export function defaultDelegationBinding(delegationContext: DelegationContext): 
 
   if (stitchingInfo != null) {
     delegationTransforms = delegationTransforms.concat([
+      new ExpandAbstractTypes(),
       new AddSelectionSets({}, stitchingInfo.selectionSetsByField, stitchingInfo.dynamicSelectionSetsByField),
       new WrapConcreteTypes(),
-      new ExpandAbstractTypes(),
     ]);
   } else if (info != null) {
     delegationTransforms = delegationTransforms.concat([new WrapConcreteTypes(), new ExpandAbstractTypes()]);

--- a/packages/stitch/tests/mergeInterfaces.test.ts
+++ b/packages/stitch/tests/mergeInterfaces.test.ts
@@ -2,71 +2,72 @@ import { graphql } from 'graphql';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { stitchSchemas } from '../src/stitchSchemas';
 
-describe('merging interfaces', () => {
-  test('merges interfaces across subschemas', async () => {
-    const namedItemSchema = makeExecutableSchema({
-      typeDefs: `
-        interface Placement {
-          id: ID!
-          name: String!
-        }
-        type Item implements Placement {
-          id: ID!
-          name: String!
-        }
-        type Query {
-          itemById(id: ID!): Item
-        }
-      `,
-      resolvers: {
-        Query: {
-          itemById(_obj, args) {
-            return { id: args.id, name: `Item ${args.id}` };
-          }
+describe('merged interfaces', () => {
+  const namedItemSchema = makeExecutableSchema({
+    typeDefs: `
+      interface Placement {
+        id: ID!
+        name: String!
+      }
+      type Item implements Placement {
+        id: ID!
+        name: String!
+      }
+      type Query {
+        itemById(id: ID!): Item
+      }
+    `,
+    resolvers: {
+      Query: {
+        itemById(_obj, args) {
+          return { id: args.id, name: `Item ${args.id}` };
         }
       }
-    });
+    }
+  });
 
-    const indexedItemSchema = makeExecutableSchema({
-      typeDefs: `
-        interface Placement {
-          id: ID!
-          index: Int!
-        }
-        type Item implements Placement {
-          id: ID!
-          index: Int!
-        }
-        type Query {
-          placementById(id: ID!): Placement
-        }
-      `,
-      resolvers: {
-        Query: {
-          placementById(_obj, args) {
-            return { __typename: 'Item', id: args.id, index: Number(args.id) };
-          }
+  const indexedItemSchema = makeExecutableSchema({
+    typeDefs: `
+      interface Placement {
+        id: ID!
+        index: Int!
+      }
+      type Item implements Placement {
+        id: ID!
+        index: Int!
+      }
+      type Query {
+        placementById(id: ID!): Placement
+      }
+    `,
+    resolvers: {
+      Query: {
+        placementById(_obj, args) {
+          return { __typename: 'Item', id: args.id, index: Number(args.id) };
         }
       }
-    });
+    }
+  });
 
-    const stitchedSchema = stitchSchemas({
-      subschemas: [
-        {
-          schema: namedItemSchema,
-          merge: {
-            Item: {
-              selectionSet: '{ id }',
-              fieldName: 'itemById',
-              args: ({ id }) => ({ id }),
-            }
+  const stitchedSchema = stitchSchemas({
+    subschemas: [
+      {
+        schema: namedItemSchema,
+        merge: {
+          Item: {
+            selectionSet: '{ id }',
+            fieldName: 'itemById',
+            args: ({ id }) => ({ id }),
           }
-        },
-        { schema: indexedItemSchema },
-      ],
-      mergeTypes: true,
-    });
+        }
+      },
+      { schema: indexedItemSchema },
+    ],
+    mergeTypes: true,
+  });
 
+
+  test('works with selection set key', async () => {
     const result = await graphql(stitchedSchema, `
       query {
         placement: placementById(id: 23) {
@@ -78,5 +79,18 @@ describe('merging interfaces', () => {
     `);
 
     expect(result.data.placement).toEqual({ id: '23', index: 23, name: 'Item 23' });
+  });
+
+  test('works without selection set key', async () => {
+    const result = await graphql(stitchedSchema, `
+      query {
+        placement: placementById(id: 23) {
+          index
+          name
+        }
+      }
+    `);
+
+    expect(result.data.placement).toEqual({ index: 23, name: 'Item 23' });
   });
 });


### PR DESCRIPTION
I came across a bug with merged interfaces while putting together a demo of them. It looks like a pretty simple fix unless I'm overlooking something.

## Issue summary

We have two merged interfaces...

```graphql
# --- Schema A
interface Placement {
  id: ID!
  name: String!
}

# --- Schema B
interface Placement {
  id: ID!
  index: Int!
}

# --- Gateway schema
type Item implements Placement {
  id: ID!
  name: String!
  index: Int!
}
type Query {
  placement(id: ID!): Placement
}
```

Querying for the full interface works fine:

```graphql
query {
  placement(id: 23) {
    id
    name
    index
  }
}
# WORKS!
```

HOWEVER, it breaks when we query without `id`, which is the key used by the merge `selectionSet`.

```graphql
query {
  placement(id: 23) {
    name
    index
  }
}
# BREAKS!
```

## Resolution

This solution simply adjusts delegation transform order to put `ExtandAbstractTypes` in front of `AddSelectionSets`. That way abstracts have been expanded into concrete types by the time selection sets are added.

@yaacovCR – does this seem comprehensive? It seems like `ExtandAbstractTypes` won't always expand interfaces unless it needs to, at which time there may still be a hole in this implementation.