### PR TITLE
enhance(stitching-directives): use keyField

### DIFF
--- a/.changeset/proud-cooks-begin.md
+++ b/.changeset/proud-cooks-begin.md
@@ -1,0 +1,9 @@
+---
+'@graphql-tools/stitch': patch
+'@graphql-tools/stitching-directives': patch
+'@graphql-tools/utils': patch
+---
+
+enhance(stitching-directives): use keyField
+
+When using simple keys, i.e. when using the keyField argument to `@merge`, the keyField can be added implicitly to the types's key. In most cases, therefore, `@key` should not be required at all.

--- a/packages/stitch/src/selectionSetArgs.ts
+++ b/packages/stitch/src/selectionSetArgs.ts
@@ -5,7 +5,7 @@ export const forwardArgsToSelectionSet: (
   selectionSet: string,
   mapping?: Record<string, string[]>
 ) => (field: FieldNode) => SelectionSetNode = (selectionSet: string, mapping?: Record<string, string[]>) => {
-  const selectionSetDef = parseSelectionSet(selectionSet);
+  const selectionSetDef = parseSelectionSet(selectionSet, { noLocation: true });
   return (field: FieldNode): SelectionSetNode => {
     const selections = selectionSetDef.selections.map(
       (selectionNode): SelectionNode => {

--- a/packages/stitch/src/stitchingInfo.ts
+++ b/packages/stitch/src/stitchingInfo.ts
@@ -49,7 +49,7 @@ export function createStitchingInfo(
         if (selectionSetsByField[typeName][fieldName] == null) {
           selectionSetsByField[typeName][fieldName] = {
             kind: Kind.SELECTION_SET,
-            selections: [parseSelectionSet('{ __typename }').selections[0]],
+            selections: [parseSelectionSet('{ __typename }', { noLocation: true }).selections[0]],
           };
         }
         selectionSetsByField[typeName][fieldName].selections = selectionSetsByField[typeName][
@@ -63,7 +63,7 @@ export function createStitchingInfo(
         if (selectionSetsByField[typeName][fieldName] == null) {
           selectionSetsByField[typeName][fieldName] = {
             kind: Kind.SELECTION_SET,
-            selections: [parseSelectionSet('{ __typename }').selections[0]],
+            selections: [parseSelectionSet('{ __typename }', { noLocation: true }).selections[0]],
           };
         }
         selectionSetsByField[typeName][fieldName].selections = selectionSetsByField[typeName][
@@ -130,7 +130,7 @@ function createMergedTypes(
           }
 
           if (mergedTypeConfig.selectionSet) {
-            const selectionSet = parseSelectionSet(mergedTypeConfig.selectionSet);
+            const selectionSet = parseSelectionSet(mergedTypeConfig.selectionSet, { noLocation: true });
             selectionSets.set(subschema, selectionSet);
           }
 
@@ -139,7 +139,7 @@ function createMergedTypes(
             Object.keys(mergedTypeConfig.fields).forEach(fieldName => {
               if (mergedTypeConfig.fields[fieldName].selectionSet) {
                 const rawFieldSelectionSet = mergedTypeConfig.fields[fieldName].selectionSet;
-                parsedFieldSelectionSets[fieldName] = parseSelectionSet(rawFieldSelectionSet);
+                parsedFieldSelectionSets[fieldName] = parseSelectionSet(rawFieldSelectionSet, { noLocation: true });
               }
             });
             fieldSelectionSets.set(subschema, parsedFieldSelectionSets);
@@ -150,7 +150,7 @@ function createMergedTypes(
             Object.keys(mergedTypeConfig.computedFields).forEach(fieldName => {
               if (mergedTypeConfig.computedFields[fieldName].selectionSet) {
                 const rawFieldSelectionSet = mergedTypeConfig.computedFields[fieldName].selectionSet;
-                parsedFieldSelectionSets[fieldName] = parseSelectionSet(rawFieldSelectionSet);
+                parsedFieldSelectionSets[fieldName] = parseSelectionSet(rawFieldSelectionSet, { noLocation: true });
               }
             });
             fieldSelectionSets.set(subschema, parsedFieldSelectionSets);
@@ -235,7 +235,7 @@ export function completeStitchingInfo(
   const selectionSetsByType = Object.create(null);
   [schema.getQueryType(), schema.getMutationType].forEach(rootType => {
     if (rootType) {
-      selectionSetsByType[rootType.name] = parseSelectionSet('{ __typename }');
+      selectionSetsByType[rootType.name] = parseSelectionSet('{ __typename }', { noLocation: true });
     }
   });
 
@@ -261,7 +261,7 @@ export function completeStitchingInfo(
 
           dynamicSelectionSetsByField[typeName][fieldName].push(field.selectionSet);
         } else {
-          const selectionSet = parseSelectionSet(field.selectionSet);
+          const selectionSet = parseSelectionSet(field.selectionSet, { noLocation: true });
           if (!(typeName in selectionSetsByField)) {
             selectionSetsByField[typeName] = Object.create(null);
           }

--- a/packages/stitch/tests/typeMergingWithDirectives.test.ts
+++ b/packages/stitch/tests/typeMergingWithDirectives.test.ts
@@ -175,7 +175,9 @@ describe('merging using type merging', () => {
         # EQUIVALENT TO:
         # _productsByUpc(upcs: [String!]!): [Product] @merge(argsExpr: "upcs: [[$key.upc]]")
       }
-      type Product @key(selectionSet: "{ upc }") {
+      # @key is not necessary when using keyField
+      # type Product @key(selectionSet: "{ upc }") {
+      type Product {
         upc: String!
         name: String
         price: Int

--- a/packages/stitch/tests/typeMergingWithExtensions.test.ts
+++ b/packages/stitch/tests/typeMergingWithExtensions.test.ts
@@ -181,13 +181,14 @@ describe('merging using type merging', () => {
       price: { type: GraphQLInt },
       weight: { type: GraphQLInt },
     }),
-    extensions: {
-      directives: {
-        key: {
-          selectionSet: '{ upc }',
-        },
-      },
-    },
+    // key is not necessary when using keyField
+    //extensions: {
+    //  directives: {
+    //    key: {
+    //      selectionSet: '{ upc }',
+    //    },
+    //  },
+    //},
   });
 
   productsSchemaTypes.Query = new GraphQLObjectType({

--- a/packages/stitch/tests/typeMergingWithExtensions.test.ts
+++ b/packages/stitch/tests/typeMergingWithExtensions.test.ts
@@ -182,13 +182,14 @@ describe('merging using type merging', () => {
       weight: { type: GraphQLInt },
     }),
     // key is not necessary when using keyField
-    //extensions: {
-    //  directives: {
-    //    key: {
-    //      selectionSet: '{ upc }',
-    //    },
-    //  },
-    //},
+    //
+    // extensions: {
+    //   directives: {
+    //     key: {
+    //       selectionSet: '{ upc }',
+    //     },
+    //   },
+    // },
   });
 
   productsSchemaTypes.Query = new GraphQLObjectType({

--- a/packages/stitching-directives/src/stitchingDirectivesTransformer.ts
+++ b/packages/stitching-directives/src/stitchingDirectivesTransformer.ts
@@ -10,6 +10,7 @@ import {
   Kind,
   parseValue,
   print,
+  SelectionNode,
   SelectionSetNode,
   valueFromASTUntyped,
 } from 'graphql';
@@ -55,9 +56,9 @@ export function stitchingDirectivesTransformer(
       [MapperKind.OBJECT_TYPE]: type => {
         const directives = getDirectives(schema, type, pathToDirectivesInExtensions);
 
-        if (directives[keyDirectiveName]) {
-          const directiveArgumentMap = directives[keyDirectiveName];
-          const selectionSet = parseSelectionSet(directiveArgumentMap.selectionSet);
+        const keyDirective = directives[keyDirectiveName];
+        if (keyDirective) {
+          const selectionSet = parseSelectionSet(keyDirective.selectionSet, { noLocation: true });
           selectionSetsByType[type.name] = selectionSet;
         }
 
@@ -66,13 +67,31 @@ export function stitchingDirectivesTransformer(
       [MapperKind.OBJECT_FIELD]: (fieldConfig, fieldName, typeName) => {
         const directives = getDirectives(schema, fieldConfig, pathToDirectivesInExtensions);
 
-        if (directives[computedDirectiveName]) {
-          const directiveArgumentMap = directives[computedDirectiveName];
-          const selectionSet = parseSelectionSet(directiveArgumentMap.selectionSet);
+        const computedDirective = directives[computedDirectiveName];
+        if (computedDirective) {
+          const selectionSet = parseSelectionSet(computedDirective.selectionSet, { noLocation: true });
           if (!computedFieldSelectionSets[typeName]) {
             computedFieldSelectionSets[typeName] = Object.create(null);
           }
           computedFieldSelectionSets[typeName][fieldName] = selectionSet;
+        }
+
+        const mergeDirectiveKeyField = directives[mergeDirectiveName]?.keyField;
+        if (mergeDirectiveKeyField) {
+          const selectionSet = parseSelectionSet(`{ ${mergeDirectiveKeyField}}`, { noLocation: true });
+
+          const typeNames: Array<string> = directives[mergeDirectiveName]?.types;
+
+          const returnType = getNamedType(fieldConfig.type);
+
+          forEachConcreteType(schema, returnType, directives[mergeDirectiveName]?.types, typeName => {
+            if (typeNames == null || typeNames.includes(typeName)) {
+              const existingSelectionSet = selectionSetsByType[typeName];
+              selectionSetsByType[typeName] = existingSelectionSet
+                ? mergeSelectionSets(existingSelectionSet, selectionSet)
+                : selectionSet;
+            }
+          });
         }
 
         return undefined;
@@ -82,7 +101,7 @@ export function stitchingDirectivesTransformer(
     if (subschemaConfig.merge) {
       Object.entries(subschemaConfig.merge).forEach(([typeName, mergedTypeConfig]) => {
         if (mergedTypeConfig.selectionSet) {
-          const selectionSet = parseSelectionSet(mergedTypeConfig.selectionSet);
+          const selectionSet = parseSelectionSet(mergedTypeConfig.selectionSet, { noLocation: true });
           if (selectionSet) {
             if (selectionSetsByType[typeName]) {
               selectionSetsByType[typeName] = mergeSelectionSets(selectionSetsByType[typeName], selectionSet);
@@ -93,7 +112,7 @@ export function stitchingDirectivesTransformer(
         }
         if (mergedTypeConfig.computedFields) {
           Object.entries(mergedTypeConfig.computedFields).forEach(([fieldName, computedFieldConfig]) => {
-            const selectionSet = parseSelectionSet(computedFieldConfig.selectionSet);
+            const selectionSet = parseSelectionSet(computedFieldConfig.selectionSet, { noLocation: true });
             if (selectionSet) {
               if (computedFieldSelectionSets[typeName]?.[fieldName]) {
                 computedFieldSelectionSets[typeName][fieldName] = mergeSelectionSets(
@@ -249,6 +268,29 @@ export function stitchingDirectivesTransformer(
   };
 }
 
+function forEachConcreteType(
+  schema: GraphQLSchema,
+  type: GraphQLNamedType,
+  typeNames: Array<string>,
+  fn: (typeName: string) => void
+) {
+  if (isInterfaceType(type)) {
+    getImplementingTypes(type.name, schema).forEach(typeName => {
+      if (typeNames == null || typeNames.includes(typeName)) {
+        fn(typeName);
+      }
+    });
+  } else if (isUnionType(type)) {
+    type.getTypes().forEach(({ name: typeName }) => {
+      if (typeNames == null || typeNames.includes(typeName)) {
+        fn(typeName);
+      }
+    });
+  } else if (isObjectType(type)) {
+    fn(type.name);
+  }
+}
+
 function generateKeyFn(mergedTypeResolverInfo: MergedTypeResolverInfo): (originalResult: any) => any {
   const keyDeclarations: Array<KeyDeclaration> = [].concat(
     ...mergedTypeResolverInfo.expansions.map(expansion => expansion.keyDeclarations)
@@ -320,10 +362,19 @@ function buildKey(key: Array<string>): string {
   return JSON.stringify(mergedObect).replace(/"/g, '');
 }
 
-function mergeSelectionSets(set1: SelectionSetNode, set2: SelectionSetNode): SelectionSetNode {
+function mergeSelectionSets(selectionSet1: SelectionSetNode, selectionSet2: SelectionSetNode): SelectionSetNode {
+  const normalizedSelections: Record<string, SelectionNode> = Object.create(null);
+
+  [selectionSet1, selectionSet2].forEach(set => {
+    set.selections.forEach(selection => {
+      const normalizedSelection = print(selection);
+      normalizedSelections[normalizedSelection] = selection;
+    });
+  });
+
   const newSelectionSet = {
     kind: Kind.SELECTION_SET,
-    selections: set1.selections.concat(set2.selections),
+    selections: Object.values(normalizedSelections),
   };
 
   return newSelectionSet;

--- a/packages/stitching-directives/tests/stitchingDirectivesTransformer.test.ts
+++ b/packages/stitching-directives/tests/stitchingDirectivesTransformer.test.ts
@@ -364,14 +364,14 @@ describe('type merging directives', () => {
     });
   });
 
-  test('adds args function when used with keyField argument', () => {
+  test('adds key and args function when @merge is used with keyField argument', () => {
     const typeDefs = `
       ${allStitchingDirectivesTypeDefs}
       type Query {
         _user(id: ID): User @merge(keyField: "id")
       }
 
-      type User @key(selectionSet: "{ id }") {
+      type User {
         id: ID
         name: String
       }
@@ -384,6 +384,8 @@ describe('type merging directives', () => {
     }
 
     const transformedSubschemaConfig = stitchingDirectivesTransformer(subschemaConfig);
+
+    expect(transformedSubschemaConfig.merge.User.selectionSet).toEqual(`{\n  id\n}`);
 
     const argsFn = transformedSubschemaConfig.merge.User.args;
 

--- a/packages/utils/src/selectionSets.ts
+++ b/packages/utils/src/selectionSets.ts
@@ -1,6 +1,7 @@
 import { OperationDefinitionNode, SelectionSetNode, parse } from 'graphql';
+import { GraphQLParseOptions } from './Interfaces';
 
-export function parseSelectionSet(selectionSet: string): SelectionSetNode {
-  const query = parse(selectionSet).definitions[0] as OperationDefinitionNode;
+export function parseSelectionSet(selectionSet: string, options?: GraphQLParseOptions): SelectionSetNode {
+  const query = parse(selectionSet, options).definitions[0] as OperationDefinitionNode;
   return query.selectionSet;
 }

--- a/website/docs/stitch-directives-sdl.md
+++ b/website/docs/stitch-directives-sdl.md
@@ -47,22 +47,22 @@ In the above example, the Users and Posts schemas will be combined in the stitch
 By default, stitching directives use the following definitions (though the names of these directives [may be customized](#customizing-names)):
 
 ```graphql
-directive @key(selectionSet: String!) on OBJECT
 directive @merge(keyField: String, keyArg: String, additionalArgs: String, key: [String!], argsExpr: String) on FIELD_DEFINITION
+directive @key(selectionSet: String!) on OBJECT
 directive @computed(selectionSet: String!) on FIELD_DEFINITION
 ```
 
 The function of these directives are:
 
-* **`@key`:** specifies a base selection set needed to merge the annotated type across subschemas. Analogous to the `selectionSet` setting specified in [merged type configuration](/docs/stitch-type-merging#basic-example).
-
 * **`@merge`:** denotes a root field used to query a merged type across services. The marked field's name is analogous to the `fieldName` setting in [merged type configuration](/docs/stitch-type-merging#basic-example), while the field's arguments and return types automatically configure merging. Additional arguments may tune the merge behavior (see [example recipes](#recipes)):
 
-  * `keyField`: specifies the name of a field to pick off origin objects as the key value. Omitting this option yields an [object key](#object-keys) that includes all selectionSet fields.
+  * `keyField`: specifies the name of a field to pick off origin objects as the key value. Omitting this option requires specification of an [object key](#object-keys) using the `@key` directive.
   * `keyArg`: specifies which field argument receives the merge key. This may be omitted for fields with only one argument where the key recipient can be inferred.
   * `additionalArgs`: specifies a string of additional keys and values to apply to other arguments, formatted as `""" arg1: "value", arg2: "value" """`.
   * _`key`: advanced use only; builds a custom key._
   * _`argsExpr`: advanced use only; builds a custom args object._
+
+* **`@key`:** specifies a base selection set needed to merge the annotated type across subschemas. Analogous to the `selectionSet` setting specified in [merged type configuration](/docs/stitch-type-merging#basic-example).
 
 * **`@computed`:** specifies a selection of fields required from other services to compute the value of this field. These additional fields are only selected when the computed field is requested. Analogous to [computed field](/docs/stitch-type-merging#computed-fields) in merged type configuration. Computed field dependencies must be sent into the subservice using an [object key](#object-keys).
 
@@ -180,11 +180,11 @@ async function fetchRemoteSchema(executor) {
 The simplest merge pattern picks a key field from origin objects:
 
 ```graphql
-type User @key(selectionSet: "{ id }") {
+type User {
   # ...
 }
 
-type Product @key(selectionSet: "{ upc }") {
+type Product {
   # ...
 }
 
@@ -214,14 +214,14 @@ merge: {
 }
 ```
 
-Here the `@key` directive specifies a base selection set for each merged type, and the `@merge` directive marks each type's merge query&mdash;then `keyField` specifies a field to be picked from each original object as the query argument value.
+Here, the `@merge` directive marks each type's merge query&mdash;then `keyField` specifies a field to be picked from each original object as the query argument value.
 
 ### Multiple arguments
 
 This pattern configures a merge query that receives multiple arguments:
 
 ```graphql
-type User @key(selectionSet: "{ id }") {
+type User {
   # ...
 }
 
@@ -247,7 +247,7 @@ merge: {
 }
 ```
 
-Because the merge field recieves multiple arguments, the `keyArg` parameter is required to specify which argument recieves the key(s). The `additionalArgs` parameter may then be used to provide static values for the other arguments.
+Because the merge field receives multiple arguments, the `keyArg` parameter is required to specify which argument receives the key(s). The `additionalArgs` parameter may then be used to provide static values for the other arguments.
 
 ### Object keys
 

--- a/website/docs/stitch-schema-extensions.md
+++ b/website/docs/stitch-schema-extensions.md
@@ -148,7 +148,7 @@ Post: {
 },
 ```
 
-The `selectionSet` specifies the key field(s) needed from an object to query for its associations. For example, `Post.user` will require that a Post provide its `userId`. Rather than relying on incoming queries to manually request this key for the association, the selection set will automatically be included in subschema requests to guarentee that these fields are fetched. Dynamic selection sets are also possible by providing a function that recieves a GraphQL `FieldNode` (the gateway field) and returns a `SelectionSetNode`.
+The `selectionSet` specifies the key field(s) needed from an object to query for its associations. For example, `Post.user` will require that a Post provide its `userId`. Rather than relying on incoming queries to manually request this key for the association, the selection set will automatically be included in subschema requests to guarentee that these fields are fetched. Dynamic selection sets are also possible by providing a function that receives a GraphQL `FieldNode` (the gateway field) and returns a `SelectionSetNode`.
 
 ### resolve
 


### PR DESCRIPTION
When using simple keys, i.e. when using the keyField argument to `@merge`, the keyField can be added implicitly to the types's key. In most cases, therefore, `@key` should not be required at all.