### PR TITLE
fix(transforms): remove \_\_typename from subscription root when errorTransformer is set

### DIFF
--- a/.changeset/giant-nails-boil.md
+++ b/.changeset/giant-nails-boil.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/wrap': patch
+---
+
+fix(transforms): remove \_\_typename from subscription root when errorTransformer is set

--- a/packages/wrap/src/transforms/TransformCompositeFields.ts
+++ b/packages/wrap/src/transforms/TransformCompositeFields.ts
@@ -139,8 +139,9 @@ export default class TransformCompositeFields implements Transform {
 
       // See https://github.com/ardatan/graphql-tools/issues/2282
       if (
-        (this.subscriptionTypeName && parentTypeName !== this.subscriptionTypeName && this.dataTransformer != null) ||
-        this.errorsTransformer != null
+        this.subscriptionTypeName &&
+        parentTypeName !== this.subscriptionTypeName &&
+        (this.dataTransformer != null || this.errorsTransformer != null)
       ) {
         newSelections.push({
           kind: Kind.FIELD,


### PR DESCRIPTION
Bug in previous implementation as discussed here: https://github.com/ardatan/graphql-tools/issues/2282#issuecomment-735816583