### PR TITLE
provide { done: true } from iterator when complete is called on obser…

### DIFF
--- a/.changeset/sharp-colts-drive.md
+++ b/.changeset/sharp-colts-drive.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/utils': patch
+---
+
+fix(utils): provide { done: true } from iterator when complete is called on observer in obsvervableToAsyncIterable

--- a/packages/utils/tests/observableToAsyncIterable.spec.ts
+++ b/packages/utils/tests/observableToAsyncIterable.spec.ts
@@ -1,0 +1,15 @@
+import { observableToAsyncIterable } from '@graphql-tools/utils';
+
+describe('observableToAsyncIterable', () => {
+  test('finalize iterator when complete() is called on observer', () => {
+
+    const iterator = observableToAsyncIterable({
+      subscribe: observer => {
+        observer.complete();
+        return { unsubscribe: () => {} };
+      }
+    });
+
+    return iterator.next().then(result => expect(result.done).toEqual(true))
+  });
+});


### PR DESCRIPTION
## Description

This implements complete method on proxy observer passed to the observable in observableToAsyncIterable.  When complete is called, the iterator will now return a promise with `{ done: true }` to the consumer of the iterator.

Related #2587 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested this by creating a remotely delegated subscription.  When The remote end closes are sends a GQL_COMPLETE, this is now properly propagated to the client.

**Test Environment**:
- OS: Mac OS 10.15.7
- `@graphql-tools/utils`: master branch
- NodeJS: 12.16.1

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
