### PR TITLE
fix(stitch): always use defaultMergedResolver by default on gateway

### DIFF
--- a/.changeset/sixty-walls-remember.md
+++ b/.changeset/sixty-walls-remember.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/stitch': patch
+---
+
+fix(stitch): always use defaultMergedResolver by default on gateway

--- a/packages/stitch/src/stitchSchemas.ts
+++ b/packages/stitch/src/stitchSchemas.ts
@@ -19,7 +19,7 @@ import {
   extendResolversFromInterfaces,
 } from '@graphql-tools/schema';
 
-import { SubschemaConfig, isSubschemaConfig, Subschema } from '@graphql-tools/delegate';
+import { SubschemaConfig, isSubschemaConfig, Subschema, defaultMergedResolver } from '@graphql-tools/delegate';
 
 import { IStitchSchemasOptions, SubschemaConfigTransform } from './types';
 
@@ -146,6 +146,7 @@ export function stitchSchemas({
 
   schema = addResolversToSchema({
     schema,
+    defaultFieldResolver: defaultMergedResolver,
     resolvers: finalResolvers,
     resolverValidationOptions,
     inheritResolversFromInterfaces: false,


### PR DESCRIPTION
External data metadata is sometimes lost when utilizing type shadowing...

Sometimes users may want to delegate from a gateway to a subschema by utilizing "type shadowing," i.e. by creating types on the gateway that mirror/mimic types in the remote schema. Normally, we encourage users to use transforms to rename types and fields from a subschema as desired, rather than create new fields on the gateway. However, we did/should support users that prefer to manually create types on the gateway that match the subschema rather than using transforms.

Schema stitching used to support this method in v4, by always utilizing the defaultMergedResolver, but along the way between v4 and at least v6, we stopped using the defaultMergedResolver as the default resolver for all new fields defined on the gateway.

This was a mistake -- and should be fixed. Thanks for bringing it to our attention!