### PR TITLE
fix(stitch) canonical via transformed subschema

### DIFF
--- a/.changeset/rich-books-nail.md
+++ b/.changeset/rich-books-nail.md
@@ -1,0 +1,5 @@
+---
+"@graphql-tools/stitch": patch
+---
+
+fix(stitch) canonical via transformed subschema

--- a/packages/stitch/src/mergeCandidates.ts
+++ b/packages/stitch/src/mergeCandidates.ts
@@ -345,7 +345,8 @@ function enumValueConfigMapFromTypeCandidates(
 
 function defaultEnumValueConfigMerger(candidates: Array<MergeEnumValueConfigCandidate>) {
   const preferred = candidates.find(
-    ({ type, subschema }) => isSubschemaConfig(subschema) && subschema.merge?.[type.name]?.canonical
+    ({ type, transformedSubschema }) =>
+      isSubschemaConfig(transformedSubschema) && transformedSubschema.merge?.[type.name]?.canonical
   );
   return (preferred || candidates[candidates.length - 1]).enumValueConfig;
 }
@@ -403,8 +404,8 @@ function orderedTypeCandidates(
 }
 
 function defaultTypeCandidateMerger(candidates: Array<MergeTypeCandidate>): MergeTypeCandidate {
-  const canonical: Array<MergeTypeCandidate> = candidates.filter(({ type, subschema }) =>
-    isSubschemaConfig(subschema) ? subschema.merge?.[type.name]?.canonical : false
+  const canonical: Array<MergeTypeCandidate> = candidates.filter(({ type, transformedSubschema }) =>
+    isSubschemaConfig(transformedSubschema) ? transformedSubschema.merge?.[type.name]?.canonical : false
   );
 
   if (canonical.length > 1) {
@@ -468,11 +469,11 @@ function defaultFieldConfigMerger(candidates: Array<MergeFieldConfigCandidate>) 
   const canonicalByField: Array<GraphQLFieldConfig<any, any>> = [];
   const canonicalByType: Array<GraphQLFieldConfig<any, any>> = [];
 
-  candidates.forEach(({ type, fieldName, fieldConfig, subschema }) => {
-    if (!isSubschemaConfig(subschema)) return;
-    if (subschema.merge?.[type.name]?.fields?.[fieldName]?.canonical) {
+  candidates.forEach(({ type, fieldName, fieldConfig, transformedSubschema }) => {
+    if (!isSubschemaConfig(transformedSubschema)) return;
+    if (transformedSubschema.merge?.[type.name]?.fields?.[fieldName]?.canonical) {
       canonicalByField.push(fieldConfig);
-    } else if (subschema.merge?.[type.name]?.canonical) {
+    } else if (transformedSubschema.merge?.[type.name]?.canonical) {
       canonicalByType.push(fieldConfig);
     }
   });
@@ -527,11 +528,11 @@ function defaultInputFieldConfigMerger(candidates: Array<MergeInputFieldConfigCa
   const canonicalByField: Array<GraphQLInputFieldConfig> = [];
   const canonicalByType: Array<GraphQLInputFieldConfig> = [];
 
-  candidates.forEach(({ type, fieldName, inputFieldConfig, subschema }) => {
-    if (!isSubschemaConfig(subschema)) return;
-    if (subschema.merge?.[type.name]?.fields?.[fieldName]?.canonical) {
+  candidates.forEach(({ type, fieldName, inputFieldConfig, transformedSubschema }) => {
+    if (!isSubschemaConfig(transformedSubschema)) return;
+    if (transformedSubschema.merge?.[type.name]?.fields?.[fieldName]?.canonical) {
       canonicalByField.push(inputFieldConfig);
-    } else if (subschema.merge?.[type.name]?.canonical) {
+    } else if (transformedSubschema.merge?.[type.name]?.canonical) {
       canonicalByType.push(inputFieldConfig);
     }
   });
@@ -550,9 +551,13 @@ function defaultInputFieldConfigMerger(candidates: Array<MergeInputFieldConfigCa
 function canonicalFieldNamesForType(candidates: Array<MergeTypeCandidate>): Array<string> {
   const canonicalFieldNames: Record<string, boolean> = Object.create(null);
 
-  candidates.forEach(({ type, subschema }) => {
-    if (isSubschemaConfig(subschema) && subschema.merge?.[type.name]?.fields && !subschema.merge[type.name].canonical) {
-      Object.entries(subschema.merge[type.name].fields).forEach(([fieldName, mergedFieldConfig]) => {
+  candidates.forEach(({ type, transformedSubschema }) => {
+    if (
+      isSubschemaConfig(transformedSubschema) &&
+      transformedSubschema.merge?.[type.name]?.fields &&
+      !transformedSubschema.merge[type.name].canonical
+    ) {
+      Object.entries(transformedSubschema.merge[type.name].fields).forEach(([fieldName, mergedFieldConfig]) => {
         if (mergedFieldConfig.canonical) {
           canonicalFieldNames[fieldName] = true;
         }


### PR DESCRIPTION
In a slightly ridiculous oversight, I wrote tests for `canonical` stitching code and directives code, but never stitching + directives code together. Go figure, I missed a critical piece of linkage in referencing `transformedSubschema` rather than `subschema`.

This fixes subschema references so that directives now affect canonical outcomes properly.