### PR TITLE
[deploy_website] fix(stitch) cleanup computed field splitting

### DIFF
--- a/.changeset/fast-lizards-try.md
+++ b/.changeset/fast-lizards-try.md
@@ -1,5 +1,7 @@
 ---
+"@graphql-tools/delegate": patch
 "@graphql-tools/stitch": patch
+"@graphql-tools/stitching-directives": patch
 ---
 
 fix(stitch) cleanup computed field splitting

--- a/.changeset/fast-lizards-try.md
+++ b/.changeset/fast-lizards-try.md
@@ -19,4 +19,4 @@ merge: {
 }
 ```
 
-A field-level `selectionSet` specifies field dependencies while the `computed` setting structures the field in a way that assures it is always selected with this data provided. The `selectionSet` is intentionally generic to support possible future uses. This new pattern organizes all field-level configuration into a single structure.
+A field-level `selectionSet` specifies field dependencies while the `computed` setting structures the field in a way that assures it is always selected with this data provided. The `selectionSet` is intentionally generic to support possible future uses. This new pattern organizes all field-level configuration (including `canonical`) into a single structure.

--- a/.changeset/fast-lizards-try.md
+++ b/.changeset/fast-lizards-try.md
@@ -1,7 +1,22 @@
 ---
 "@graphql-tools/delegate": patch
-"@graphql-tools/stitch": patch
-"@graphql-tools/stitching-directives": patch
+"@graphql-tools/stitch": minor
+"@graphql-tools/stitching-directives": minor
 ---
 
-fix(stitch) cleanup computed field splitting
+Deprecates the `MergeTypeConfig.computedFields` setting (with backwards-compatible warning) in favor of new computed field configuration written as:
+
+```js
+merge: {
+  MyType: {
+    fields: {
+      myComputedField: {
+        selectionSet: '{ weight }',
+        computed: true,
+      }
+    }
+  }
+}
+```
+
+A field-level `selectionSet` specifies field dependencies while the `computed` setting structures the field in a way that assures it is always selected with this data provided. The `selectionSet` is intentionally generic to support possible future uses. This new pattern organizes all field-level configuration into a single structure.

--- a/.changeset/fast-lizards-try.md
+++ b/.changeset/fast-lizards-try.md
@@ -1,0 +1,5 @@
+---
+"@graphql-tools/stitch": patch
+---
+
+fix(stitch) cleanup computed field splitting

--- a/packages/batch-delegate/tests/typeMerging.example.test.ts
+++ b/packages/batch-delegate/tests/typeMerging.example.test.ts
@@ -235,9 +235,10 @@ describe('merging using type merging', () => {
         merge: {
           Product: {
             selectionSet: '{ upc }',
-            computedFields: {
+            fields: {
               shippingEstimate: {
                 selectionSet: '{ price weight }',
+                computed: true,
               },
             },
             fieldName: '_products',

--- a/packages/delegate/src/subschemaConfig.ts
+++ b/packages/delegate/src/subschemaConfig.ts
@@ -21,13 +21,6 @@ export function cloneSubschemaConfig(subschemaConfig: SubschemaConfig): Subschem
           fields[fieldName] = { ...fields[fieldName] };
         });
       }
-
-      const computedFields = newSubschemaConfig.merge[typeName].computedFields;
-      if (computedFields != null) {
-        Object.keys(computedFields).forEach(fieldName => {
-          computedFields[fieldName] = { ...computedFields[fieldName] };
-        });
-      }
     });
   }
 

--- a/packages/delegate/src/types.ts
+++ b/packages/delegate/src/types.ts
@@ -172,7 +172,7 @@ export interface SubschemaConfig<K = any, V = any, C = K> {
 
 export interface MergedTypeConfig<K = any, V = any> extends MergedTypeResolverOptions<K, V> {
   selectionSet?: string;
-  fields?: Record<string, { selectionSet?: string; canonical?: boolean }>;
+  fields?: Record<string, MergedFieldConfig>;
   computedFields?: Record<string, { selectionSet?: string }>;
   key?: (originalResult: any) => K;
   canonical?: boolean;
@@ -188,6 +188,8 @@ export interface MergedTypeResolverOptions<K = any, V = any> {
 
 export interface MergedFieldConfig {
   selectionSet?: string;
+  computed?: boolean;
+  canonical?: boolean;
 }
 
 export type MergedTypeResolver = (

--- a/packages/stitch/src/isolateComputedFields.ts
+++ b/packages/stitch/src/isolateComputedFields.ts
@@ -24,6 +24,8 @@ export function isolateComputedFields(subschemaConfig: SubschemaConfig): Array<S
       Object.entries(mergedTypeConfig.fields).forEach(([fieldName, mergedFieldConfig]) => {
         if (mergedFieldConfig.computed && mergedFieldConfig.selectionSet) {
           isolatedFields[fieldName] = mergedFieldConfig;
+        } else if (mergedFieldConfig.computed) {
+          throw new Error(`A selectionSet is required for computed field "${typeName}.${fieldName}"`);
         } else {
           baseFields[fieldName] = { ...mergedFieldConfig, computed: false };
         }

--- a/packages/stitch/src/isolateComputedFields.ts
+++ b/packages/stitch/src/isolateComputedFields.ts
@@ -7,32 +7,25 @@ import { getImplementingTypes, pruneSchema, filterSchema } from '@graphql-tools/
 import { TransformCompositeFields } from '@graphql-tools/wrap';
 
 export function isolateComputedFields(subschemaConfig: SubschemaConfig): Array<SubschemaConfig> {
-  const baseSchemaTypes: Record<string, MergedTypeConfig> = {};
-  const isolatedSchemaTypes: Record<string, MergedTypeConfig> = {};
-
   if (subschemaConfig.merge == null) {
     return [subschemaConfig];
   }
 
-  Object.keys(subschemaConfig.merge).forEach((typeName: string) => {
-    const mergedTypeConfig: MergedTypeConfig = subschemaConfig.merge[typeName];
+  const baseSchemaTypes: Record<string, MergedTypeConfig> = Object.create(null);
+  const isolatedSchemaTypes: Record<string, MergedTypeConfig> = Object.create(null);
+
+  Object.entries(subschemaConfig.merge).forEach(([typeName, mergedTypeConfig]) => {
     baseSchemaTypes[typeName] = mergedTypeConfig;
 
-    if (mergedTypeConfig.computedFields) {
-      const baseFields: Record<string, MergedFieldConfig> = { ...(mergedTypeConfig?.fields || {}) };
-      const isolatedFields: Record<string, MergedFieldConfig> = {};
+    if (mergedTypeConfig.fields) {
+      const baseFields: Record<string, MergedFieldConfig> = Object.create(null);
+      const isolatedFields: Record<string, MergedFieldConfig> = Object.create(null);
 
-      Object.keys(mergedTypeConfig.computedFields).forEach((fieldName: string) => {
-        const mergedFieldConfig = mergedTypeConfig.computedFields[fieldName];
-        const fieldCollection = mergedFieldConfig.selectionSet ? isolatedFields : baseFields;
-
-        fieldCollection[fieldName] = {
-          ...(mergedTypeConfig?.fields?.[fieldName] || {}),
-          ...mergedFieldConfig,
-        };
-
-        if (fieldCollection === isolatedFields && baseFields[fieldName]) {
-          delete baseFields[fieldName];
+      Object.entries(mergedTypeConfig.fields).forEach(([fieldName, mergedFieldConfig]) => {
+        if (mergedFieldConfig.computed && mergedFieldConfig.selectionSet) {
+          isolatedFields[fieldName] = mergedFieldConfig;
+        } else {
+          baseFields[fieldName] = { ...mergedFieldConfig, computed: false };
         }
       });
 
@@ -42,8 +35,7 @@ export function isolateComputedFields(subschemaConfig: SubschemaConfig): Array<S
       if (isolatedFieldCount && isolatedFieldCount !== Object.keys(objectType.getFields()).length) {
         baseSchemaTypes[typeName] = {
           ...mergedTypeConfig,
-          fields: Object.keys(baseFields).length ? baseFields : undefined,
-          computedFields: undefined,
+          fields: baseFields,
         };
         isolatedSchemaTypes[typeName] = {
           ...mergedTypeConfig,

--- a/packages/stitch/src/isolateComputedFields.ts
+++ b/packages/stitch/src/isolateComputedFields.ts
@@ -17,6 +17,21 @@ export function isolateComputedFields(subschemaConfig: SubschemaConfig): Array<S
   Object.entries(subschemaConfig.merge).forEach(([typeName, mergedTypeConfig]) => {
     baseSchemaTypes[typeName] = mergedTypeConfig;
 
+    if (mergedTypeConfig.computedFields) {
+      mergedTypeConfig.fields = mergedTypeConfig.fields ?? Object.create(null);
+      Object.entries(mergedTypeConfig.computedFields).forEach(([fieldName, mergedFieldConfig]) => {
+        console.warn(
+          `The "computedFields" setting is deprecated. Update your @graphql-tools/stitching-directives package, and/or update static merged type config to "${typeName}.fields.${fieldName} = { selectionSet: '${mergedFieldConfig.selectionSet}', computed: true }"`
+        );
+        mergedTypeConfig.fields[fieldName] = {
+          ...(mergedTypeConfig.fields[fieldName] ?? {}),
+          ...mergedFieldConfig,
+          computed: true,
+        };
+      });
+      delete mergedTypeConfig.computedFields;
+    }
+
     if (mergedTypeConfig.fields) {
       const baseFields: Record<string, MergedFieldConfig> = Object.create(null);
       const isolatedFields: Record<string, MergedFieldConfig> = Object.create(null);

--- a/packages/stitch/src/isolateComputedFields.ts
+++ b/packages/stitch/src/isolateComputedFields.ts
@@ -27,7 +27,7 @@ export function isolateComputedFields(subschemaConfig: SubschemaConfig): Array<S
         } else if (mergedFieldConfig.computed) {
           throw new Error(`A selectionSet is required for computed field "${typeName}.${fieldName}"`);
         } else {
-          baseFields[fieldName] = { ...mergedFieldConfig, computed: false };
+          baseFields[fieldName] = mergedFieldConfig;
         }
       });
 

--- a/packages/stitch/src/stitchingInfo.ts
+++ b/packages/stitch/src/stitchingInfo.ts
@@ -134,22 +134,6 @@ function createMergedTypes(
             selectionSets.set(subschema, selectionSet);
           }
 
-          if (mergedTypeConfig.computedFields) {
-            mergedTypeConfig.fields = mergedTypeConfig.fields ?? Object.create(null);
-            Object.keys(mergedTypeConfig.computedFields).forEach(fieldName => {
-              const fieldConfig = mergedTypeConfig.computedFields[fieldName];
-              console.warn(
-                `MergedTypeConfig.computedFields is deprecated. Use MergedTypeConfig.fields.${fieldName} = { selectionSet: '${fieldConfig.selectionSet}', computed: true }\nIf using @graphql-tools/stitching-directives, update the package.`
-              );
-              mergedTypeConfig.fields[fieldName] = {
-                ...(mergedTypeConfig.fields[fieldName] ?? {}),
-                ...fieldConfig,
-                computed: true,
-              };
-            });
-            delete mergedTypeConfig.computedFields;
-          }
-
           if (mergedTypeConfig.fields) {
             const parsedFieldSelectionSets = Object.create(null);
             Object.keys(mergedTypeConfig.fields).forEach(fieldName => {

--- a/packages/stitch/src/stitchingInfo.ts
+++ b/packages/stitch/src/stitchingInfo.ts
@@ -134,22 +134,27 @@ function createMergedTypes(
             selectionSets.set(subschema, selectionSet);
           }
 
+          if (mergedTypeConfig.computedFields) {
+            mergedTypeConfig.fields = mergedTypeConfig.fields ?? Object.create(null);
+            Object.keys(mergedTypeConfig.computedFields).forEach(fieldName => {
+              const fieldConfig = mergedTypeConfig.computedFields[fieldName];
+              console.warn(
+                `MergedTypeConfig.computedFields is deprecated. Use MergedTypeConfig.fields.${fieldName} = { selectionSet: '${fieldConfig.selectionSet}', computed: true }`
+              );
+              mergedTypeConfig.fields[fieldName] = {
+                ...(mergedTypeConfig.fields[fieldName] ?? {}),
+                ...fieldConfig,
+                computed: true,
+              };
+            });
+            delete mergedTypeConfig.computedFields;
+          }
+
           if (mergedTypeConfig.fields) {
             const parsedFieldSelectionSets = Object.create(null);
             Object.keys(mergedTypeConfig.fields).forEach(fieldName => {
               if (mergedTypeConfig.fields[fieldName].selectionSet) {
                 const rawFieldSelectionSet = mergedTypeConfig.fields[fieldName].selectionSet;
-                parsedFieldSelectionSets[fieldName] = parseSelectionSet(rawFieldSelectionSet, { noLocation: true });
-              }
-            });
-            fieldSelectionSets.set(subschema, parsedFieldSelectionSets);
-          }
-
-          if (mergedTypeConfig.computedFields) {
-            const parsedFieldSelectionSets = Object.create(null);
-            Object.keys(mergedTypeConfig.computedFields).forEach(fieldName => {
-              if (mergedTypeConfig.computedFields[fieldName].selectionSet) {
-                const rawFieldSelectionSet = mergedTypeConfig.computedFields[fieldName].selectionSet;
                 parsedFieldSelectionSets[fieldName] = parseSelectionSet(rawFieldSelectionSet, { noLocation: true });
               }
             });

--- a/packages/stitch/src/stitchingInfo.ts
+++ b/packages/stitch/src/stitchingInfo.ts
@@ -139,7 +139,7 @@ function createMergedTypes(
             Object.keys(mergedTypeConfig.computedFields).forEach(fieldName => {
               const fieldConfig = mergedTypeConfig.computedFields[fieldName];
               console.warn(
-                `MergedTypeConfig.computedFields is deprecated. Use MergedTypeConfig.fields.${fieldName} = { selectionSet: '${fieldConfig.selectionSet}', computed: true }`
+                `MergedTypeConfig.computedFields is deprecated. Use MergedTypeConfig.fields.${fieldName} = { selectionSet: '${fieldConfig.selectionSet}', computed: true }\nIf using @graphql-tools/stitching-directives, update the package.`
               );
               mergedTypeConfig.fields[fieldName] = {
                 ...(mergedTypeConfig.fields[fieldName] ?? {}),

--- a/packages/stitch/src/subschemaConfigTransforms/computedDirectiveTransformer.ts
+++ b/packages/stitch/src/subschemaConfigTransforms/computedDirectiveTransformer.ts
@@ -27,11 +27,12 @@ export function computedDirectiveTransformer(computedDirectiveName: string): Sub
           return undefined;
         }
 
-        mergeTypeConfig.computedFields = mergeTypeConfig.computedFields ?? {};
-        mergeTypeConfig.computedFields[fieldName] = mergeTypeConfig.computedFields[fieldName] ?? {};
+        mergeTypeConfig.fields = mergeTypeConfig.fields ?? {};
+        mergeTypeConfig.fields[fieldName] = mergeTypeConfig.fields[fieldName] ?? {};
 
-        const mergeFieldConfig = mergeTypeConfig.computedFields[fieldName];
+        const mergeFieldConfig = mergeTypeConfig.fields[fieldName];
         mergeFieldConfig.selectionSet = mergeFieldConfig.selectionSet ?? selectionSet;
+        mergeFieldConfig.computed = true;
 
         return undefined;
       },

--- a/packages/stitch/tests/isolateComputedFields.test.ts
+++ b/packages/stitch/tests/isolateComputedFields.test.ts
@@ -75,7 +75,7 @@ describe('isolateComputedFields', () => {
 
       expect(baseSubschema.merge.Product.canonical).toEqual(true);
       expect(baseSubschema.merge.Product.fields).toEqual({
-        deliveryService: { computed: false, canonical: true },
+        deliveryService: { canonical: true },
       });
 
       expect(computedSubschema.merge.Product.canonical).toBeUndefined();

--- a/packages/stitch/tests/isolateComputedFields.test.ts
+++ b/packages/stitch/tests/isolateComputedFields.test.ts
@@ -39,11 +39,14 @@ describe('isolateComputedFields', () => {
           Product: {
             selectionSet: '{ id weight }',
             fields: {
-              shippingEstimate: { canonical: true },
-              deliveryService: { canonical: true },
-            },
-            computedFields: {
-              shippingEstimate: { selectionSet: '{ price }' },
+              shippingEstimate: {
+                selectionSet: '{ price }',
+                computed: true,
+                canonical: true,
+              },
+              deliveryService: {
+                canonical: true,
+              },
             },
             fieldName: '_products',
             key: ({ id, price, weight }) => ({ id, price, weight }),
@@ -72,12 +75,12 @@ describe('isolateComputedFields', () => {
 
       expect(baseSubschema.merge.Product.canonical).toEqual(true);
       expect(baseSubschema.merge.Product.fields).toEqual({
-        deliveryService: { canonical: true },
+        deliveryService: { computed: false, canonical: true },
       });
 
       expect(computedSubschema.merge.Product.canonical).toBeUndefined();
       expect(computedSubschema.merge.Product.fields).toEqual({
-        shippingEstimate: { selectionSet: '{ price }', canonical: true },
+        shippingEstimate: { selectionSet: '{ price }', computed: true, canonical: true },
       });
     });
 
@@ -117,9 +120,15 @@ describe('isolateComputedFields', () => {
         merge: {
           Product: {
             selectionSet: '{ id }',
-            computedFields: {
-              computedOne: { selectionSet: '{ price weight }' },
-              computedTwo: { selectionSet: '{ weight }' },
+            fields: {
+              computedOne: {
+                selectionSet: '{ price weight }',
+                computed: true,
+              },
+              computedTwo: {
+                selectionSet: '{ weight }',
+                computed: true,
+              },
             },
             fieldName: '_products',
             key: ({ id, price, weight }) => ({ id, price, weight }),
@@ -137,11 +146,11 @@ describe('isolateComputedFields', () => {
       typeDefs: `
         type Product {
           base: String!
-          computed: String!
+          computeMe: String!
         }
         type Storefront {
           base: ID!
-          computed: [Product]!
+          computeMe: [Product]!
         }
         type Query {
           storefront(id: ID!): Storefront
@@ -156,16 +165,22 @@ describe('isolateComputedFields', () => {
         merge: {
           Storefront: {
             selectionSet: '{ id }',
-            computedFields: {
-              computed: { selectionSet: '{ availableProductIds }' },
+            fields: {
+              computeMe: {
+                selectionSet: '{ availableProductIds }',
+                computed: true,
+              },
             },
             fieldName: 'storefront',
             args: ({ id }) => ({ id }),
           },
           Product: {
             selectionSet: '{ id weight }',
-            computedFields: {
-              computed: { selectionSet: '{ price }' },
+            fields: {
+              computeMe: {
+                selectionSet: '{ price }',
+                computed: true,
+              },
             },
             fieldName: '_products',
             key: ({ id, price, weight }) => ({ id, price, weight }),
@@ -180,16 +195,16 @@ describe('isolateComputedFields', () => {
       expect(Object.keys((baseSubschema.transformedSchema.getType('Query') as GraphQLObjectType).getFields())).toEqual(['storefront', '_products']);
       expect(Object.keys((baseSubschema.transformedSchema.getType('Product') as GraphQLObjectType).getFields())).toEqual(['base']);
       expect(Object.keys((baseSubschema.transformedSchema.getType('Storefront') as GraphQLObjectType).getFields())).toEqual(['base']);
-      expect(baseSubschema.merge.Storefront.fields).toBeUndefined();
+      expect(baseSubschema.merge.Storefront.fields).toEqual({});
 
       expect(Object.keys((computedSubschema.transformedSchema.getType('Query') as GraphQLObjectType).getFields())).toEqual(['storefront', '_products']);
-      expect(Object.keys((computedSubschema.transformedSchema.getType('Product') as GraphQLObjectType).getFields())).toEqual(['computed']);
-      expect(Object.keys((computedSubschema.transformedSchema.getType('Storefront') as GraphQLObjectType).getFields())).toEqual(['computed']);
+      expect(Object.keys((computedSubschema.transformedSchema.getType('Product') as GraphQLObjectType).getFields())).toEqual(['computeMe']);
+      expect(Object.keys((computedSubschema.transformedSchema.getType('Storefront') as GraphQLObjectType).getFields())).toEqual(['computeMe']);
       expect(computedSubschema.merge.Storefront.fields).toEqual({
-        computed: { selectionSet: '{ availableProductIds }' },
+        computeMe: { selectionSet: '{ availableProductIds }', computed: true },
       });
       expect(computedSubschema.merge.Product.fields).toEqual({
-        computed: { selectionSet: '{ price }' },
+        computeMe: { selectionSet: '{ price }', computed: true },
       });
     });
   });
@@ -200,11 +215,11 @@ describe('isolateComputedFields', () => {
         typeDefs: `
           interface IProduct {
             base: String!
-            computed: String!
+            computeMe: String!
           }
           type Product implements IProduct {
             base: String!
-            computed: String!
+            computeMe: String!
           }
           type Query {
             _products(representations: [ID!]!): [Product]!
@@ -217,8 +232,11 @@ describe('isolateComputedFields', () => {
         merge: {
           Product: {
             selectionSet: '{ id }',
-            computedFields: {
-              computed: { selectionSet: '{ price weight }' }
+            fields: {
+              computeMe: {
+                selectionSet: '{ price weight }',
+                computed: true,
+              }
             },
             fieldName: '_products',
             key: ({ id, price, weight }) => ({ id, price, weight }),
@@ -232,8 +250,8 @@ describe('isolateComputedFields', () => {
 
       expect(Object.keys((baseSubschema.transformedSchema.getType('IProduct') as GraphQLInterfaceType).getFields())).toEqual(['base']);
       expect(Object.keys((baseSubschema.transformedSchema.getType('Product') as GraphQLObjectType).getFields())).toEqual(['base']);
-      expect(Object.keys((computedSubschema.transformedSchema.getType('IProduct') as GraphQLInterfaceType).getFields())).toEqual(['computed']);
-      expect(Object.keys((computedSubschema.transformedSchema.getType('Product') as GraphQLObjectType).getFields())).toEqual(['computed']);
+      expect(Object.keys((computedSubschema.transformedSchema.getType('IProduct') as GraphQLInterfaceType).getFields())).toEqual(['computeMe']);
+      expect(Object.keys((computedSubschema.transformedSchema.getType('Product') as GraphQLObjectType).getFields())).toEqual(['computeMe']);
     });
   });
 });

--- a/packages/stitch/tests/mergeComputedFields.test.ts
+++ b/packages/stitch/tests/mergeComputedFields.test.ts
@@ -144,7 +144,7 @@ describe('merge computed fields via config', () => {
   });
 
   it('supports deprecated computedFields setting (remove in major version)', async () => {
-    const legacySchema = stitchSchemas({
+    const oldComputedSchema = stitchSchemas({
       subschemas: [
         {
           schema: productSchema,
@@ -162,7 +162,6 @@ describe('merge computed fields via config', () => {
             Product: {
               selectionSet: '{ id }',
               computedFields: {
-                shippingEstimate: { selectionSet: '{ price weight }' },
                 deliveryService: { selectionSet: '{ weight }' },
               },
               fieldName: '_products',
@@ -174,13 +173,12 @@ describe('merge computed fields via config', () => {
       ],
     });
 
-    const { data } = await graphql(legacySchema, `
+    const { data } = await graphql(oldComputedSchema, `
       query {
         product(id: 77) {
           id
           price
           weight
-          shippingEstimate
           deliveryService
         }
       }
@@ -190,7 +188,6 @@ describe('merge computed fields via config', () => {
       id: '77',
       price: 77.99,
       weight: 77,
-      shippingEstimate: 0,
       deliveryService: 'FREIGHT'
     });
   });

--- a/packages/stitch/tests/mergeComputedFields.test.ts
+++ b/packages/stitch/tests/mergeComputedFields.test.ts
@@ -16,7 +16,7 @@ const productSchema = makeExecutableSchema({
   `,
   resolvers: {
     Query: {
-      product: (root, { id }) => ({ id, price: Number(id) + 0.99, weight: Number(id) }),
+      product: (_root, { id }) => ({ id, price: Number(id) + 0.99, weight: Number(id) }),
     }
   }
 });
@@ -49,8 +49,8 @@ describe('merge computed fields via config', () => {
     `,
     resolvers: {
       Query: {
-        storefront: (root, { id }) => ({ id, availableProducts: [{ id: '23' }] }),
-        _products: (root, { representations }) => representations,
+        storefront: (_root, { id }) => ({ id, availableProducts: [{ id: '23' }] }),
+        _products: (_root, { representations }) => representations,
       },
       Product: {
         shippingEstimate: (obj) => obj.price != null && obj.weight != null ? (obj.price > 50 ? 0 : obj.weight / 2) : null,
@@ -76,9 +76,15 @@ describe('merge computed fields via config', () => {
         merge: {
           Product: {
             selectionSet: '{ id }',
-            computedFields: {
-              shippingEstimate: { selectionSet: '{ price weight }' },
-              deliveryService: { selectionSet: '{ weight }' },
+            fields: {
+              shippingEstimate: {
+                selectionSet: '{ price weight }',
+                computed: true,
+              },
+              deliveryService: {
+                selectionSet: '{ weight }',
+                computed: true,
+              },
             },
             fieldName: '_products',
             key: ({ id, price, weight }) => ({ id, price, weight }),
@@ -136,6 +142,58 @@ describe('merge computed fields via config', () => {
       }
     ]);
   });
+
+  it('supports deprecated computedFields setting (remove in major version)', async () => {
+    const legacySchema = stitchSchemas({
+      subschemas: [
+        {
+          schema: productSchema,
+          merge: {
+            Product: {
+              selectionSet: '{ id }',
+              fieldName: 'product',
+              args: ({ id }) => ({ id }),
+            }
+          }
+        },
+        {
+          schema: storefrontSchema,
+          merge: {
+            Product: {
+              selectionSet: '{ id }',
+              computedFields: {
+                shippingEstimate: { selectionSet: '{ price weight }' },
+                deliveryService: { selectionSet: '{ weight }' },
+              },
+              fieldName: '_products',
+              key: ({ id, price, weight }) => ({ id, price, weight }),
+              argsFromKeys: (representations) => ({ representations }),
+            }
+          }
+        }
+      ],
+    });
+
+    const { data } = await graphql(legacySchema, `
+      query {
+        product(id: 77) {
+          id
+          price
+          weight
+          shippingEstimate
+          deliveryService
+        }
+      }
+    `);
+
+    expect(data.product).toEqual({
+      id: '77',
+      price: 77.99,
+      weight: 77,
+      shippingEstimate: 0,
+      deliveryService: 'FREIGHT'
+    });
+  });
 });
 
 describe('merge computed fields via SDL (Apollo Federation-style directive annotation)', () => {
@@ -165,8 +223,8 @@ describe('merge computed fields via SDL (Apollo Federation-style directive annot
     `,
     resolvers: {
       Query: {
-        storefront: (root, { id }) => ({ id, availableProducts: [{ id: '23' }] }),
-        _entities: (root, { representations }) => representations,
+        storefront: (_root, { id }) => ({ id, availableProducts: [{ id: '23' }] }),
+        _entities: (_root, { representations }) => representations,
       },
       Product: {
         shippingEstimate: (obj) => obj.price != null && obj.weight != null ? (obj.price > 50 ? 0 : obj.weight / 2) : null,

--- a/packages/stitching-directives/src/stitchingDirectivesTransformer.ts
+++ b/packages/stitching-directives/src/stitchingDirectivesTransformer.ts
@@ -200,9 +200,11 @@ export function stitchingDirectivesTransformer(
             }
           }
         }
-        if (mergedTypeConfig.computedFields) {
-          Object.entries(mergedTypeConfig.computedFields).forEach(([fieldName, computedFieldConfig]) => {
-            const selectionSet = parseSelectionSet(computedFieldConfig.selectionSet, { noLocation: true });
+        if (mergedTypeConfig.fields) {
+          Object.entries(mergedTypeConfig.fields).forEach(([fieldName, fieldConfig]) => {
+            if (!fieldConfig.selectionSet) return;
+
+            const selectionSet = parseSelectionSet(fieldConfig.selectionSet, { noLocation: true });
             if (selectionSet) {
               if (computedFieldSelectionSets[typeName]?.[fieldName]) {
                 computedFieldSelectionSets[typeName][fieldName] = mergeSelectionSets(
@@ -320,16 +322,17 @@ export function stitchingDirectivesTransformer(
 
       const mergeTypeConfig = newSubschemaConfig.merge[typeName];
 
-      if (mergeTypeConfig.computedFields == null) {
-        mergeTypeConfig.computedFields = Object.create(null);
+      if (mergeTypeConfig.fields == null) {
+        mergeTypeConfig.fields = Object.create(null);
       }
 
       Object.entries(selectionSets).forEach(([fieldName, selectionSet]) => {
-        if (mergeTypeConfig.computedFields[fieldName] == null) {
-          mergeTypeConfig.computedFields[fieldName] = Object.create(null);
+        if (mergeTypeConfig.fields[fieldName] == null) {
+          mergeTypeConfig.fields[fieldName] = Object.create(null);
         }
 
-        mergeTypeConfig.computedFields[fieldName].selectionSet = print(selectionSet);
+        mergeTypeConfig.fields[fieldName].selectionSet = print(selectionSet);
+        mergeTypeConfig.fields[fieldName].computed = true;
       });
     });
 

--- a/packages/stitching-directives/tests/stitchingDirectivesTransformer.test.ts
+++ b/packages/stitching-directives/tests/stitchingDirectivesTransformer.test.ts
@@ -118,7 +118,8 @@ describe('type merging directives', () => {
 
     const transformedSubschemaConfig = stitchingDirectivesTransformer(subschemaConfig);
 
-    expect(transformedSubschemaConfig.merge.User.computedFields.name.selectionSet).toEqual(print(parseSelectionSet('{ id }')));
+    expect(transformedSubschemaConfig.merge.User.fields.name.selectionSet).toEqual(print(parseSelectionSet('{ id }')));
+    expect(transformedSubschemaConfig.merge.User.fields.name.computed).toEqual(true);
     expect(transformedSubschemaConfig.merge.User.fieldName).toEqual('_user');
   });
 

--- a/website/docs/stitch-type-merging.md
+++ b/website/docs/stitch-type-merging.md
@@ -458,9 +458,15 @@ The `@computed` SDL directive is a convenience syntax for static configuration t
   merge: {
     Product: {
       selectionSet: '{ id }',
-      computedFields: {
-        shippingEstimate: { selectionSet: '{ price weight }' },
-        deliveryService: { selectionSet: '{ weight }' },
+      fields: {
+        shippingEstimate: {
+          selectionSet: '{ price weight }',
+          computed: true,
+        },
+        deliveryService: {
+          selectionSet: '{ weight }',
+          computed: true,
+        },
       },
       fieldName: '_products',
       key: ({ id, price, weight }) => ({ id, price, weight }),
@@ -470,9 +476,11 @@ The `@computed` SDL directive is a convenience syntax for static configuration t
 }
 ```
 
-The main disadvantage of computed fields is that they cannot be resolved independently from the stitched gateway. Tolerance for this subservice inconsistency is largely dependent on your own service architecture. An imperfect solution is to deprecate all computed fields within a subschema, and then normalize their behavior in the gateway schema with a [`RemoveObjectFieldDeprecations`](/docs/schema-wrapping#grooming) transform. See related [handbook example](https://github.com/gmac/schema-stitching-handbook/tree/master/computed-fields).
+A field-level `selectionSet` specifies field dependencies while the `computed` setting structures the field in a way that assures it is always selected with this data provided. The `selectionSet` is intentionally generic to support possible future uses.
 
-> **Implementation note:** to facilitate field-level dependencies, computed and non-computed fields of a type in the same subservice are automatically split apart into separate schemas. This assures that computed fields are always requested directly by the gateway with their dependencies provided. However, it also means that computed and non-computed fields may require separate resolution steps. You may enable [query batching](#batching) to consolidate requests whenever possible.
+> **Implementation note:** to assure that computed fields are always requested directly by the gateway with their dependencies provided, computed and non-computed fields of a type in the same subservice are automatically split apart into separate schemas. This means that computed and non-computed fields may require separate resolution steps. You may enable [query batching](#batching) to consolidate requests whenever possible.
+
+The main disadvantage of computed fields is that they cannot be resolved independently from the stitched gateway. Tolerance for this subservice inconsistency is largely dependent on your own service architecture. An imperfect solution is to deprecate all computed fields within a subschema, and then normalize their behavior in the gateway schema with a [`RemoveObjectFieldDeprecations`](/docs/schema-wrapping#grooming) transform. See related [handbook example](https://github.com/gmac/schema-stitching-handbook/tree/master/computed-fields).
 
 ## Federation services
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -40,7 +40,7 @@ module.exports = {
       ]
     },
     {
-      "API Reference": []
+      "API Reference": require('./api-sidebar.json')
     }
   ]
 }

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -40,7 +40,7 @@ module.exports = {
       ]
     },
     {
-      "API Reference": require('./api-sidebar.json')
+      "API Reference": []
     }
   ]
 }


### PR DESCRIPTION
Cleans up the splitting of computed schemas to preserve subschema configuration as follows:

- Currently, the `fields` setting on the base schema is eliminated in the presence of computed fields. This assures that field settings of the base schema (such as `canonical`) are preserved, and that computed field settings are transferred to the computed schema.
- Currently, both subschemas resolve with a duplicate `computedFields` setting, which I believe is moot after this stage in schema building? It's still odd though, because the base schema no longer has computed fields. So, the `computedFields` setting is removed from the base schema.
- Also assures that the computed schema disables its types as `canonical` so that they don't conflict with the base definition.
- Aaaaand, fixes a bunch of typescript warnings that I'm sure I'm originally responsible for.

In general, I really feel like the `computedFields` member is needless baggage here and I would still make the case for consolidating the fields API in v8 to this:

```js
merge: {
  Product: {
    selectionSet: '{ id weight }',
    fields: {
      shippingEstimate: {
        selectionSet: '{ price }',
        computed: true,
        canonical: true
      },
      deliveryService: {
        canonical: true
      },
    },
    fieldName: '_products',
    key: ({ id, price, weight }) => ({ id, price, weight }),
    argsFromKeys: (representations) => ({ representations }),
    canonical: true,
  }
}
```

@yaacovCR – for your approval.