### PR TITLE
fix(typeMerging): enable renaming of subschema key fields via transforms

### DIFF
--- a/.changeset/olive-parrots-cross.md
+++ b/.changeset/olive-parrots-cross.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/delegate': patch
+---
+
+fix(typeMerging): enable subschemas to use keys that have been renamed via transforms

--- a/packages/delegate/src/mergeFields.ts
+++ b/packages/delegate/src/mergeFields.ts
@@ -234,14 +234,14 @@ const subschemaTypesContainSelectionSet = memoize3(function (
   if (Array.isArray(sourceSubschemaOrSourceSubschemas)) {
     return typesContainSelectionSet(
       sourceSubschemaOrSourceSubschemas.map(
-        sourceSubschema => sourceSubschema.schema.getType(mergedTypeInfo.typeName) as GraphQLObjectType
+        sourceSubschema => sourceSubschema.transformedSchema.getType(mergedTypeInfo.typeName) as GraphQLObjectType
       ),
       selectionSet
     );
   }
 
   return typesContainSelectionSet(
-    [sourceSubschemaOrSourceSubschemas.schema.getType(mergedTypeInfo.typeName) as GraphQLObjectType],
+    [sourceSubschemaOrSourceSubschemas.transformedSchema.getType(mergedTypeInfo.typeName) as GraphQLObjectType],
     selectionSet
   );
 });


### PR DESCRIPTION
Disallows key fields to be filtered from subschema.

Work-around would be to use filterSchema to filter as desired after creating the stitched schema.