### PR TITLE
fix(delegate) fix array check

### DIFF
--- a/.changeset/grumpy-suits-scream.md
+++ b/.changeset/grumpy-suits-scream.md
@@ -1,0 +1,5 @@
+---
+"@graphql-tools/delegate": patch
+---
+
+fix(delegate) fix array check

--- a/packages/delegate/src/mergeFields.ts
+++ b/packages/delegate/src/mergeFields.ts
@@ -111,13 +111,12 @@ const buildDelegationPlan = memoize3(function (
     }
 
     nonUniqueSubschemas = nonUniqueSubschemas.filter(s => proxiableSubschemas.includes(s));
-    if (nonUniqueSubschemas == null) {
+    if (!nonUniqueSubschemas.length) {
       unproxiableFieldNodes.push(fieldNode);
       return;
     }
 
-    const subschemas: Array<Subschema> = Array.from(delegationMap.keys());
-    const existingSubschema = nonUniqueSubschemas.find(s => subschemas.includes(s));
+    const existingSubschema = nonUniqueSubschemas.find(s => delegationMap.has(s));
     if (existingSubschema != null) {
       delegationMap.get(existingSubschema).push(fieldNode);
     } else {


### PR DESCRIPTION
@yaacovCR – was reading some delegation code and happened to notice what appears to be a mistake in the query planner logic. Seems like after a `filter`, this:

```js
if (nonUniqueSubschemas == null) { ...
```

Should be this:

```js
if (!nonUniqueSubschemas.length) { ...
```

Also flattened out an `includes` call to check the map directly, which _I think_ should still be compatible with all versions of Node that support `Map`.