### PR TITLE
fix(stitch) fix merged error paths from batched arrays

### DIFF
--- a/.changeset/moody-worms-shave.md
+++ b/.changeset/moody-worms-shave.md
@@ -1,7 +1,0 @@
----
-"@graphql-tools/delegate": patch
-"@graphql-tools/stitch": patch
----
-
-fix(delegate) fix merged error paths from batched arrays
-fix(stitch) add selection sets to abstract types

--- a/.changeset/seven-dryers-vanish.md
+++ b/.changeset/seven-dryers-vanish.md
@@ -1,0 +1,6 @@
+---
+'@graphql-tools/batch-delegate': patch
+'@graphql-tools/delegate': patch
+---
+
+fix(batch-delegate): proxy batched errors

--- a/packages/delegate/src/delegateToSchema.ts
+++ b/packages/delegate/src/delegateToSchema.ts
@@ -92,6 +92,7 @@ export function delegateRequest({
   fieldName,
   args,
   returnType,
+  onLocatedError,
   context,
   transforms = [],
   transformedSchema,
@@ -134,6 +135,7 @@ export function delegateRequest({
     info,
     returnType:
       returnType ?? info?.returnType ?? getDelegationReturnType(targetSchema, targetOperation, targetFieldName),
+    onLocatedError,
     transforms: allTransforms,
     transformedSchema: transformedSchema ?? (subschemaConfig as Subschema)?.transformedSchema ?? targetSchema,
     skipTypeMerging,

--- a/packages/delegate/src/mergeFields.ts
+++ b/packages/delegate/src/mergeFields.ts
@@ -180,11 +180,12 @@ export function mergeFields(
   const resultMap: Map<Promise<any> | any, SelectionSetNode> = new Map();
   delegationMap.forEach((selectionSet: SelectionSetNode, s: Subschema) => {
     const resolver = mergedTypeInfo.resolvers.get(s);
-    const maybePromise = resolver(object, context, info, s, selectionSet);
-    resultMap.set(maybePromise, selectionSet);
+    let maybePromise = resolver(object, context, info, s, selectionSet);
     if (isPromise(maybePromise)) {
       containsPromises = true;
+      maybePromise = maybePromise.then(undefined, error => error);
     }
+    resultMap.set(maybePromise, selectionSet);
   });
 
   return containsPromises

--- a/packages/delegate/src/types.ts
+++ b/packages/delegate/src/types.ts
@@ -51,6 +51,7 @@ export interface DelegationContext {
   context: Record<string, any>;
   info: GraphQLResolveInfo;
   returnType: GraphQLOutputType;
+  onLocatedError?: (originalError: GraphQLError) => GraphQLError;
   transforms: Array<Transform>;
   transformedSchema: GraphQLSchema;
   skipTypeMerging: boolean;
@@ -64,6 +65,7 @@ export interface IDelegateToSchemaOptions<TContext = Record<string, any>, TArgs 
   operation?: OperationTypeNode;
   fieldName?: string;
   returnType?: GraphQLOutputType;
+  onLocatedError?: (originalError: GraphQLError) => GraphQLError;
   args?: TArgs;
   selectionSet?: SelectionSetNode;
   fieldNodes?: ReadonlyArray<FieldNode>;


### PR DESCRIPTION
At present there's a bug in error paths mapped from batched arrays... an error taken from a batched array always ends with its position in the underlying batch set, even though that position is not applicable within the stitched document path:

```json
{
  "errors": [
    {
      "message": "nope",
      "locations": [],
      "path": [
        "parent",
        "thing",
         0
      ]
    }
  ],
  "data": {
    "parent": {
      "thing": null
    }
  }
}
```

This checks the return type of the delegation query and omits the final path position from array values when they check out as integers.

cc @yaacovCR 