### PR TITLE
enhance(printSchemaWithDirectives): for code first schemas

### DIFF
--- a/.changeset/dirty-bears-agree.md
+++ b/.changeset/dirty-bears-agree.md
@@ -1,0 +1,6 @@
+---
+'@graphql-tools/stitching-directives': patch
+'@graphql-tools/utils': patch
+---
+
+fix(stitchingDirectives): complete support for code first schemas

--- a/.changeset/hungry-dragons-drop.md
+++ b/.changeset/hungry-dragons-drop.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/utils': patch
+---
+
+fix(printSchemaWithDirectives): should work for code-first schemas as well

--- a/packages/stitching-directives/src/stitchingDirectives.ts
+++ b/packages/stitching-directives/src/stitchingDirectives.ts
@@ -1,4 +1,4 @@
-import { GraphQLSchema } from 'graphql';
+import { GraphQLDirective, GraphQLList, GraphQLNonNull, GraphQLSchema, GraphQLString } from 'graphql';
 
 import { SubschemaConfig } from '@graphql-tools/delegate';
 
@@ -17,6 +17,10 @@ export function stitchingDirectives(
   stitchingDirectivesTypeDefs: string;
   stitchingDirectivesValidator: (schema: GraphQLSchema) => GraphQLSchema;
   stitchingDirectivesTransformer: (subschemaConfig: SubschemaConfig) => SubschemaConfig;
+  keyDirective: GraphQLDirective;
+  computedDirective: GraphQLDirective;
+  mergeDirective: GraphQLDirective;
+  stitchingDirectives: Array<GraphQLDirective>;
 } {
   const finalOptions = {
     ...defaultStitchingDirectiveOptions,
@@ -29,6 +33,34 @@ export function stitchingDirectives(
   const computedDirectiveTypeDefs = `directive @${computedDirectiveName}(selectionSet: String!) on FIELD_DEFINITION`;
   const mergeDirectiveTypeDefs = `directive @${mergeDirectiveName}(argsExpr: String, keyArg: String, keyField: String, key: [String!], additionalArgs: String) on FIELD_DEFINITION`;
 
+  const keyDirective = new GraphQLDirective({
+    name: keyDirectiveName,
+    locations: ['OBJECT'],
+    args: {
+      selectionSet: { type: new GraphQLNonNull(GraphQLString) },
+    },
+  });
+
+  const computedDirective = new GraphQLDirective({
+    name: computedDirectiveName,
+    locations: ['FIELD_DEFINITION'],
+    args: {
+      selectionSet: { type: new GraphQLNonNull(GraphQLString) },
+    },
+  });
+
+  const mergeDirective = new GraphQLDirective({
+    name: mergeDirectiveName,
+    locations: ['FIELD_DEFINITION'],
+    args: {
+      argsExpr: { type: GraphQLString },
+      keyArg: { type: GraphQLString },
+      keyField: { type: GraphQLString },
+      key: { type: new GraphQLList(new GraphQLNonNull(GraphQLString)) },
+      additionalArgs: { type: GraphQLString },
+    },
+  });
+
   return {
     keyDirectiveTypeDefs,
     computedDirectiveTypeDefs,
@@ -38,6 +70,10 @@ export function stitchingDirectives(
       ${computedDirectiveTypeDefs}
       ${mergeDirectiveTypeDefs}
     `,
+    keyDirective,
+    computedDirective,
+    mergeDirective,
+    stitchingDirectives: [keyDirective, computedDirective, mergeDirective],
     stitchingDirectivesValidator: stitchingDirectivesValidator(finalOptions),
     stitchingDirectivesTransformer: stitchingDirectivesTransformer(finalOptions),
   };

--- a/packages/utils/src/fix-schema-ast.ts
+++ b/packages/utils/src/fix-schema-ast.ts
@@ -3,7 +3,7 @@ import { SchemaPrintOptions } from './types';
 import { printSchemaWithDirectives } from './print-schema-with-directives';
 
 function buildFixedSchema(schema: GraphQLSchema, options: BuildSchemaOptions & SchemaPrintOptions) {
-  return buildSchema(printSchemaWithDirectives(schema, options), {
+  return buildSchema(printSchemaWithDirectives(schema), {
     noLocation: true,
     ...(options || {}),
   });
@@ -11,25 +11,15 @@ function buildFixedSchema(schema: GraphQLSchema, options: BuildSchemaOptions & S
 
 export function fixSchemaAst(schema: GraphQLSchema, options: BuildSchemaOptions & SchemaPrintOptions) {
   let schemaWithValidAst: GraphQLSchema;
+  if (!schema.astNode || !schema.extensionASTNodes) {
+    schemaWithValidAst = buildFixedSchema(schema, options);
+  }
+
   if (!schema.astNode) {
-    Object.defineProperty(schema, 'astNode', {
-      get() {
-        if (!schemaWithValidAst) {
-          schemaWithValidAst = buildFixedSchema(schema, options);
-        }
-        return schemaWithValidAst.astNode;
-      },
-    });
+    schema.astNode = schemaWithValidAst.astNode;
   }
   if (!schema.extensionASTNodes) {
-    Object.defineProperty(schema, 'extensionASTNodes', {
-      get() {
-        if (!schemaWithValidAst) {
-          schemaWithValidAst = buildFixedSchema(schema, options);
-        }
-        return schemaWithValidAst.extensionASTNodes;
-      },
-    });
+    schema.extensionASTNodes = schemaWithValidAst.extensionASTNodes;
   }
   return schema;
 }

--- a/packages/utils/src/get-directives.ts
+++ b/packages/utils/src/get-directives.ts
@@ -54,8 +54,7 @@ type DirectableGraphQLObject =
   | GraphQLFieldConfig<any, any>
   | GraphQLInputFieldConfig;
 
-export function getDirectives(
-  schema: GraphQLSchema,
+export function getDirectivesInExtensions(
   node: DirectableGraphQLObject,
   pathToDirectivesInExtensions = ['directives']
 ): DirectiveUseMap {
@@ -63,6 +62,16 @@ export function getDirectives(
     (acc, pathSegment) => (acc == null ? acc : acc[pathSegment]),
     node?.extensions
   );
+
+  return directivesInExtensions;
+}
+
+export function getDirectives(
+  schema: GraphQLSchema,
+  node: DirectableGraphQLObject,
+  pathToDirectivesInExtensions = ['directives']
+): DirectiveUseMap {
+  const directivesInExtensions = getDirectivesInExtensions(node, pathToDirectivesInExtensions);
 
   if (directivesInExtensions != null) {
     return directivesInExtensions;

--- a/packages/utils/src/print-schema-with-directives.ts
+++ b/packages/utils/src/print-schema-with-directives.ts
@@ -19,13 +19,19 @@ import {
   DirectiveDefinitionNode,
   astFromValue,
 } from 'graphql';
-import { SchemaPrintOptions } from './types';
+import { PrintSchemaWithDirectivesOptions } from './types';
 import { createSchemaDefinition } from './create-schema-definition';
 import { astFromType } from './astFromType';
+import { mapSchema } from './mapSchema';
 
 // this approach uses the default schema printer rather than a custom solution, so may be more backwards compatible
 // currently does not allow customization of printSchema options having to do with comments.
-export function printSchemaWithDirectives(schema: GraphQLSchema, _options: SchemaPrintOptions = {}): string {
+export function printSchemaWithDirectives(
+  schema: GraphQLSchema,
+  options: PrintSchemaWithDirectivesOptions = {}
+): string {
+  schema = loadDirectivesFromExtensions(schema, options);
+
   const typesMap = schema.getTypeMap();
 
   const result: string[] = [getSchemaDefinition(schema)];
@@ -133,7 +139,7 @@ function correctType<TMap extends { [key: string]: GraphQLNamedType }, TName ext
   return type;
 }
 
-function getSchemaDefinition(schema: GraphQLSchema) {
+export function getSchemaDefinition(schema: GraphQLSchema) {
   if (!Object.getOwnPropertyDescriptor(schema, 'astNode').get && schema.astNode) {
     return print(schema.astNode);
   } else {
@@ -234,4 +240,11 @@ function astFromArg(arg: GraphQLArgument): InputValueDefinitionNode {
         ? directiveNodesBesidesDeprecated
         : [deprecatedDirectiveNode].concat(directiveNodesBesidesDeprecated),
   };
+}
+
+export function loadDirectivesFromExtensions(schema: GraphQLSchema, options: PrintSchemaWithDirectivesOptions) {
+  const pathToDirectivesInExtensions = options.pathToDirectivesInExtensions ?? ['directives'];
+
+  // do the thing
+  return mapSchema(schema, {});
 }

--- a/packages/utils/src/print-schema-with-directives.ts
+++ b/packages/utils/src/print-schema-with-directives.ts
@@ -1,13 +1,10 @@
 import {
   GraphQLSchema,
   print,
-  printType,
   GraphQLNamedType,
   Kind,
-  ObjectTypeExtensionNode,
   isSpecifiedScalarType,
   isIntrospectionType,
-  parse,
   TypeDefinitionNode,
   DirectiveNode,
   FieldDefinitionNode,
@@ -18,11 +15,41 @@ import {
   GraphQLDirective,
   DirectiveDefinitionNode,
   astFromValue,
+  ArgumentNode,
+  SchemaDefinitionNode,
+  OperationTypeDefinitionNode,
+  SchemaExtensionNode,
+  OperationTypeNode,
+  GraphQLObjectType,
+  GraphQLDeprecatedDirective,
+  isObjectType,
+  ObjectTypeDefinitionNode,
+  GraphQLField,
+  NamedTypeNode,
+  TypeExtensionNode,
+  GraphQLInterfaceType,
+  InterfaceTypeDefinitionNode,
+  isInterfaceType,
+  isUnionType,
+  UnionTypeDefinitionNode,
+  GraphQLUnionType,
+  isInputObjectType,
+  GraphQLInputObjectType,
+  InputObjectTypeDefinitionNode,
+  GraphQLInputField,
+  isEnumType,
+  isScalarType,
+  GraphQLEnumType,
+  GraphQLEnumValue,
+  EnumTypeDefinitionNode,
+  GraphQLScalarType,
+  ScalarTypeDefinitionNode,
+  StringValueNode,
 } from 'graphql';
 import { PrintSchemaWithDirectivesOptions } from './types';
-import { createSchemaDefinition } from './create-schema-definition';
+
 import { astFromType } from './astFromType';
-import { mapSchema } from './mapSchema';
+import { getDirectivesInExtensions } from './get-directives';
 
 // this approach uses the default schema printer rather than a custom solution, so may be more backwards compatible
 // currently does not allow customization of printSchema options having to do with comments.
@@ -30,11 +57,12 @@ export function printSchemaWithDirectives(
   schema: GraphQLSchema,
   options: PrintSchemaWithDirectivesOptions = {}
 ): string {
-  schema = loadDirectivesFromExtensions(schema, options);
+  const pathToDirectivesInExtensions = options.pathToDirectivesInExtensions;
 
   const typesMap = schema.getTypeMap();
 
-  const result: string[] = [getSchemaDefinition(schema)];
+  const schemaNode = astFromSchema(schema, pathToDirectivesInExtensions);
+  const result: Array<string> = schemaNode != null ? [print(schemaNode)] : [];
 
   for (const typeName in typesMap) {
     const type = typesMap[typeName];
@@ -45,8 +73,21 @@ export function printSchemaWithDirectives(
       continue;
     }
 
-    // KAMIL: we might want to turn on descriptions in future
-    result.push(print(correctType(typeName, typesMap)?.astNode));
+    if (isObjectType(type)) {
+      result.push(print(astFromObjectType(type, schema, pathToDirectivesInExtensions)));
+    } else if (isInterfaceType(type)) {
+      result.push(print(astFromInterfaceType(type, schema, pathToDirectivesInExtensions)));
+    } else if (isUnionType(type)) {
+      result.push(print(astFromUnionType(type, schema, pathToDirectivesInExtensions)));
+    } else if (isInputObjectType(type)) {
+      result.push(print(astFromInputObjectType(type, schema, pathToDirectivesInExtensions)));
+    } else if (isEnumType(type)) {
+      result.push(print(astFromEnumType(type, schema, pathToDirectivesInExtensions)));
+    } else if (isScalarType(type)) {
+      result.push(print(astFromScalarType(type, schema, pathToDirectivesInExtensions)));
+    } else {
+      throw new Error(`Unknown type ${type}.`);
+    }
   }
 
   const directives = schema.getDirectives();
@@ -55,106 +96,94 @@ export function printSchemaWithDirectives(
       continue;
     }
 
-    result.push(print(astFromDirective(directive)));
+    result.push(print(astFromDirective(directive, schema, pathToDirectivesInExtensions)));
   }
 
   return result.join('\n');
 }
 
-function extendDefinition(type: GraphQLNamedType): GraphQLNamedType['astNode'] {
-  switch (type.astNode.kind) {
-    case Kind.OBJECT_TYPE_DEFINITION:
-      return {
-        ...type.astNode,
-        fields: type.astNode.fields.concat(
-          (type.extensionASTNodes as ReadonlyArray<ObjectTypeExtensionNode>).reduce(
-            (fields, node) => fields.concat(node.fields),
-            []
-          )
-        ),
-      };
-    case Kind.INPUT_OBJECT_TYPE_DEFINITION:
-      return {
-        ...type.astNode,
-        fields: type.astNode.fields.concat(
-          (type.extensionASTNodes as ReadonlyArray<ObjectTypeExtensionNode>).reduce(
-            (fields, node) => fields.concat(node.fields),
-            []
-          )
-        ),
-      };
-    default:
-      return type.astNode;
+function astFromSchema(
+  schema: GraphQLSchema,
+  pathToDirectivesInExtensions: Array<string>
+): SchemaDefinitionNode | SchemaExtensionNode {
+  const operationTypeMap: Record<OperationTypeNode, OperationTypeDefinitionNode> = {
+    query: undefined,
+    mutation: undefined,
+    subscription: undefined,
+  };
+
+  let nodes: Array<SchemaDefinitionNode | SchemaExtensionNode> = [];
+  if (schema.astNode != null) {
+    nodes.push(schema.astNode);
   }
-}
-
-function correctType<TMap extends { [key: string]: GraphQLNamedType }, TName extends keyof TMap>(
-  typeName: TName,
-  typesMap: TMap
-): TMap[TName] {
-  const type = typesMap[typeName];
-
-  type.name = typeName.toString();
-
-  if (type.astNode && type.extensionASTNodes) {
-    type.astNode = type.extensionASTNodes ? extendDefinition(type) : type.astNode;
+  if (schema.extensionASTNodes != null) {
+    nodes = nodes.concat(schema.extensionASTNodes);
   }
-  const doc = parse(printType(type));
-  const fixedAstNode = doc.definitions[0] as TypeDefinitionNode;
-  const originalAstNode = type?.astNode;
-  if (originalAstNode) {
-    (fixedAstNode.directives as DirectiveNode[]) = originalAstNode?.directives as DirectiveNode[];
-    if (fixedAstNode && 'fields' in fixedAstNode && originalAstNode && 'fields' in originalAstNode) {
-      for (const fieldDefinitionNode of fixedAstNode.fields) {
-        const originalFieldDefinitionNode = (originalAstNode.fields as (
-          | InputValueDefinitionNode
-          | FieldDefinitionNode
-        )[]).find(field => field.name.value === fieldDefinitionNode.name.value);
-        (fieldDefinitionNode.directives as DirectiveNode[]) = originalFieldDefinitionNode?.directives as DirectiveNode[];
-        if (
-          fieldDefinitionNode &&
-          'arguments' in fieldDefinitionNode &&
-          originalFieldDefinitionNode &&
-          'arguments' in originalFieldDefinitionNode
-        ) {
-          for (const argument of fieldDefinitionNode.arguments) {
-            const originalArgumentNode = (originalFieldDefinitionNode as FieldDefinitionNode).arguments?.find(
-              arg => arg.name.value === argument.name.value
-            );
-            (argument.directives as DirectiveNode[]) = originalArgumentNode.directives as DirectiveNode[];
-          }
-        }
-      }
-    } else if (fixedAstNode && 'values' in fixedAstNode && originalAstNode && 'values' in originalAstNode) {
-      for (const valueDefinitionNode of fixedAstNode.values) {
-        const originalValueDefinitionNode = (originalAstNode.values as EnumValueDefinitionNode[]).find(
-          valueNode => valueNode.name.value === valueDefinitionNode.name.value
-        );
-        (valueDefinitionNode.directives as DirectiveNode[]) = originalValueDefinitionNode?.directives as DirectiveNode[];
+
+  nodes.forEach(node => {
+    if (node.operationTypes) {
+      node.operationTypes.forEach(operationTypeDefinitionNode => {
+        operationTypeMap[operationTypeDefinitionNode.operation] = operationTypeDefinitionNode;
+      });
+    }
+  });
+
+  const rootTypeMap: Record<OperationTypeNode, GraphQLObjectType> = {
+    query: schema.getQueryType(),
+    mutation: schema.getMutationType(),
+    subscription: schema.getSubscriptionType(),
+  };
+
+  Object.keys(operationTypeMap).forEach(operationTypeNode => {
+    if (rootTypeMap[operationTypeNode] != null) {
+      if (operationTypeMap[operationTypeNode] != null) {
+        operationTypeMap[operationTypeNode].type = astFromType(rootTypeMap[operationTypeNode]);
+      } else {
+        operationTypeMap[operationTypeNode] = {
+          kind: Kind.OPERATION_TYPE_DEFINITION,
+          operation: operationTypeNode,
+          type: astFromType(rootTypeMap[operationTypeNode]),
+        };
       }
     }
-  }
-  type.astNode = fixedAstNode;
+  });
 
-  return type;
+  const operationTypes = Object.values(operationTypeMap).filter(
+    operationTypeDefinitionNode => operationTypeDefinitionNode != null
+  );
+
+  const directives = getDirectiveNodes(schema, schema, pathToDirectivesInExtensions);
+
+  if (!operationTypes.length && !directives.length) {
+    return null;
+  }
+
+  const schemaNode: SchemaDefinitionNode | SchemaExtensionNode = {
+    kind: operationTypes != null ? Kind.SCHEMA_DEFINITION : Kind.SCHEMA_EXTENSION,
+    operationTypes,
+    directives,
+  };
+
+  ((schemaNode as unknown) as { description: StringValueNode }).description =
+    ((schema.astNode as unknown) as { description: string })?.description ??
+    ((schema as unknown) as { description: string }).description != null
+      ? {
+          kind: Kind.STRING,
+          value: ((schema as unknown) as { description: string }).description,
+          block: true,
+        }
+      : undefined;
+
+  return schemaNode;
 }
 
-export function getSchemaDefinition(schema: GraphQLSchema) {
-  if (!Object.getOwnPropertyDescriptor(schema, 'astNode').get && schema.astNode) {
-    return print(schema.astNode);
-  } else {
-    return createSchemaDefinition({
-      query: schema.getQueryType(),
-      mutation: schema.getMutationType(),
-      subscription: schema.getSubscriptionType(),
-    });
-  }
-}
-
-function astFromDirective(directive: GraphQLDirective): DirectiveDefinitionNode {
+function astFromDirective(
+  directive: GraphQLDirective,
+  schema: GraphQLSchema,
+  pathToDirectivesInExtensions: Array<string>
+): DirectiveDefinitionNode {
   return {
     kind: Kind.DIRECTIVE_DEFINITION,
-    loc: directive.astNode?.loc,
     description:
       directive.astNode?.description ??
       (directive.description
@@ -167,7 +196,9 @@ function astFromDirective(directive: GraphQLDirective): DirectiveDefinitionNode 
       kind: Kind.NAME,
       value: directive.name,
     },
-    arguments: directive?.args ? directive.args.map(astFromArg) : undefined,
+    arguments: directive?.args
+      ? directive.args.map(arg => astFromArg(arg, schema, pathToDirectivesInExtensions))
+      : undefined,
     repeatable: directive.isRepeatable,
     locations: directive?.locations
       ? directive.locations.map(location => ({
@@ -178,73 +209,367 @@ function astFromDirective(directive: GraphQLDirective): DirectiveDefinitionNode 
   };
 }
 
-function astFromArg(arg: GraphQLArgument): InputValueDefinitionNode {
+function getDirectiveNodes(
+  entity: GraphQLSchema | GraphQLNamedType | GraphQLEnumValue,
+  schema: GraphQLSchema,
+  pathToDirectivesInExtensions: Array<string>
+): Array<DirectiveNode> {
+  const directivesInExtensions = getDirectivesInExtensions(entity, pathToDirectivesInExtensions);
+
+  let nodes: Array<
+    SchemaDefinitionNode | SchemaExtensionNode | TypeDefinitionNode | TypeExtensionNode | EnumValueDefinitionNode
+  > = [];
+  if (entity.astNode != null) {
+    nodes.push(entity.astNode);
+  }
+  if ('extensionASTNodes' in entity && entity.extensionASTNodes != null) {
+    nodes = nodes.concat(entity.extensionASTNodes);
+  }
+
+  let directives: Array<DirectiveNode>;
+  if (directivesInExtensions != null) {
+    directives = makeDirectives(schema, directivesInExtensions);
+  } else {
+    directives = [].concat(...nodes.filter(node => node.directives != null).map(node => node.directives));
+  }
+
+  return directives;
+}
+
+function getDeprecatableDirectiveNodes(
+  entity: GraphQLArgument | GraphQLField<any, any> | GraphQLInputField,
+  schema: GraphQLSchema,
+  pathToDirectivesInExtensions: Array<string>
+): Array<DirectiveNode> {
   let directiveNodesBesidesDeprecated: Array<DirectiveNode> = [];
   let deprecatedDirectiveNode: DirectiveNode;
 
-  const hasASTDirectives = arg.astNode?.directives;
-  if (hasASTDirectives) {
-    directiveNodesBesidesDeprecated = arg.astNode.directives.filter(directive => directive.name.value !== 'deprecated');
-    if (((arg as unknown) as { deprecationReason: string }).deprecationReason != null) {
-      deprecatedDirectiveNode = ((arg as unknown) as { astNode: InputValueDefinitionNode }).astNode.directives.filter(
-        directive => directive.name.value === 'deprecated'
-      )?.[0];
+  const directivesInExtensions = getDirectivesInExtensions(entity, pathToDirectivesInExtensions);
+
+  let directives: ReadonlyArray<DirectiveNode>;
+  if (directivesInExtensions != null) {
+    directives = makeDirectives(schema, directivesInExtensions);
+  } else {
+    directives = entity.astNode?.directives;
+  }
+
+  if (directives != null) {
+    directiveNodesBesidesDeprecated = directives.filter(directive => directive.name.value !== 'deprecated');
+    if (((entity as unknown) as { deprecationReason: string }).deprecationReason != null) {
+      deprecatedDirectiveNode = directives.filter(directive => directive.name.value === 'deprecated')?.[0];
     }
   }
 
   if (
-    ((arg as unknown) as { deprecationReason: string }).deprecationReason != null &&
+    ((entity as unknown) as { deprecationReason: string }).deprecationReason != null &&
     deprecatedDirectiveNode == null
   ) {
-    deprecatedDirectiveNode = {
-      kind: Kind.DIRECTIVE,
-      name: {
-        kind: Kind.NAME,
-        value: 'deprecated',
-      },
-      arguments: [
-        {
-          kind: Kind.ARGUMENT,
-          name: {
-            kind: Kind.NAME,
-            value: 'reason',
-          },
-          value: {
-            kind: Kind.STRING,
-            value: ((arg as unknown) as { deprecationReason: string }).deprecationReason,
-          },
-        },
-      ],
-    };
+    deprecatedDirectiveNode = makeDeprecatedDirective(
+      ((entity as unknown) as { deprecationReason: string }).deprecationReason
+    );
   }
 
+  return deprecatedDirectiveNode == null
+    ? directiveNodesBesidesDeprecated
+    : [deprecatedDirectiveNode].concat(directiveNodesBesidesDeprecated);
+}
+
+function astFromArg(
+  arg: GraphQLArgument,
+  schema: GraphQLSchema,
+  pathToDirectivesInExtensions: Array<string>
+): InputValueDefinitionNode {
   return {
     kind: Kind.INPUT_VALUE_DEFINITION,
-    loc: arg.astNode?.loc,
     description:
-      arg.astNode?.description ??
-      (arg.description
+      arg.astNode?.description ?? arg.description
         ? {
             kind: Kind.STRING,
             value: arg.description,
+            block: true,
           }
-        : undefined),
+        : undefined,
     name: {
       kind: Kind.NAME,
       value: arg.name,
     },
     type: astFromType(arg.type),
     defaultValue: arg.defaultValue !== undefined ? astFromValue(arg.defaultValue, arg.type) : undefined,
-    directives:
-      deprecatedDirectiveNode == null
-        ? directiveNodesBesidesDeprecated
-        : [deprecatedDirectiveNode].concat(directiveNodesBesidesDeprecated),
+    directives: getDeprecatableDirectiveNodes(arg, schema, pathToDirectivesInExtensions),
   };
 }
 
-export function loadDirectivesFromExtensions(schema: GraphQLSchema, options: PrintSchemaWithDirectivesOptions) {
-  const pathToDirectivesInExtensions = options.pathToDirectivesInExtensions ?? ['directives'];
+function astFromObjectType(
+  type: GraphQLObjectType,
+  schema: GraphQLSchema,
+  pathToDirectivesInExtensions: Array<string>
+): ObjectTypeDefinitionNode {
+  return {
+    kind: Kind.OBJECT_TYPE_DEFINITION,
+    description:
+      type.astNode?.description ?? type.description
+        ? {
+            kind: Kind.STRING,
+            value: type.description,
+            block: true,
+          }
+        : undefined,
+    name: {
+      kind: Kind.NAME,
+      value: type.name,
+    },
+    fields: Object.values(type.getFields()).map(field => astFromField(field, schema, pathToDirectivesInExtensions)),
+    interfaces: Object.values(type.getInterfaces()).map(iFace => astFromType(iFace) as NamedTypeNode),
+    directives: getDirectiveNodes(type, schema, pathToDirectivesInExtensions),
+  };
+}
 
-  // do the thing
-  return mapSchema(schema, {});
+function astFromInterfaceType(
+  type: GraphQLInterfaceType,
+  schema: GraphQLSchema,
+  pathToDirectivesInExtensions: Array<string>
+): InterfaceTypeDefinitionNode {
+  const node = {
+    kind: Kind.INTERFACE_TYPE_DEFINITION,
+    description:
+      type.astNode?.description ?? type.description
+        ? {
+            kind: Kind.STRING,
+            value: type.description,
+            block: true,
+          }
+        : undefined,
+    name: {
+      kind: Kind.NAME,
+      value: type.name,
+    },
+    fields: Object.values(type.getFields()).map(field => astFromField(field, schema, pathToDirectivesInExtensions)),
+    directives: getDirectiveNodes(type, schema, pathToDirectivesInExtensions),
+  };
+
+  if ('getInterfaces' in type) {
+    ((node as unknown) as { interfaces: Array<NamedTypeNode> }).interfaces = Object.values(
+      ((type as unknown) as GraphQLObjectType).getInterfaces()
+    ).map(iFace => astFromType(iFace) as NamedTypeNode);
+  }
+
+  return node;
+}
+
+function astFromUnionType(
+  type: GraphQLUnionType,
+  schema: GraphQLSchema,
+  pathToDirectivesInExtensions: Array<string>
+): UnionTypeDefinitionNode {
+  return {
+    kind: Kind.UNION_TYPE_DEFINITION,
+    description:
+      type.astNode?.description ?? type.description
+        ? {
+            kind: Kind.STRING,
+            value: type.description,
+            block: true,
+          }
+        : undefined,
+    name: {
+      kind: Kind.NAME,
+      value: type.name,
+    },
+    directives: getDirectiveNodes(type, schema, pathToDirectivesInExtensions),
+    types: type.getTypes().map(type => astFromType(type) as NamedTypeNode),
+  };
+}
+
+function astFromInputObjectType(
+  type: GraphQLInputObjectType,
+  schema: GraphQLSchema,
+  pathToDirectivesInExtensions: Array<string>
+): InputObjectTypeDefinitionNode {
+  return {
+    kind: Kind.INPUT_OBJECT_TYPE_DEFINITION,
+    description:
+      type.astNode?.description ?? type.description
+        ? {
+            kind: Kind.STRING,
+            value: type.description,
+            block: true,
+          }
+        : undefined,
+    name: {
+      kind: Kind.NAME,
+      value: type.name,
+    },
+    fields: Object.values(type.getFields()).map(field =>
+      astFromInputField(field, schema, pathToDirectivesInExtensions)
+    ),
+    directives: getDirectiveNodes(type, schema, pathToDirectivesInExtensions),
+  };
+}
+
+function astFromEnumType(
+  type: GraphQLEnumType,
+  schema: GraphQLSchema,
+  pathToDirectivesInExtensions: Array<string>
+): EnumTypeDefinitionNode {
+  return {
+    kind: Kind.ENUM_TYPE_DEFINITION,
+    description:
+      type.astNode?.description ?? type.description
+        ? {
+            kind: Kind.STRING,
+            value: type.description,
+            block: true,
+          }
+        : undefined,
+    name: {
+      kind: Kind.NAME,
+      value: type.name,
+    },
+    values: Object.values(type.getValues()).map(value => astFromEnumValue(value, schema, pathToDirectivesInExtensions)),
+    directives: getDirectiveNodes(type, schema, pathToDirectivesInExtensions),
+  };
+}
+
+function astFromScalarType(
+  type: GraphQLScalarType,
+  schema: GraphQLSchema,
+  pathToDirectivesInExtensions: Array<string>
+): ScalarTypeDefinitionNode {
+  return {
+    kind: Kind.SCALAR_TYPE_DEFINITION,
+    description:
+      type.astNode?.description ?? type.description
+        ? {
+            kind: Kind.STRING,
+            value: type.description,
+            block: true,
+          }
+        : undefined,
+    name: {
+      kind: Kind.NAME,
+      value: type.name,
+    },
+    directives: getDirectiveNodes(type, schema, pathToDirectivesInExtensions),
+  };
+}
+
+function astFromField(
+  field: GraphQLField<any, any>,
+  schema: GraphQLSchema,
+  pathToDirectivesInExtensions: Array<string>
+): FieldDefinitionNode {
+  return {
+    kind: Kind.FIELD_DEFINITION,
+    description:
+      field.astNode?.description ?? field.description
+        ? {
+            kind: Kind.STRING,
+            value: field.description,
+            block: true,
+          }
+        : undefined,
+    name: {
+      kind: Kind.NAME,
+      value: field.name,
+    },
+    arguments: field.args.map(arg => astFromArg(arg, schema, pathToDirectivesInExtensions)),
+    type: astFromType(field.type),
+    directives: getDeprecatableDirectiveNodes(field, schema, pathToDirectivesInExtensions),
+  };
+}
+
+function astFromInputField(
+  field: GraphQLInputField,
+  schema: GraphQLSchema,
+  pathToDirectivesInExtensions: Array<string>
+): InputValueDefinitionNode {
+  return {
+    kind: Kind.INPUT_VALUE_DEFINITION,
+    description:
+      field.astNode?.description ?? field.description
+        ? {
+            kind: Kind.STRING,
+            value: field.description,
+            block: true,
+          }
+        : undefined,
+    name: {
+      kind: Kind.NAME,
+      value: field.name,
+    },
+    type: astFromType(field.type),
+    directives: getDeprecatableDirectiveNodes(field, schema, pathToDirectivesInExtensions),
+  };
+}
+
+function astFromEnumValue(
+  value: GraphQLEnumValue,
+  schema: GraphQLSchema,
+  pathToDirectivesInExtensions: Array<string>
+): EnumValueDefinitionNode {
+  return {
+    kind: Kind.ENUM_VALUE_DEFINITION,
+    description:
+      value.astNode?.description ?? value.description
+        ? {
+            kind: Kind.STRING,
+            value: value.description,
+            block: true,
+          }
+        : undefined,
+    name: {
+      kind: Kind.NAME,
+      value: value.name,
+    },
+    directives: getDirectiveNodes(value, schema, pathToDirectivesInExtensions),
+  };
+}
+
+function makeDeprecatedDirective(deprecationReason: string): DirectiveNode {
+  return makeDirective('deprecated', { reason: deprecationReason }, GraphQLDeprecatedDirective);
+}
+
+function makeDirective(name: string, args: Record<string, any>, directive: GraphQLDirective): DirectiveNode {
+  const directiveArguments: Array<ArgumentNode> = [];
+
+  Object.entries(args).forEach(([argName, argValue]) => {
+    const directiveArg = directive.args.find(arg => arg.name === argName);
+
+    if (directiveArg) {
+      directiveArguments.push({
+        kind: Kind.ARGUMENT,
+        name: {
+          kind: Kind.NAME,
+          value: argName,
+        },
+        value: astFromValue(argValue, directiveArg.type),
+      });
+    }
+  });
+
+  return {
+    kind: Kind.DIRECTIVE,
+    name: {
+      kind: Kind.NAME,
+      value: name,
+    },
+    arguments: directiveArguments,
+  };
+}
+
+function makeDirectives(schema: GraphQLSchema, directiveValues: Record<string, any>): Array<DirectiveNode> {
+  const directiveNodes: Array<DirectiveNode> = [];
+  Object.entries(directiveValues).forEach(([directiveName, arrayOrSingleValue]) => {
+    const directive = schema.getDirective(directiveName);
+    if (directive != null) {
+      if (Array.isArray(arrayOrSingleValue)) {
+        arrayOrSingleValue.forEach(value => {
+          directiveNodes.push(makeDirective(directiveName, value, directive));
+        });
+      } else {
+        directiveNodes.push(makeDirective(directiveName, arrayOrSingleValue, directive));
+      }
+    }
+  });
+  return directiveNodes;
 }

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -10,6 +10,10 @@ export interface SchemaPrintOptions {
   commentDescriptions?: boolean;
 }
 
+export interface PrintSchemaWithDirectivesOptions {
+  pathToDirectivesInExtensions?: Array<string>;
+}
+
 export type Maybe<T> = null | undefined | T;
 
 export type Constructor<T> = new (...args: any[]) => T;

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -10,7 +10,7 @@ export interface SchemaPrintOptions {
   commentDescriptions?: boolean;
 }
 
-export interface PrintSchemaWithDirectivesOptions {
+export interface PrintSchemaWithDirectivesOptions extends SchemaPrintOptions {
   pathToDirectivesInExtensions?: Array<string>;
 }
 

--- a/packages/utils/tests/print-schema-with-directives.spec.ts
+++ b/packages/utils/tests/print-schema-with-directives.spec.ts
@@ -1,6 +1,6 @@
 import { RenameTypes, wrapSchema } from '@graphql-tools/wrap';
 import { makeExecutableSchema } from '@graphql-tools/schema';
-import { buildSchema, printSchema } from 'graphql';
+import { buildSchema, GraphQLDirective, printSchema, GraphQLSchema } from 'graphql';
 import { printSchemaWithDirectives } from '../src';
 import { GraphQLJSON } from 'graphql-scalars';
 
@@ -65,6 +65,19 @@ describe('printSchemaWithDirectives', () => {
     expect(output).toContain('type Other');
     expect(output).toContain('type TestType');
     expect(output).toContain('type Query');
+  });
+
+  it('Should print directives correctly if they dont have astNode', () => {
+    const schema = new GraphQLSchema({
+      directives: [new GraphQLDirective({
+        name: 'dummy',
+        locations: ['QUERY'],
+      })]
+    });
+
+    const output = printSchemaWithDirectives(schema);
+
+    expect(output).toContain('directive @dummy on QUERY');
   });
 
   it('should print comments', () => {

--- a/packages/utils/tests/print-schema-with-directives.spec.ts
+++ b/packages/utils/tests/print-schema-with-directives.spec.ts
@@ -1,6 +1,6 @@
 import { RenameTypes, wrapSchema } from '@graphql-tools/wrap';
 import { makeExecutableSchema } from '@graphql-tools/schema';
-import { buildSchema, GraphQLDirective, printSchema, GraphQLSchema } from 'graphql';
+import { buildSchema, GraphQLDirective, printSchema, GraphQLSchema, specifiedDirectives, GraphQLObjectType, GraphQLNonNull, GraphQLID, GraphQLList } from 'graphql';
 import { printSchemaWithDirectives } from '../src';
 import { GraphQLJSON } from 'graphql-scalars';
 
@@ -20,6 +20,96 @@ describe('printSchemaWithDirectives', () => {
         friends: [User!]! @link
       }
     `);
+
+    const printedSchemaByGraphQL = printSchema(schemaWithDirectives);
+    expect(printedSchemaByGraphQL).toContain('directive @entity on OBJECT');
+    expect(printedSchemaByGraphQL).not.toContain(`id: ID! @id`);
+    expect(printedSchemaByGraphQL).not.toContain(`friends: [User!]! @link`);
+    expect(printedSchemaByGraphQL).not.toContain(`type User @entity`);
+    const printedSchemaAlternative = printSchemaWithDirectives(schemaWithDirectives);
+    expect(printedSchemaAlternative).toContain('directive @entity on OBJECT');
+    expect(printedSchemaAlternative).toContain(`id: ID! @id`);
+    expect(printedSchemaAlternative).toContain(`friends: [User!]! @link`);
+    expect(printedSchemaAlternative).toContain(`type User @entity`);
+  });
+
+  it('Should print with directives, even when using extend', () => {
+    // note that in graphql v14, similar test will fail when using buildSchema from graphql-js
+    // instead of makeExecutableSchema, because in v14, buildSchema ignores the extend keywords
+    const schemaWithDirectives = makeExecutableSchema({
+      typeDefs: `
+        directive @entity on OBJECT
+
+        type Query {
+          me: User
+        }
+
+        type User {
+          id: ID!
+          friends: [User!]!
+        }
+
+        extend type User @entity
+      `
+    });
+
+    const printedSchemaAlternative = printSchemaWithDirectives(schemaWithDirectives);
+    expect(printedSchemaAlternative).toContain('directive @entity on OBJECT');
+    expect(printedSchemaAlternative).toContain(`type User @entity`);
+  });
+
+  it('Should print with directives even with code-first approach', () => {
+    const schemaTypes = Object.create(null);
+    schemaTypes.Query = new GraphQLObjectType({
+      name: 'Query',
+      fields: () => ({
+        me: { type: schemaTypes.User}
+      }),
+    });
+    schemaTypes.User = new GraphQLObjectType({
+      name: 'User',
+      fields: () => ({
+        id: {
+          type: new GraphQLNonNull(GraphQLID),
+          extensions: {
+            directives: {
+              id: {},
+            },
+          },
+        },
+        friends: {
+          type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(schemaTypes.User))),
+          extensions: {
+            directives: {
+              link: {},
+            },
+          },
+        },
+      }),
+      extensions: {
+        directives: {
+          entity: {},
+        },
+      },
+    });
+
+    const schemaWithDirectives = new GraphQLSchema({
+      query: schemaTypes.Query,
+      directives: specifiedDirectives.concat([
+        new GraphQLDirective({
+          name: 'entity',
+          locations: ['OBJECT'],
+        }),
+        new GraphQLDirective({
+          name: 'id',
+          locations: ['FIELD_DEFINITION'],
+        }),
+        new GraphQLDirective({
+          name: 'link',
+          locations: ['FIELD_DEFINITION'],
+        }),
+      ]),
+    })
 
     const printedSchemaByGraphQL = printSchema(schemaWithDirectives);
     expect(printedSchemaByGraphQL).toContain('directive @entity on OBJECT');


### PR DESCRIPTION
GraphQL directives defined without an astNode should be converted to as astNode/print.

GraphQL directives found in extensions should be converted to astNodes/print. 