### PR TITLE
enhance(utils) filter root field arguments with filterSchema

### DIFF
--- a/.changeset/unlucky-apes-raise.md
+++ b/.changeset/unlucky-apes-raise.md
@@ -1,0 +1,5 @@
+---
+"@graphql-tools/utils": patch
+---
+
+enhance(utils) filter root field arguments with filterSchema

--- a/packages/utils/tests/filterSchema.test.ts
+++ b/packages/utils/tests/filterSchema.test.ts
@@ -18,7 +18,7 @@ describe('filterSchema', () => {
 
     const filtered = filterSchema({
       schema,
-      rootFieldFilter: (opName, fieldName) => fieldName.startsWith('keep'),
+      rootFieldFilter: (_opName, fieldName) => fieldName.startsWith('keep'),
     });
 
     expect(filtered.getType('Query').getFields()['keep']).toBeDefined();
@@ -96,7 +96,7 @@ describe('filterSchema', () => {
 
     const filtered = filterSchema({
       schema,
-      objectFieldFilter: (typeName, fieldName) => fieldName.startsWith('keep'),
+      objectFieldFilter: (_typeName, fieldName) => fieldName.startsWith('keep'),
     });
 
     expect(filtered.getType('Thing').getFields()['keep']).toBeDefined();
@@ -119,7 +119,7 @@ describe('filterSchema', () => {
 
     const filtered = filterSchema({
       schema,
-      interfaceFieldFilter: (typeName, fieldName) => fieldName.startsWith('keep'),
+      interfaceFieldFilter: (_typeName, fieldName) => fieldName.startsWith('keep'),
     });
 
     expect(filtered.getType('IThing').getFields()['keep']).toBeDefined();
@@ -142,7 +142,7 @@ describe('filterSchema', () => {
 
     const filtered = filterSchema({
       schema,
-      inputObjectFieldFilter: (typeName, fieldName) => fieldName.startsWith('keep'),
+      inputObjectFieldFilter: (_typeName, fieldName) => fieldName.startsWith('keep'),
     });
 
     expect(filtered.getType('ThingInput').getFields()['keep']).toBeDefined();
@@ -170,7 +170,7 @@ describe('filterSchema', () => {
 
     const filtered = filterSchema({
       schema,
-      fieldFilter: (typeName, fieldName) => fieldName.startsWith('keep'),
+      fieldFilter: (_typeName, fieldName) => fieldName.startsWith('keep'),
     });
 
     expect(filtered.getType('Thing').getFields()['keep']).toBeDefined();
@@ -184,6 +184,9 @@ describe('filterSchema', () => {
   it('filters all arguments', () => {
     const schema = makeExecutableSchema({
       typeDefs: `
+        type Query {
+          field(keep: String, omit: String): String
+        }
         type Thing implements IThing {
           field(keep: String, omit: String): String
         }
@@ -195,9 +198,10 @@ describe('filterSchema', () => {
 
     const filtered = filterSchema({
       schema,
-      argumentFilter: (typeName, fieldName, argName) => argName.startsWith('keep'),
+      argumentFilter: (_typeName, _fieldName, argName) => argName.startsWith('keep'),
     });
 
+    expect(filtered.getType('Query').getFields()['field'].args.map(arg => arg.name)).toEqual(['keep']);
     expect(filtered.getType('Thing').getFields()['field'].args.map(arg => arg.name)).toEqual(['keep']);
     expect(filtered.getType('IThing').getFields()['field'].args.map(arg => arg.name)).toEqual(['keep']);
   });


### PR DESCRIPTION
Whoops. Forgot to extend argument filtering to root fields in the new v7 implementation of `filterSchema`. This adds argument filtering for root fields.

Why? Because filtering arguments is really handy while reducing an API down to only a select set of features made available to the public.

TODO:

- [ ] If this PR is a new feature, reference an issue where a consensus about the design was reached (not necessary for small changes)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
