### PR TITLE
fix(merge/stitch) consistent enum value merge

### DIFF
--- a/.changeset/eleven-toys-arrive.md
+++ b/.changeset/eleven-toys-arrive.md
@@ -1,0 +1,6 @@
+---
+"@graphql-tools/merge": patch
+"@graphql-tools/stitch": patch
+---
+
+fix(merge/stitch) consistent enum value merge

--- a/packages/merge/src/typedefs-mergers/enum-values.ts
+++ b/packages/merge/src/typedefs-mergers/enum-values.ts
@@ -6,8 +6,13 @@ import { compareNodes } from '@graphql-tools/utils';
 export function mergeEnumValues(
   first: ReadonlyArray<EnumValueDefinitionNode>,
   second: ReadonlyArray<EnumValueDefinitionNode>,
-  config: Config
+  config?: Config
 ): EnumValueDefinitionNode[] {
+  if (config?.consistentEnumMerge) {
+    const reversed: ReadonlyArray<EnumValueDefinitionNode> = first;
+    first = second;
+    second = reversed;
+  }
   const enumValueMap = new Map<string, EnumValueDefinitionNode>();
   for (const firstValue of first) {
     enumValueMap.set(firstValue.name.value, firstValue);

--- a/packages/merge/src/typedefs-mergers/enum.ts
+++ b/packages/merge/src/typedefs-mergers/enum.ts
@@ -18,7 +18,7 @@ export function mergeEnum(
           : 'EnumTypeExtension',
       loc: e1.loc,
       directives: mergeDirectives(e1.directives, e2.directives, config),
-      values: mergeEnumValues(e2.values, e1.values, config),
+      values: mergeEnumValues(e1.values, e2.values, config),
     } as any;
   }
 

--- a/packages/merge/src/typedefs-mergers/merge-typedefs.ts
+++ b/packages/merge/src/typedefs-mergers/merge-typedefs.ts
@@ -57,6 +57,7 @@ export interface Config {
   exclusions?: string[];
   sort?: boolean | CompareFn<string>;
   convertExtensions?: boolean;
+  consistentEnumMerge?: boolean;
 }
 
 /**

--- a/packages/stitch/src/mergeCandidates.ts
+++ b/packages/stitch/src/mergeCandidates.ts
@@ -286,7 +286,11 @@ function mergeEnumTypeCandidates(
   const astNodes = pluck<EnumTypeDefinitionNode>('astNode', candidates);
   const astNode = astNodes
     .slice(1)
-    .reduce((acc, astNode) => mergeEnum(astNode, acc as EnumTypeDefinitionNode) as EnumTypeDefinitionNode, astNodes[0]);
+    .reduce(
+      (acc, astNode) =>
+        mergeEnum(astNode, acc as EnumTypeDefinitionNode, { consistentEnumMerge: true }) as EnumTypeDefinitionNode,
+      astNodes[0]
+    );
 
   const extensionASTNodes = [].concat(pluck<Record<string, any>>('extensionASTNodes', candidates));
 


### PR DESCRIPTION
Follows up the conversation and change made here: https://github.com/ardatan/graphql-tools/pull/2417/files#r554290366

At present in the `merge` package, enum values are merged in the opposite direction from an enum type; so merging enums A and B results in type characteristics of A being prioritized and value characteristics of B being prioritized. This was normalized in https://github.com/ardatan/graphql-tools/pull/2417, but not released for fear of the potential for breaking changes.

This rewrites the normalization to go through an opt-in setting. When `consistentEnumMerge` is enabled, the enum value merger will reverse its arguments for consistency with the type merger. I've specifically chosen to update the value merger function because it is the unit that is implemented backwards from everything else in the merge package.

Ideally, we'll remove this normalization setting in v8 and just make a release note that `mergeEnumValues` argument order has changed to match the rest of the merge methods.

@yaacovCR – seem okay?