### PR TITLE
fix(stitch): add __typename for root fields

### DIFF
--- a/.changeset/angry-coats-relax.md
+++ b/.changeset/angry-coats-relax.md
@@ -1,0 +1,14 @@
+---
+'@graphql-tools/delegate': patch
+'@graphql-tools/stitch': patch
+---
+
+fix(stitch): type merging for nested root types
+
+Because root types do not usually require selectionSets, a nested root type proxied to a remote service may end up having an empty selectionSet, if the nested root types only includes fields from a different subservice.
+
+Empty selection sets return null, but, in this case, it should return an empty object. We can force this behavior by including the \_\_typename field which exists on every schema.
+
+Addresses #2347.
+
+In the future, we may want to include short-circuiting behavior that when delegating to composite fields, if an empty selection set is included, an empty object is returned rather than null. This short-circuiting behavior would be complex for lists, as it would be unclear the length of the list...

--- a/packages/delegate/src/delegationBindings.ts
+++ b/packages/delegate/src/delegationBindings.ts
@@ -17,7 +17,11 @@ export function defaultDelegationBinding(delegationContext: DelegationContext): 
   if (stitchingInfo != null) {
     delegationTransforms = delegationTransforms.concat([
       new ExpandAbstractTypes(),
-      new AddSelectionSets({}, stitchingInfo.selectionSetsByField, stitchingInfo.dynamicSelectionSetsByField),
+      new AddSelectionSets(
+        stitchingInfo.selectionSetsByType,
+        stitchingInfo.selectionSetsByField,
+        stitchingInfo.dynamicSelectionSetsByField
+      ),
       new WrapConcreteTypes(),
     ]);
   } else if (info != null) {

--- a/packages/delegate/src/types.ts
+++ b/packages/delegate/src/types.ts
@@ -200,6 +200,7 @@ export type MergedTypeResolver = (
 
 export interface StitchingInfo {
   subschemaMap: Map<GraphQLSchema | SubschemaConfig, Subschema>;
+  selectionSetsByType: Record<string, SelectionSetNode>;
   selectionSetsByField: Record<string, Record<string, SelectionSetNode>>;
   dynamicSelectionSetsByField: Record<string, Record<string, Array<(node: FieldNode) => SelectionSetNode>>>;
   mergedTypes: Record<string, MergedTypeInfo>;

--- a/packages/stitch/src/stitchSchemas.ts
+++ b/packages/stitch/src/stitchSchemas.ts
@@ -142,7 +142,7 @@ export function stitchSchemas({
     ? extendResolversFromInterfaces(schema, resolverMap)
     : resolverMap;
 
-  stitchingInfo = completeStitchingInfo(stitchingInfo, finalResolvers);
+  stitchingInfo = completeStitchingInfo(stitchingInfo, finalResolvers, schema);
 
   schema = addResolversToSchema({
     schema,

--- a/packages/stitch/src/stitchingInfo.ts
+++ b/packages/stitch/src/stitchingInfo.ts
@@ -75,6 +75,7 @@ export function createStitchingInfo(
 
   return {
     subschemaMap,
+    selectionSetsByType: undefined,
     selectionSetsByField,
     dynamicSelectionSetsByField: undefined,
     mergedTypes,
@@ -226,7 +227,18 @@ function createMergedTypes(
   return mergedTypes;
 }
 
-export function completeStitchingInfo(stitchingInfo: StitchingInfo, resolvers: IResolvers): StitchingInfo {
+export function completeStitchingInfo(
+  stitchingInfo: StitchingInfo,
+  resolvers: IResolvers,
+  schema: GraphQLSchema
+): StitchingInfo {
+  const selectionSetsByType = Object.create(null);
+  [schema.getQueryType(), schema.getMutationType].forEach(rootType => {
+    if (rootType) {
+      selectionSetsByType[rootType.name] = parseSelectionSet('{ __typename }');
+    }
+  });
+
   const selectionSetsByField = stitchingInfo.selectionSetsByField;
   const dynamicSelectionSetsByField = Object.create(null);
 
@@ -280,6 +292,7 @@ export function completeStitchingInfo(stitchingInfo: StitchingInfo, resolvers: I
     });
   });
 
+  stitchingInfo.selectionSetsByType = selectionSetsByType;
   stitchingInfo.selectionSetsByField = selectionSetsByField;
   stitchingInfo.dynamicSelectionSetsByField = dynamicSelectionSetsByField;
 

--- a/packages/stitch/src/types.ts
+++ b/packages/stitch/src/types.ts
@@ -50,6 +50,7 @@ export interface MergedTypeInfo {
 
 export interface StitchingInfo {
   subschemaMap: Map<GraphQLSchema | SubschemaConfig, Subschema>;
+  selectionSetsByType: Record<string, SelectionSetNode>;
   selectionSetsByField: Record<string, Record<string, SelectionSetNode>>;
   dynamicSelectionSetsByField: Record<string, Record<string, Array<(node: FieldNode) => SelectionSetNode>>>;
   mergedTypes: Record<string, MergedTypeInfo>;

--- a/packages/stitch/tests/nestedRootTypes.test.ts
+++ b/packages/stitch/tests/nestedRootTypes.test.ts
@@ -1,0 +1,78 @@
+import { makeExecutableSchema } from "@graphql-tools/schema";
+import { stitchSchemas } from "@graphql-tools/stitch";
+import { graphql } from 'graphql';
+
+describe('nested root types', () => {
+  const schema1 = makeExecutableSchema({
+    typeDefs: `
+      type Query {
+        schema1Boolean: Boolean
+        schema1Query: Query
+      }
+    `,
+    resolvers: {
+      Query: {
+        schema1Boolean: () => true,
+        schema1Query: () => ({}),
+      },
+    },
+  });
+
+  const schema2 = makeExecutableSchema({
+    typeDefs: `
+      type Query {
+        schema2Boolean: Boolean
+        schema2Query: Query
+      }
+    `,
+    resolvers: {
+      Query: {
+        schema2Boolean: () => true,
+        schema2Query: () => ({}),
+      },
+    },
+  });
+
+  const stitchedSchema = stitchSchemas({
+    subschemas: [schema1, schema2],
+  });
+
+  it('works to nest root field', async () => {
+    const query = `
+      query {
+        schema1Query {
+          schema1Boolean
+          schema2Query {
+            schema1Boolean
+          }
+        }
+        schema2Query {
+          schema2Boolean
+          schema1Query {
+            schema2Boolean
+          }
+        }
+      }
+    `;
+
+    const expectedResult = {
+      data: {
+        schema1Query: {
+          schema1Boolean: true,
+          schema2Query: {
+            schema1Boolean: true,
+          },
+        },
+        schema2Query: {
+          schema2Boolean: true,
+          schema1Query: {
+            schema2Boolean: true,
+          },
+        },
+      },
+    };
+
+    const result = await graphql(stitchedSchema, query);
+    expect(result).toEqual(expectedResult);
+  });
+});


### PR DESCRIPTION
addresses #2347

also removed code that adds __typename to all merged types, it should only be necessary for root types when nesting, as all other merged types should have some selection set hint defined.
