### PR TITLE
Spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This package provides a few useful ways to create a GraphQL schema:
 
 If you want to bind your JavaScript GraphQL schema to an HTTP server, you can use [`express-graphql`](https://github.com/graphql/express-graphql).
 
-You can develop your Javascript based GraphQL API with `graphql-tools` and `express-graphql` together: One to write the schema and resolver code, and the other to connect it to a web server.
+You can develop your JavaScript based GraphQL API with `graphql-tools` and `express-graphql` together: One to write the schema and resolver code, and the other to connect it to a web server.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![toolskit](https://user-images.githubusercontent.com/20847995/80261023-feb6e380-8691-11ea-8680-5747fa02c5d8.gif)](https://graphql-tools.com)
+[![toolkit](https://user-images.githubusercontent.com/20847995/80261023-feb6e380-8691-11ea-8680-5747fa02c5d8.gif)](https://graphql-tools.com)
 
 [![npm version](https://badge.fury.io/js/%40graphql-tools%2Futils.svg)](https://badge.fury.io/js/%40graphql-tools%2Futils)
 [![CI](https://github.com/ardatan/graphql-tools/workflows/CI/badge.svg)](https://github.com/ardatan/graphql-tools/actions)

--- a/packages/batch-delegate/CHANGELOG.md
+++ b/packages/batch-delegate/CHANGELOG.md
@@ -23,7 +23,7 @@
 
   * The `transformRequest`/`transformResult` methods are now provided additional `delegationContext` and `transformationContext` arguments -- these were introduced in v6, but previously optional.
 
-  * The `transformSchema` method may wish to create additional delegating resolvers and so it is now provided the `subschemaConfig` and final (non-executable) `transformedSchema` parameters. As in v6, the `transformSchema` is kicked off once to produce the non-executable version, and then, if a wrapping schema is being generated, proxying resolvers are created with access to the (non-executabel) initial result. In v7, the individual `transformSchema` methods also get access to the result of the first run, if necessary, they can create additional wrapping schema proxying resolvers.
+  * The `transformSchema` method may wish to create additional delegating resolvers and so it is now provided the `subschemaConfig` and final (non-executable) `transformedSchema` parameters. As in v6, the `transformSchema` is kicked off once to produce the non-executable version, and then, if a wrapping schema is being generated, proxying resolvers are created with access to the (non-executable) initial result. In v7, the individual `transformSchema` methods also get access to the result of the first run, if necessary, they can create additional wrapping schema proxying resolvers.
 
   * `applySchemaTransforms` parameters have been updated to match and support the `transformSchema` parameters above.
 

--- a/packages/batch-execute/CHANGELOG.md
+++ b/packages/batch-execute/CHANGELOG.md
@@ -19,7 +19,7 @@
   
   - The `transformRequest`/`transformResult` methods are now provided additional `delegationContext` and `transformationContext` arguments -- these were introduced in v6, but previously optional.
   
-  - The `transformSchema` method may wish to create additional delegating resolvers and so it is now provided the `subschemaConfig` and final (non-executable) `transformedSchema` parameters. As in v6, the `transformSchema` is kicked off once to produce the non-executable version, and then, if a wrapping schema is being generated, proxying resolvers are created with access to the (non-executabel) initial result. In v7, the individual `transformSchema` methods also get access to the result of the first run, if necessary, they can create additional wrapping schema proxying resolvers.
+  - The `transformSchema` method may wish to create additional delegating resolvers and so it is now provided the `subschemaConfig` and final (non-executable) `transformedSchema` parameters. As in v6, the `transformSchema` is kicked off once to produce the non-executable version, and then, if a wrapping schema is being generated, proxying resolvers are created with access to the (non-executable) initial result. In v7, the individual `transformSchema` methods also get access to the result of the first run, if necessary, they can create additional wrapping schema proxying resolvers.
   
   - `applySchemaTransforms` parameters have been updated to match and support the `transformSchema` parameters above.
   

--- a/packages/delegate/CHANGELOG.md
+++ b/packages/delegate/CHANGELOG.md
@@ -121,7 +121,7 @@
 
   - The `transformRequest`/`transformResult` methods are now provided additional `delegationContext` and `transformationContext` arguments -- these were introduced in v6, but previously optional.
 
-  - The `transformSchema` method may wish to create additional delegating resolvers and so it is now provided the `subschemaConfig` and final (non-executable) `transformedSchema` parameters. As in v6, the `transformSchema` is kicked off once to produce the non-executable version, and then, if a wrapping schema is being generated, proxying resolvers are created with access to the (non-executabel) initial result. In v7, the individual `transformSchema` methods also get access to the result of the first run, if necessary, they can create additional wrapping schema proxying resolvers.
+  - The `transformSchema` method may wish to create additional delegating resolvers and so it is now provided the `subschemaConfig` and final (non-executable) `transformedSchema` parameters. As in v6, the `transformSchema` is kicked off once to produce the non-executable version, and then, if a wrapping schema is being generated, proxying resolvers are created with access to the (non-executable) initial result. In v7, the individual `transformSchema` methods also get access to the result of the first run, if necessary, they can create additional wrapping schema proxying resolvers.
 
   - `applySchemaTransforms` parameters have been updated to match and support the `transformSchema` parameters above.
 

--- a/packages/delegate/src/defaultMergedResolver.ts
+++ b/packages/delegate/src/defaultMergedResolver.ts
@@ -10,7 +10,7 @@ import { ExternalObject } from './types';
  * Resolver that knows how to:
  * a) handle aliases for proxied schemas
  * b) handle errors from proxied schemas
- * c) handle external to internal enum coversion
+ * c) handle external to internal enum conversion
  */
 export function defaultMergedResolver(
   parent: ExternalObject,

--- a/packages/graphql-tag-pluck/CHANGELOG.md
+++ b/packages/graphql-tag-pluck/CHANGELOG.md
@@ -36,7 +36,7 @@
 ### Patch Changes
 
 - e9ed9394: Change intenral API to add more details on found locations, and export parseCode for lower-level parsing
-- 54b440a9: allow to skip identation while plucking
+- 54b440a9: allow to skip indentation while plucking
 
 ## 6.2.4
 

--- a/packages/graphql-tag-pluck/CHANGELOG.md
+++ b/packages/graphql-tag-pluck/CHANGELOG.md
@@ -35,7 +35,7 @@
 
 ### Patch Changes
 
-- e9ed9394: Change intenral API to add more details on found locations, and export parseCode for lower-level parsing
+- e9ed9394: Change internal API to add more details on found locations, and export parseCode for lower-level parsing
 - 54b440a9: allow to skip indentation while plucking
 
 ## 6.2.4

--- a/packages/graphql-tag-pluck/src/visitor.ts
+++ b/packages/graphql-tag-pluck/src/visitor.ts
@@ -149,7 +149,7 @@ export default (code: string, out: any, options: GraphQLTagPluckOptions = {}) =>
         // Slice quotes
         .slice(start + 1, end - 1)
         // Erase string interpolations as we gonna export everything as a single
-        // string anyways
+        // string anyway
         .replace(/\$\{[^}]*\}/g, '')
         .split('\\`')
         .join('`'),

--- a/packages/graphql-tools/CHANGELOG.md
+++ b/packages/graphql-tools/CHANGELOG.md
@@ -48,7 +48,7 @@
 
   * The `transformRequest`/`transformResult` methods are now provided additional `delegationContext` and `transformationContext` arguments -- these were introduced in v6, but previously optional.
 
-  * The `transformSchema` method may wish to create additional delegating resolvers and so it is now provided the `subschemaConfig` and final (non-executable) `transformedSchema` parameters. As in v6, the `transformSchema` is kicked off once to produce the non-executable version, and then, if a wrapping schema is being generated, proxying resolvers are created with access to the (non-executabel) initial result. In v7, the individual `transformSchema` methods also get access to the result of the first run, if necessary, they can create additional wrapping schema proxying resolvers.
+  * The `transformSchema` method may wish to create additional delegating resolvers and so it is now provided the `subschemaConfig` and final (non-executable) `transformedSchema` parameters. As in v6, the `transformSchema` is kicked off once to produce the non-executable version, and then, if a wrapping schema is being generated, proxying resolvers are created with access to the (non-executable) initial result. In v7, the individual `transformSchema` methods also get access to the result of the first run, if necessary, they can create additional wrapping schema proxying resolvers.
 
   * `applySchemaTransforms` parameters have been updated to match and support the `transformSchema` parameters above.
 

--- a/packages/import/tests/schema/import-schema.spec.ts
+++ b/packages/import/tests/schema/import-schema.spec.ts
@@ -95,7 +95,7 @@ describe('importSchema', () => {
   });
 
   test('parseSDL: non-import comment', () => {
-    expect(parseSDL(`#importent: comment`)).toEqual([]);
+    expect(parseSDL(`#important: comment`)).toEqual([]);
   });
 
   test('parse: multi line import', () => {

--- a/packages/links/CHANGELOG.md
+++ b/packages/links/CHANGELOG.md
@@ -67,7 +67,7 @@
 
   - The `transformRequest`/`transformResult` methods are now provided additional `delegationContext` and `transformationContext` arguments -- these were introduced in v6, but previously optional.
 
-  - The `transformSchema` method may wish to create additional delegating resolvers and so it is now provided the `subschemaConfig` and final (non-executable) `transformedSchema` parameters. As in v6, the `transformSchema` is kicked off once to produce the non-executable version, and then, if a wrapping schema is being generated, proxying resolvers are created with access to the (non-executabel) initial result. In v7, the individual `transformSchema` methods also get access to the result of the first run, if necessary, they can create additional wrapping schema proxying resolvers.
+  - The `transformSchema` method may wish to create additional delegating resolvers and so it is now provided the `subschemaConfig` and final (non-executable) `transformedSchema` parameters. As in v6, the `transformSchema` is kicked off once to produce the non-executable version, and then, if a wrapping schema is being generated, proxying resolvers are created with access to the (non-executable) initial result. In v7, the individual `transformSchema` methods also get access to the result of the first run, if necessary, they can create additional wrapping schema proxying resolvers.
 
   - `applySchemaTransforms` parameters have been updated to match and support the `transformSchema` parameters above.
 

--- a/packages/load-files/tests/file-scanner.spec.ts
+++ b/packages/load-files/tests/file-scanner.spec.ts
@@ -205,7 +205,7 @@ describe('file scanner', function() {
           },
         },
       ],
-      note: 'ingore index files',
+      note: 'ignore index files',
       extensions: ['js'],
       compareValue: true,
       ignoreIndex: true,

--- a/packages/load-files/tests/test-assets/12/index.ts
+++ b/packages/load-files/tests/test-assets/12/index.ts
@@ -1,5 +1,5 @@
 export default {
-  IngoredType: {
+  IgnoredType: {
     f: '12',
   },
 };

--- a/packages/load/tests/loaders/schema/schema-from-typedefs.spec.ts
+++ b/packages/load/tests/loaders/schema/schema-from-typedefs.spec.ts
@@ -51,7 +51,7 @@ describe('schema from typedefs', () => {
       }
     });
 
-    it('should ignore graphql documents when loading a scehma', async () => {
+    it('should ignore graphql documents when loading a schema', async () => {
       const glob = './tests/loaders/schema/test-files/schema-dir/*.non-schema.graphql';
 
       try {

--- a/packages/loaders/code-file/tests/load-from-code-file.spec.ts
+++ b/packages/loaders/code-file/tests/load-from-code-file.spec.ts
@@ -22,7 +22,7 @@ describe('loadFromCodeFile', () => {
     }
   });
 
-  it('should load a vaild file', async () => {
+  it('should load a valid file', async () => {
     const loaded = await loader.load('./test-files/valid-doc.js', {
       noRequire: true,
       fs,
@@ -85,7 +85,7 @@ describe('loadFromCodeFileSync', () => {
     }).toThrowError('Syntax Error: Unexpected Name "InvalidGetUser"')
   });
 
-  it('should load a vaild file', () => {
+  it('should load a valid file', () => {
     const loaded = loader.loadSync('./test-files/valid-doc.js', {
       noRequire: true,
       fs,

--- a/packages/loaders/git/tests/test-files/introspection.json
+++ b/packages/loaders/git/tests/test-files/introspection.json
@@ -963,7 +963,7 @@
       },
       {
         "name": "specifiedBy",
-        "description": "Exposes a URL that specifies the behaviour of this scalar.",
+        "description": "Exposes a URL that specifies the behavior of this scalar.",
         "isRepeatable": false,
         "locations": [
           "SCALAR"
@@ -971,7 +971,7 @@
         "args": [
           {
             "name": "url",
-            "description": "The URL that specifies the behaviour of this scalar.",
+            "description": "The URL that specifies the behavior of this scalar.",
             "type": {
               "kind": "NON_NULL",
               "name": null,

--- a/packages/loaders/github/tests/schema-from-github.spec.ts
+++ b/packages/loaders/github/tests/schema-from-github.spec.ts
@@ -27,7 +27,7 @@ function normalize(doc: string): string {
     return print(parse(doc));
 }
 
-test('load schema from Github', async () => {
+test('load schema from GitHub', async () => {
   let headers: Record<string, string> = {};
   let query: string;
   let variables: any;

--- a/packages/loaders/json-file/tests/test-files/introspection.json
+++ b/packages/loaders/json-file/tests/test-files/introspection.json
@@ -963,7 +963,7 @@
       },
       {
         "name": "specifiedBy",
-        "description": "Exposes a URL that specifies the behaviour of this scalar.",
+        "description": "Exposes a URL that specifies the behavior of this scalar.",
         "isRepeatable": false,
         "locations": [
           "SCALAR"
@@ -971,7 +971,7 @@
         "args": [
           {
             "name": "url",
-            "description": "The URL that specifies the behaviour of this scalar.",
+            "description": "The URL that specifies the behavior of this scalar.",
             "type": {
               "kind": "NON_NULL",
               "name": null,

--- a/packages/loaders/prisma/src/prisma-yml/PrismaDefinition.test.ts
+++ b/packages/loaders/prisma/src/prisma-yml/PrismaDefinition.test.ts
@@ -177,7 +177,7 @@ type User @model {
   /**
    * This test ensures, that GRAPHCOOL_SECRET can't be injected anymore
    */
-  test('dont load yml with secret and env var in args', async () => {
+  test(`don't load yml with secret and env var in args`, async () => {
     const yml = `\
 service: jj
 stage: dev

--- a/packages/loaders/prisma/src/prisma-yml/__snapshots__/PrismaDefinition.test.ts.snap
+++ b/packages/loaders/prisma/src/prisma-yml/__snapshots__/PrismaDefinition.test.ts.snap
@@ -157,7 +157,7 @@ Array [
 ]
 `;
 
-exports[`prisma definition dont load yml with secret and env var in args 1`] = `
+exports[`prisma definition don't load yml with secret and env var in args 1`] = `
 [Error: Invalid prisma.yml file
 prisma.yml should NOT have additional properties. additionalProperty: service]
 `;

--- a/packages/loaders/prisma/src/prisma-yml/utils/parseEndpoint.test.ts
+++ b/packages/loaders/prisma/src/prisma-yml/utils/parseEndpoint.test.ts
@@ -9,7 +9,7 @@ describe('parseEndpoint', () => {
   });
   test('local behind a proxy', () => {
     // This snapshot will be incorrect for now as URL does not have enough
-    // information to detemine if something is truly local
+    // information to determine if something is truly local
     expect(parseEndpoint('http://local.dev')).toMatchSnapshot();
   });
   test('work for url with service', () => {

--- a/packages/merge/CHANGELOG.md
+++ b/packages/merge/CHANGELOG.md
@@ -33,7 +33,7 @@
 
   - The `transformRequest`/`transformResult` methods are now provided additional `delegationContext` and `transformationContext` arguments -- these were introduced in v6, but previously optional.
 
-  - The `transformSchema` method may wish to create additional delegating resolvers and so it is now provided the `subschemaConfig` and final (non-executable) `transformedSchema` parameters. As in v6, the `transformSchema` is kicked off once to produce the non-executable version, and then, if a wrapping schema is being generated, proxying resolvers are created with access to the (non-executabel) initial result. In v7, the individual `transformSchema` methods also get access to the result of the first run, if necessary, they can create additional wrapping schema proxying resolvers.
+  - The `transformSchema` method may wish to create additional delegating resolvers and so it is now provided the `subschemaConfig` and final (non-executable) `transformedSchema` parameters. As in v6, the `transformSchema` is kicked off once to produce the non-executable version, and then, if a wrapping schema is being generated, proxying resolvers are created with access to the (non-executable) initial result. In v7, the individual `transformSchema` methods also get access to the result of the first run, if necessary, they can create additional wrapping schema proxying resolvers.
 
   - `applySchemaTransforms` parameters have been updated to match and support the `transformSchema` parameters above.
 

--- a/packages/mock/CHANGELOG.md
+++ b/packages/mock/CHANGELOG.md
@@ -32,7 +32,7 @@
 
   - The `transformRequest`/`transformResult` methods are now provided additional `delegationContext` and `transformationContext` arguments -- these were introduced in v6, but previously optional.
 
-  - The `transformSchema` method may wish to create additional delegating resolvers and so it is now provided the `subschemaConfig` and final (non-executable) `transformedSchema` parameters. As in v6, the `transformSchema` is kicked off once to produce the non-executable version, and then, if a wrapping schema is being generated, proxying resolvers are created with access to the (non-executabel) initial result. In v7, the individual `transformSchema` methods also get access to the result of the first run, if necessary, they can create additional wrapping schema proxying resolvers.
+  - The `transformSchema` method may wish to create additional delegating resolvers and so it is now provided the `subschemaConfig` and final (non-executable) `transformedSchema` parameters. As in v6, the `transformSchema` is kicked off once to produce the non-executable version, and then, if a wrapping schema is being generated, proxying resolvers are created with access to the (non-executable) initial result. In v7, the individual `transformSchema` methods also get access to the result of the first run, if necessary, they can create additional wrapping schema proxying resolvers.
 
   - `applySchemaTransforms` parameters have been updated to match and support the `transformSchema` parameters above.
 

--- a/packages/mock/src/MockStore.ts
+++ b/packages/mock/src/MockStore.ts
@@ -260,7 +260,7 @@ export class MockStore implements IMockStore {
       this.store[typeName][key] = {};
     }
 
-    // if already set and we don't ovveride
+    // if already set and we don't override
     if (this.store[typeName][key][fieldNameInStore] !== undefined && noOverride) {
       return;
     }

--- a/packages/mock/src/MockStore.ts
+++ b/packages/mock/src/MockStore.ts
@@ -420,7 +420,7 @@ export class MockStore implements IMockStore {
     if (value !== undefined) return value;
 
     const type = this.getType(typeName);
-    // GraphQL 14 Compability
+    // GraphQL 14 Compatibility
     const interfaces = 'getInterfaces' in type ? type.getInterfaces() : [];
 
     if (interfaces.length > 0) {

--- a/packages/mock/src/MockStore.ts
+++ b/packages/mock/src/MockStore.ts
@@ -292,7 +292,7 @@ export class MockStore implements IMockStore {
     const fieldTypeName = fieldType.toString();
     if (value === null) {
       if (!isNullableType(fieldType)) {
-        throw new Error(`should not be null bacause ${fieldTypeName} is not nullable. Received null.`);
+        throw new Error(`should not be null because ${fieldTypeName} is not nullable. Received null.`);
       }
     }
 

--- a/packages/mock/src/MockStore.ts
+++ b/packages/mock/src/MockStore.ts
@@ -77,7 +77,7 @@ export class MockStore implements IMockStore {
     if (typeof _typeName !== 'string') {
       if (_key === undefined) {
         if (isRef<KeyT>(_typeName)) {
-          throw new Error("Can't provide a ref as first arguement and no other argument");
+          throw new Error("Can't provide a ref as first argument and no other argument");
         }
         // get({...})
         return this.getImpl(_typeName);
@@ -139,7 +139,7 @@ export class MockStore implements IMockStore {
     if (typeof _typeName !== 'string') {
       if (_key === undefined) {
         if (isRef<KeyT>(_typeName)) {
-          throw new Error("Can't provide a ref as first arguement and no other argument");
+          throw new Error("Can't provide a ref as first argument and no other argument");
         }
         // set({...})
         return this.setImpl(_typeName);

--- a/packages/mock/src/addMocksToSchema.ts
+++ b/packages/mock/src/addMocksToSchema.ts
@@ -134,7 +134,7 @@ export function addMocksToSchema({
       });
     }
 
-    // we have to handle the root mutation, root query and root subscripton types
+    // we have to handle the root mutation, root query and root subscription types
     // differently, because no resolver is called at the root
     if (isRootType(info.parentType, info.schema)) {
       return store.get({

--- a/packages/mock/src/index.ts
+++ b/packages/mock/src/index.ts
@@ -36,7 +36,7 @@ export * from './MockList';
  */
 export function createMockStore(options: {
   /**
-   * The `schema` to based mokcks on.
+   * The `schema` to based mocks on.
    */
   schema: GraphQLSchema;
 

--- a/packages/mock/src/types.ts
+++ b/packages/mock/src/types.ts
@@ -25,7 +25,7 @@ export type GetArgs<KeyT extends KeyTypeConstraints = string> = {
   key?: KeyT;
   fieldName?: string;
   /**
-   * Optionnal arguments when querying the field.
+   * Optional arguments when querying the field.
    *
    * Querying the field with the same arguments will return
    * the same value. Deep equality is checked.
@@ -50,7 +50,7 @@ export type SetArgs<KeyT extends KeyTypeConstraints = string> = {
   key: KeyT;
   fieldName?: string;
   /**
-   * Optionnal arguments when querying the field.
+   * Optional arguments when querying the field.
    *
    * @see GetArgs#fieldArgs
    */

--- a/packages/mock/src/types.ts
+++ b/packages/mock/src/types.ts
@@ -69,7 +69,7 @@ export interface IMockStore {
   schema: GraphQLSchema;
   /**
    * Get a field value from the store for the given type, key and field
-   * name — and optionnally field arguments. If the field name is not given,
+   * name — and optionally field arguments. If the field name is not given,
    * a reference to the type will be returned.
    *
    * If the the value for this field is not set, a value will be
@@ -122,7 +122,7 @@ export interface IMockStore {
 
   /**
    * Set a field value in the store for the given type, key and field
-   * name — and optionnally field arguments.
+   * name — and optionally field arguments.
    *
    * If the the field return type is an `ObjectType` or a list of
    * `ObjectType`, you can set references to other entity as value:

--- a/packages/mock/src/types.ts
+++ b/packages/mock/src/types.ts
@@ -58,7 +58,7 @@ export type SetArgs<KeyT extends KeyTypeConstraints = string> = {
   value?: unknown | { [fieldName: string]: any };
   /**
    * If the value for this field is already set, it won't
-   * be overriden.
+   * be overridden.
    *
    * Propagates down do nested `set`.
    */

--- a/packages/mock/src/types.ts
+++ b/packages/mock/src/types.ts
@@ -36,7 +36,7 @@ export type GetArgs<KeyT extends KeyTypeConstraints = string> = {
    * ```
    *
    * Args can be a record, just like `args` argument of field resolver or an
-   * arbitraty string.
+   * arbitrary string.
    */
   fieldArgs?: string | { [argName: string]: any };
   /**

--- a/packages/mock/tests/store.spec.ts
+++ b/packages/mock/tests/store.spec.ts
@@ -359,7 +359,7 @@ describe('MockStore', () => {
     const myFriendsRefs = store.get('User', 'me', 'friends') as Ref[];
     expect(myFriendsRefs).toHaveLength(2);
 
-    // should retrurn array of valid refs
+    // should return array of valid refs
     expect(myFriendsRefs[0]).toHaveProperty('$ref')
   });
 

--- a/packages/mock/tests/store.spec.ts
+++ b/packages/mock/tests/store.spec.ts
@@ -198,7 +198,7 @@ describe('MockStore', () => {
     expect(store.get('User', '123', 'name')).toEqual('Superman');
   });
 
-  it('with type level mocks, it should produce consistant values', () => {
+  it('with type level mocks, it should produce consistent values', () => {
     const store = createMockStore({
       schema,
       mocks: {

--- a/packages/optimize/src/optimize.ts
+++ b/packages/optimize/src/optimize.ts
@@ -8,7 +8,7 @@ const DEFAULT_OPTIMIZERS: DocumentOptimizer[] = [removeDescriptions, removeEmpty
 
 /**
  * This method accept a DocumentNode and applies the optimizations you wish to use.
- * You can override the defualt ones or provide you own optimizers if you wish.
+ * You can override the default ones or provide you own optimizers if you wish.
  *
  * @param node document to optimize
  * @param optimizers optional, list of optimizer to use

--- a/packages/optimize/src/optimizers/remove-description.ts
+++ b/packages/optimize/src/optimizers/remove-description.ts
@@ -2,7 +2,7 @@ import { visit } from 'graphql';
 import { DocumentOptimizer } from '../types';
 
 /**
- * This optimizer removes "desciption" field from schema AST definitions.
+ * This optimizer removes "description" field from schema AST definitions.
  * @param input
  */
 export const removeDescriptions: DocumentOptimizer = input => {

--- a/packages/resolvers-composition/package.json
+++ b/packages/resolvers-composition/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@graphql-tools/resolvers-composition",
   "version": "6.2.5",
-  "description": "Common package containting utils and types for GraphQL tools",
+  "description": "Common package containing utils and types for GraphQL tools",
   "repository": {
     "type": "git",
     "url": "ardatan/graphql-tools",

--- a/packages/resolvers-composition/src/resolvers-composition.ts
+++ b/packages/resolvers-composition/src/resolvers-composition.ts
@@ -26,16 +26,16 @@ function resolveRelevantMappings<Resolvers extends Record<string, any> = Record<
   path: string,
   allMappings: ResolversComposerMapping<Resolvers>
 ): string[] {
-  const splitted = path.split('.');
+  const split = path.split('.');
 
-  if (splitted.length === 2) {
-    const typeName = splitted[0];
+  if (split.length === 2) {
+    const typeName = split[0];
 
     if (isScalarType(resolvers[typeName])) {
       return [];
     }
 
-    const fieldName = splitted[1];
+    const fieldName = split[1];
 
     if (typeName === '*') {
       return flatten(
@@ -70,8 +70,8 @@ function resolveRelevantMappings<Resolvers extends Record<string, any> = Record<
 
       return paths;
     }
-  } else if (splitted.length === 1) {
-    const typeName = splitted[0];
+  } else if (split.length === 1) {
+    const typeName = split[0];
 
     return flatten(
       Object.keys(resolvers[typeName]).map(fieldName =>

--- a/packages/schema/CHANGELOG.md
+++ b/packages/schema/CHANGELOG.md
@@ -55,7 +55,7 @@
 
   - The `transformRequest`/`transformResult` methods are now provided additional `delegationContext` and `transformationContext` arguments -- these were introduced in v6, but previously optional.
 
-  - The `transformSchema` method may wish to create additional delegating resolvers and so it is now provided the `subschemaConfig` and final (non-executable) `transformedSchema` parameters. As in v6, the `transformSchema` is kicked off once to produce the non-executable version, and then, if a wrapping schema is being generated, proxying resolvers are created with access to the (non-executabel) initial result. In v7, the individual `transformSchema` methods also get access to the result of the first run, if necessary, they can create additional wrapping schema proxying resolvers.
+  - The `transformSchema` method may wish to create additional delegating resolvers and so it is now provided the `subschemaConfig` and final (non-executable) `transformedSchema` parameters. As in v6, the `transformSchema` is kicked off once to produce the non-executable version, and then, if a wrapping schema is being generated, proxying resolvers are created with access to the (non-executable) initial result. In v7, the individual `transformSchema` methods also get access to the result of the first run, if necessary, they can create additional wrapping schema proxying resolvers.
 
   - `applySchemaTransforms` parameters have been updated to match and support the `transformSchema` parameters above.
 

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -72,7 +72,7 @@ export interface IExecutableSchemaDefinition<TContext = any> {
    */
   updateResolversInPlace?: boolean;
   /**
-   * Do not extract and apply extensions seperately and leave it to `buildASTSchema`
+   * Do not extract and apply extensions separately and leave it to `buildASTSchema`
    */
   noExtensionExtraction?: boolean;
 }

--- a/packages/schema/tests/logger.test.ts
+++ b/packages/schema/tests/logger.test.ts
@@ -36,7 +36,7 @@ describe('Logger', () => {
       resolvers: resolve,
       logger,
     });
-    // calling the mutation here so the erros will be ordered.
+    // calling the mutation here so the errors will be ordered.
     const testQuery = 'mutation { species, stuff }';
     const expected0 = 'Error in resolver RootMutation.species\noops!';
     const expected1 = 'Error in resolver RootMutation.stuff\noh noes!';

--- a/packages/schema/tests/schemaGenerator.test.ts
+++ b/packages/schema/tests/schemaGenerator.test.ts
@@ -1715,7 +1715,7 @@ To disable this validator, use:
     );
   });
 
-  test('doesnt let you define resolver field not present in schema', () => {
+  test(`doesn't let you define resolver field not present in schema`, () => {
     const short = `
       type Person {
         name: String

--- a/packages/stitch/CHANGELOG.md
+++ b/packages/stitch/CHANGELOG.md
@@ -203,7 +203,7 @@
 
   - The `transformRequest`/`transformResult` methods are now provided additional `delegationContext` and `transformationContext` arguments -- these were introduced in v6, but previously optional.
 
-  - The `transformSchema` method may wish to create additional delegating resolvers and so it is now provided the `subschemaConfig` and final (non-executable) `transformedSchema` parameters. As in v6, the `transformSchema` is kicked off once to produce the non-executable version, and then, if a wrapping schema is being generated, proxying resolvers are created with access to the (non-executabel) initial result. In v7, the individual `transformSchema` methods also get access to the result of the first run, if necessary, they can create additional wrapping schema proxying resolvers.
+  - The `transformSchema` method may wish to create additional delegating resolvers and so it is now provided the `subschemaConfig` and final (non-executable) `transformedSchema` parameters. As in v6, the `transformSchema` is kicked off once to produce the non-executable version, and then, if a wrapping schema is being generated, proxying resolvers are created with access to the (non-executable) initial result. In v7, the individual `transformSchema` methods also get access to the result of the first run, if necessary, they can create additional wrapping schema proxying resolvers.
 
   - `applySchemaTransforms` parameters have been updated to match and support the `transformSchema` parameters above.
 

--- a/packages/stitch/tests/alternateStitchSchemas.test.ts
+++ b/packages/stitch/tests/alternateStitchSchemas.test.ts
@@ -237,7 +237,7 @@ describe('merge schemas through transforms', () => {
     });
   });
 
-  // FIXME fragemnt replacements
+  // FIXME fragment replacements
   test('node should work', async () => {
     const result = await graphql(
       stitchedSchema,

--- a/packages/stitch/tests/typeMergingWithDirectives.test.ts
+++ b/packages/stitch/tests/typeMergingWithDirectives.test.ts
@@ -79,7 +79,7 @@ describe('merging using type merging', () => {
     // the @computed directive will defer resolution of these fields even when queries originate
     // within this subschema. The resolver for the mostStockedProduct therefore correctly returns
     // an object with a `upc` property, but without `price` and `weight`. The gateway will use
-    // the `upc` to retrive the `price` and `weight` from the external services and return to this
+    // the `upc` to retrieve the `price` and `weight` from the external services and return to this
     // service for the `shippingEstimate`. Resolution for @computed fields thereby differs when
     // querying via the gateway versus when querying the subservice directly.
     //

--- a/packages/stitch/tests/typeMergingWithDirectives.test.ts
+++ b/packages/stitch/tests/typeMergingWithDirectives.test.ts
@@ -236,7 +236,7 @@ describe('merging using type merging', () => {
     //
     // The equivalent `argsExpr` is also included. This example highlights how when using
     // `argsExpr`, the $ sign without dot notation will pass the entire key as an object.
-    // This allows arbitary nesting of the key input as needed.
+    // This allows arbitrary nesting of the key input as needed.
     //
     typeDefs: `
       ${allStitchingDirectivesTypeDefs}

--- a/packages/stitch/tests/typeMergingWithInterfaces.test.ts
+++ b/packages/stitch/tests/typeMergingWithInterfaces.test.ts
@@ -82,7 +82,7 @@ describe('merging using type merging', () => {
     // the @computed directive will defer resolution of these fields even when queries originate
     // within this subschema. The resolver for the mostStockedProduct therefore correctly returns
     // an object with a `upc` property, but without `price` and `weight`. The gateway will use
-    // the `upc` to retrive the `price` and `weight` from the external services and return to this
+    // the `upc` to retrieve the `price` and `weight` from the external services and return to this
     // service for the `shippingEstimate`. Resolution for @computed fields thereby differs when
     // querying via the gateway versus when querying the subservice directly.
     //

--- a/packages/stitch/tests/typeMergingWithInterfaces.test.ts
+++ b/packages/stitch/tests/typeMergingWithInterfaces.test.ts
@@ -236,7 +236,7 @@ describe('merging using type merging', () => {
     //
     // The equivalent `argsExpr` is also included. This example highlights how when using
     // `argsExpr`, the $ sign without dot notation will pass the entire key as an object.
-    // This allows arbitary nesting of the key input as needed.
+    // This allows arbitrary nesting of the key input as needed.
     //
     typeDefs: `
       ${allStitchingDirectivesTypeDefs}

--- a/packages/stitching-directives/src/stitchingDirectivesTransformer.ts
+++ b/packages/stitching-directives/src/stitchingDirectivesTransformer.ts
@@ -461,7 +461,7 @@ function generateArgsFn(mergedTypeResolverInfo: MergedTypeResolverInfo): (origin
 }
 
 function buildKey(key: Array<string>): string {
-  let mergedObect = {};
+  let mergedObject = {};
   key.forEach(keyDef => {
     let [aliasOrKeyPath, keyPath] = keyDef.split(':');
     let aliasPath: string;
@@ -477,10 +477,10 @@ function buildKey(key: Array<string>): string {
     aliasParts.reverse().forEach(aliasPart => {
       object = { [aliasPart]: object };
     });
-    mergedObect = mergeDeep(mergedObect, object);
+    mergedObject = mergeDeep(mergedObject, object);
   });
 
-  return JSON.stringify(mergedObect).replace(/"/g, '');
+  return JSON.stringify(mergedObject).replace(/"/g, '');
 }
 
 function mergeSelectionSets(selectionSet1: SelectionSetNode, selectionSet2: SelectionSetNode): SelectionSetNode {

--- a/packages/testing/utils.ts
+++ b/packages/testing/utils.ts
@@ -82,7 +82,7 @@ function findProjectDir(dirname: string): string | never {
     }
   }
 
-  throw new Error(`Coudn't find project's root from: ${originalDirname}`);
+  throw new Error(`Couldn't find project's root from: ${originalDirname}`);
 }
 
 export function mockGraphQLServer({

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Patch Changes
 
-- e53f97b3: fix(utils): provide { done: true } from iterator when complete is called on observer in obsvervableToAsyncIterable
+- e53f97b3: fix(utils): provide { done: true } from iterator when complete is called on observer in observableToAsyncIterable
 
 ## 7.2.5
 

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -137,7 +137,7 @@
 
   - The `transformRequest`/`transformResult` methods are now provided additional `delegationContext` and `transformationContext` arguments -- these were introduced in v6, but previously optional.
 
-  - The `transformSchema` method may wish to create additional delegating resolvers and so it is now provided the `subschemaConfig` and final (non-executable) `transformedSchema` parameters. As in v6, the `transformSchema` is kicked off once to produce the non-executable version, and then, if a wrapping schema is being generated, proxying resolvers are created with access to the (non-executabel) initial result. In v7, the individual `transformSchema` methods also get access to the result of the first run, if necessary, they can create additional wrapping schema proxying resolvers.
+  - The `transformSchema` method may wish to create additional delegating resolvers and so it is now provided the `subschemaConfig` and final (non-executable) `transformedSchema` parameters. As in v6, the `transformSchema` is kicked off once to produce the non-executable version, and then, if a wrapping schema is being generated, proxying resolvers are created with access to the (non-executable) initial result. In v7, the individual `transformSchema` methods also get access to the result of the first run, if necessary, they can create additional wrapping schema proxying resolvers.
 
   - `applySchemaTransforms` parameters have been updated to match and support the `transformSchema` parameters above.
 

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -66,7 +66,7 @@
 
 ### Patch Changes
 
-- cd5da458: fix(utils): fix crashs when return null while visitSchema
+- cd5da458: fix(utils): fix crashes when return null while visitSchema
 
 ## 7.1.5
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@graphql-tools/utils",
   "version": "7.2.6",
-  "description": "Common package containting utils and types for GraphQL tools",
+  "description": "Common package containing utils and types for GraphQL tools",
   "repository": {
     "type": "git",
     "url": "ardatan/graphql-tools",

--- a/packages/utils/src/SchemaDirectiveVisitor.ts
+++ b/packages/utils/src/SchemaDirectiveVisitor.ts
@@ -19,7 +19,7 @@ import { getArgumentValues } from './getArgumentValues';
 // registers interest in certain schema types, such as GraphQLObjectType,
 // GraphQLUnionType, etc. When SchemaDirectiveVisitor.visitSchemaDirectives is
 // called with a GraphQLSchema object and a map of visitor subclasses, the
-// overidden methods of those subclasses allow the visitors to obtain
+// overridden methods of those subclasses allow the visitors to obtain
 // references to any type objects that have @directives attached to them,
 // enabling visitors to inspect or modify the schema as appropriate.
 //

--- a/packages/utils/src/addTypes.ts
+++ b/packages/utils/src/addTypes.ts
@@ -19,7 +19,7 @@
 // Type recreation happens, for example, with every use of mapSchema, as the
 // types are always rewired. If fields are selected and removed using
 // mapSchema, adding those fields to a new type can no longer be simply done
-// by toConfig, as the types are not the identical Javascript objects, and
+// by toConfig, as the types are not the identical JavaScript objects, and
 // schema creation will fail with errors referencing multiple types with the
 // same names.
 //

--- a/packages/utils/src/visitSchema.ts
+++ b/packages/utils/src/visitSchema.ts
@@ -269,7 +269,7 @@ export function visitSchema(
   visit(schema);
 
   // Automatically update any references to named schema types replaced
-  // during the traversal, so implementors don't have to worry about that.
+  // during the traversal, so implementers don't have to worry about that.
   healSchema(schema);
 
   // Return schema for convenience, even though schema parameter has all updated types.

--- a/packages/utils/tests/__snapshots__/parse-graphql-sdl.spec.ts.snap
+++ b/packages/utils/tests/__snapshots__/parse-graphql-sdl.spec.ts.snap
@@ -43,7 +43,7 @@ enum Enum {
 \\"Union test\\"
 union Union = Type | OtherType
 
-\\"Inferface test\\"
+\\"Interface test\\"
 interface Node {
   id: ID!
 }
@@ -96,7 +96,7 @@ enum Enum {
 \\"Union test\\"
 union Union = Type | OtherType
 
-\\"Inferface test\\"
+\\"Interface test\\"
 interface Node {
   id: ID!
 }

--- a/packages/utils/tests/build-operation-node-for-field.spec.ts
+++ b/packages/utils/tests/build-operation-node-for-field.spec.ts
@@ -30,7 +30,7 @@ const schema = buildSchema(/* GraphQL */ `
     ingredients: [String!]!
   }
 
-  type CeaserSalad implements Salad {
+  type CaeserSalad implements Salad {
     ingredients: [String!]!
     additionalParmesan: Boolean!
   }
@@ -101,7 +101,7 @@ test('should work with Query', async () => {
               toppings
             }
             ... on Salad {
-              ... on CeaserSalad {
+              ... on CaeserSalad {
                 ingredients
                 additionalParmesan
               }
@@ -148,7 +148,7 @@ test('should work with Query and variables', async () => {
               toppings
             }
             ... on Salad {
-              ... on CeaserSalad {
+              ... on CaeserSalad {
                 ingredients
                 additionalParmesan
               }
@@ -185,7 +185,7 @@ test('should work with Query and complicated variable', async () => {
             toppings
           }
           ... on Salad {
-            ... on CeaserSalad {
+            ... on CaeserSalad {
               ingredients
               additionalParmesan
             }
@@ -218,7 +218,7 @@ test('should work with Union', async () => {
             toppings
           }
           ... on Salad {
-            ... on CeaserSalad {
+            ... on CaeserSalad {
               ingredients
               additionalParmesan
             }
@@ -246,7 +246,7 @@ test('should work with mutation', async () => {
     clean(/* GraphQL */ `
       mutation addSaladMutation($ingredients: [String!]!) {
         addSalad(ingredients: $ingredients) {
-          ... on CeaserSalad {
+          ... on CaeserSalad {
             ingredients
             additionalParmesan
           }
@@ -278,7 +278,7 @@ test('should work with mutation and unions', async () => {
             toppings
           }
           ... on Salad {
-            ... on CeaserSalad {
+            ... on CaeserSalad {
               ingredients
               additionalParmesan
             }
@@ -342,7 +342,7 @@ test('should be able to ignore using models when requested', async () => {
               toppings
             }
             ... on Salad {
-              ... on CeaserSalad {
+              ... on CaeserSalad {
                 ingredients
                 additionalParmesan
               }
@@ -380,7 +380,7 @@ test('should work with Subscription', async () => {
             toppings
           }
           ... on Salad {
-            ... on CeaserSalad {
+            ... on CaeserSalad {
               ingredients
               additionalParmesan
             }

--- a/packages/utils/tests/parse-graphql-sdl.spec.ts
+++ b/packages/utils/tests/parse-graphql-sdl.spec.ts
@@ -58,7 +58,7 @@ describe('parse sdl', () => {
       # Union test
       union Union = Type | OtherType
 
-      # Inferface test
+      # Interface test
       interface Node {
         id: ID!
       }

--- a/packages/utils/tests/print-schema-with-directives.spec.ts
+++ b/packages/utils/tests/print-schema-with-directives.spec.ts
@@ -184,7 +184,7 @@ describe('printSchemaWithDirectives', () => {
     expect(printedSchema).toContain(`type User @entity`);
   });
 
-  it('Should print types correctly if they dont have astNode', () => {
+  it(`Should print types correctly if they don't have astNode`, () => {
     const schema = makeExecutableSchema({
       typeDefs: `
       scalar JSON
@@ -218,7 +218,7 @@ describe('printSchemaWithDirectives', () => {
     expect(output).toContain('type Query');
   });
 
-  it('Should print directives correctly if they dont have astNode', () => {
+  it(`Should print directives correctly if they don't have astNode`, () => {
     const schema = new GraphQLSchema({
       directives: [new GraphQLDirective({
         name: 'dummy',

--- a/packages/utils/tests/print-schema-with-directives.spec.ts
+++ b/packages/utils/tests/print-schema-with-directives.spec.ts
@@ -6,7 +6,7 @@ import { printSchemaWithDirectives } from '../src';
 import { GraphQLJSON } from 'graphql-scalars';
 
 describe('printSchemaWithDirectives', () => {
-  it('Should print with directives, while printSchema doesnt', () => {
+  it(`Should print with directives, while printSchema doesn't`, () => {
     const schemaWithDirectives = buildSchema(/* GraphQL */ `
       directive @entity on OBJECT
       directive @id on FIELD_DEFINITION

--- a/packages/utils/tests/schemaTransforms.test.ts
+++ b/packages/utils/tests/schemaTransforms.test.ts
@@ -902,7 +902,7 @@ describe('@directives', () => {
   });
 
   test("can modify enum value's external value", () => {
-    function modfyExternalEnumValueDirective(directiveName: string): (schema: GraphQLSchema) => GraphQLSchema {
+    function modifyExternalEnumValueDirective(directiveName: string): (schema: GraphQLSchema) => GraphQLSchema {
       return schema => mapSchema(schema, {
         [MapperKind.ENUM_VALUE]: (enumValueConfig) => {
           const directives = getDirectives(schema, enumValueConfig);
@@ -928,7 +928,7 @@ describe('@directives', () => {
           LAPTOP @value(new: "COMPUTER")
         }
       `,
-      schemaTransforms: [modfyExternalEnumValueDirective('value')]
+      schemaTransforms: [modifyExternalEnumValueDirective('value')]
     });
 
     const Device = schema.getType('Device') as GraphQLEnumType;
@@ -940,7 +940,7 @@ describe('@directives', () => {
   });
 
   test("can modify enum value's internal value", () => {
-    function modfyInternalEnumValueDirective(directiveName: string): (schema: GraphQLSchema) => GraphQLSchema {
+    function modifyInternalEnumValueDirective(directiveName: string): (schema: GraphQLSchema) => GraphQLSchema {
       return schema => mapSchema(schema, {
         [MapperKind.ENUM_VALUE]: (enumValueConfig) => {
           const directives = getDirectives(schema, enumValueConfig);
@@ -967,7 +967,7 @@ describe('@directives', () => {
           LAPTOP @value(new: "COMPUTER")
         }
       `,
-      schemaTransforms: [modfyInternalEnumValueDirective('value')]
+      schemaTransforms: [modifyInternalEnumValueDirective('value')]
     });
 
     const Device = schema.getType('Device') as GraphQLEnumType;

--- a/packages/webpack-loader/tests/parser.test.ts
+++ b/packages/webpack-loader/tests/parser.test.ts
@@ -31,10 +31,10 @@ test('fragment spread', () => {
   const docStr = /* GraphQL */`
     query Foo {
       foo {
-        ...fooFrgmnt
+        ...fooFragment
       }
     }
-    fragment fooFrgmnt on Foo {
+    fragment fooFragment on Foo {
       id
     }
   `;

--- a/packages/wrap/CHANGELOG.md
+++ b/packages/wrap/CHANGELOG.md
@@ -66,7 +66,7 @@
 
   - The `transformRequest`/`transformResult` methods are now provided additional `delegationContext` and `transformationContext` arguments -- these were introduced in v6, but previously optional.
 
-  - The `transformSchema` method may wish to create additional delegating resolvers and so it is now provided the `subschemaConfig` and final (non-executable) `transformedSchema` parameters. As in v6, the `transformSchema` is kicked off once to produce the non-executable version, and then, if a wrapping schema is being generated, proxying resolvers are created with access to the (non-executabel) initial result. In v7, the individual `transformSchema` methods also get access to the result of the first run, if necessary, they can create additional wrapping schema proxying resolvers.
+  - The `transformSchema` method may wish to create additional delegating resolvers and so it is now provided the `subschemaConfig` and final (non-executable) `transformedSchema` parameters. As in v6, the `transformSchema` is kicked off once to produce the non-executable version, and then, if a wrapping schema is being generated, proxying resolvers are created with access to the (non-executable) initial result. In v7, the individual `transformSchema` methods also get access to the result of the first run, if necessary, they can create additional wrapping schema proxying resolvers.
 
   - `applySchemaTransforms` parameters have been updated to match and support the `transformSchema` parameters above.
 

--- a/packages/wrap/src/introspect.ts
+++ b/packages/wrap/src/introspect.ts
@@ -44,7 +44,7 @@ export function introspectSchema<TExecutor extends AsyncExecutor | SyncExecutor>
   return getSchemaFromIntrospection(introspectionResult) as any;
 }
 
-// Keep for backwards compability. Will be removed on next release.
+// Keep for backwards compatibility. Will be removed on next release.
 export function introspectSchemaSync(
   executor: SyncExecutor,
   context?: Record<string, any>,

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -13,7 +13,7 @@ Even though we recommend a specific way of building GraphQL servers, you can use
 
 If you want to bind your JavaScript GraphQL schema to an HTTP server, you can use [`express-graphql`](https://github.com/graphql/express-graphql).
 
-You can develop your Javascript based GraphQL API with `graphql-tools` and `express-graphql` together: One to write the schema and resolver code, and the other to connect it to a web server.
+You can develop your JavaScript based GraphQL API with `graphql-tools` and `express-graphql` together: One to write the schema and resolver code, and the other to connect it to a web server.
 
 ## The GraphQL-first philosophy
 

--- a/website/docs/legacy-schema-directives.md
+++ b/website/docs/legacy-schema-directives.md
@@ -608,7 +608,7 @@ type User @auth(requires: USER) {
 
 This hypothetical `@auth` directive takes an argument named `requires` of type `Role`, which defaults to `ADMIN` if `@auth` is used without passing an explicit `requires` argument. The `@auth` directive can appear on an `OBJECT` like `User` to set a default access control for all `User` fields, and also on individual fields, to enforce field-specific `@auth` restrictions.
 
-Enforcing the requirements of the declaration is something a `SchemaDirectiveVisitor` implementation could do itself, in theory, but the SDL syntax is easer to read and write, and provides value even if you're not using the `SchemaDirectiveVisitor` abstraction.
+Enforcing the requirements of the declaration is something a `SchemaDirectiveVisitor` implementation could do itself, in theory, but the SDL syntax is easier to read and write, and provides value even if you're not using the `SchemaDirectiveVisitor` abstraction.
 
 However, if you're implementing a reusable `SchemaDirectiveVisitor` for public consumption, you will probably not be the person writing the SDL syntax, so you may not have control over which directives the schema author decides to declare, and how. That's why a well-implemented, reusable `SchemaDirectiveVisitor` should consider overriding the `getDirectiveDeclaration` method:
 

--- a/website/docs/migration-from-tools.md
+++ b/website/docs/migration-from-tools.md
@@ -23,7 +23,7 @@ If you are using GraphQL Tools v6, there are several breaking changes to be awar
 
 - The `transformRequest`/`transformResult` methods are now provided additional `delegationContext` and `transformationContext` arguments -- these were introduced in v6, but previously optional.
 
-- The `transformSchema` method may wish to create additional delegating resolvers and so it is now provided the `subschemaConfig` and final (non-executable) `transformedSchema` parameters. As in v6, the `transformSchema` is kicked off once to produce the non-executable version, and then, if a wrapping schema is being generated, proxying resolvers are created with access to the (non-executabel) initial result. In v7, the individual `transformSchema` methods also get access to the result of the first run, if necessary, they can create additional wrapping schema proxying resolvers.
+- The `transformSchema` method may wish to create additional delegating resolvers and so it is now provided the `subschemaConfig` and final (non-executable) `transformedSchema` parameters. As in v6, the `transformSchema` is kicked off once to produce the non-executable version, and then, if a wrapping schema is being generated, proxying resolvers are created with access to the (non-executable) initial result. In v7, the individual `transformSchema` methods also get access to the result of the first run, if necessary, they can create additional wrapping schema proxying resolvers.
 
 - `applySchemaTransforms` parameters have been updated to match and support the `transformSchema` parameters above.
 

--- a/website/docs/migration-from-tools.md
+++ b/website/docs/migration-from-tools.md
@@ -67,7 +67,7 @@ If you are using GraphQL Tools v6, there are several breaking changes to be awar
 
 ## Upgrading from v4/v5
 
-If you are using GraphQL Tools v4/v5, additioanl changes are necessary.
+If you are using GraphQL Tools v4/v5, additional changes are necessary.
 
 #### Monorepo design
 

--- a/website/docs/mocking.md
+++ b/website/docs/mocking.md
@@ -397,7 +397,7 @@ const store = createMockStore({ schema });
 const schemaWithMocks = addMocksToSchema({ schema, store });
 ```
 
-The content is accessible and modifiabale via the methods `get` and `set` of the `MockStore`. These methods have several signatures (see [their typing](https://github.com/ardatan/graphql-tools/blob/master/packages/mock/src/types.ts))
+The content is accessible and modifiable via the methods `get` and `set` of the `MockStore`. These methods have several signatures (see [their typing](https://github.com/ardatan/graphql-tools/blob/master/packages/mock/src/types.ts))
 but here are some examples:
 
 #### get

--- a/website/docs/mocking.md
+++ b/website/docs/mocking.md
@@ -444,7 +444,7 @@ store.get('User', 'abc-737dh-djdjd')
 > { $ref: { key: 'abc-737dh-djdjd', typeName: 'User' } }
 ```
 
-Root types (`Query`, `Mutation`), which necessarely have only one entity, will use the special store key `ROOT` to reference this only entity:
+Root types (`Query`, `Mutation`), which necessarily have only one entity, will use the special store key `ROOT` to reference this only entity:
 
 ```ts
 store.get('Query', 'ROOT', 'viewer');

--- a/website/docs/mocking.md
+++ b/website/docs/mocking.md
@@ -372,7 +372,7 @@ your query with variables. **Note**: when executing queries from the returned se
 
 ### MockStore
 
-The `MockStore` is holding the generated mocks and can be used to acess, generate or alter mocked values.
+The `MockStore` is holding the generated mocks and can be used to access, generate or alter mocked values.
 
 You can access the `MockStore` either as argument of `resolvers` option of `addMocksToSchema`:
 

--- a/website/docs/mocking.md
+++ b/website/docs/mocking.md
@@ -483,7 +483,7 @@ Set a field value via graph traversal (nested set):
 ```ts
 store.get('Query', 'ROOT', {
   viewer: {
-    name: 'Alexamdre',
+    name: 'Alexandre',
     friends: [
       { name: 'Emily' },
       { name: 'Caroline' }

--- a/website/docs/mocking.md
+++ b/website/docs/mocking.md
@@ -156,7 +156,7 @@ const mocks = {
 }
 ```
 
-### Appplying mutations
+### Applying mutations
 
 Use `resolvers` option of `addMocksToSchema` to implement custom resolvers that interact with the [`MockStore`](#mockstore), especially to mutate field values.
 

--- a/website/docs/remote-schemas.md
+++ b/website/docs/remote-schemas.md
@@ -240,7 +240,7 @@ export function defaultCreateProxyingResolver({
 }
 ```
 
-Parentheticaly, note that that `args` from the root field resolver are not directly passed to the target schema. These arguments have already been parsed into their corresponding internal values by the GraphQL execution algorithm. The correct, serialized form of the arguments are available within the `info` object, ready for proxying. Specifying the `args` property for `delegateToSchema` allows one to pass *additional* arguments to the target schema, which is not necessary when creating a simple proxying schema.
+Parenthetically, note that that `args` from the root field resolver are not directly passed to the target schema. These arguments have already been parsed into their corresponding internal values by the GraphQL execution algorithm. The correct, serialized form of the arguments are available within the `info` object, ready for proxying. Specifying the `args` property for `delegateToSchema` allows one to pass *additional* arguments to the target schema, which is not necessary when creating a simple proxying schema.
 
 The above can can all be put together like this:
 

--- a/website/docs/remote-schemas.md
+++ b/website/docs/remote-schemas.md
@@ -20,7 +20,7 @@ Generally, to create a remote schema, you generally need just three steps:
 2. Use [`introspectSchema`](#introspectschemaexecutor-context) to get the non-executable schema of the remote server
 3. Use [`wrapSchema`](#wrapschemaschemaconfig) to create a schema that uses the executor to delegate requests to the underlying service
 
-You can optionally also include a [subscriber](#creating-a-subscriber) that can retrieve real time subcription results from the remote schema (only if you are using GraphQL Subscriptions)
+You can optionally also include a [subscriber](#creating-a-subscriber) that can retrieve real time subscription results from the remote schema (only if you are using GraphQL Subscriptions)
 
 ### Creating an executor
 

--- a/website/docs/remote-schemas.md
+++ b/website/docs/remote-schemas.md
@@ -191,7 +191,7 @@ const schema = await introspectSchema(executor);
 
 ### wrapSchema(schemaConfig)
 
-`wrapSchema` comes most in handly when wrapping a remote schema. When using the function to wrap a remote schema, it takes a single object: an subschema configuration object with properties describing how the schema should be accessed and wrapped. The `schema` and `executor` options are required.
+`wrapSchema` comes most in handy when wrapping a remote schema. When using the function to wrap a remote schema, it takes a single object: an subschema configuration object with properties describing how the schema should be accessed and wrapped. The `schema` and `executor` options are required.
 
 ```js
 import { wrapSchema } from '@graphql-tools/wrap';

--- a/website/docs/resolvers.md
+++ b/website/docs/resolvers.md
@@ -187,7 +187,7 @@ export interface IAddResolveFunctionsToSchemaOptions {
 }
 ```
 
-Additonally, the `updateResolversInPlace` property, when set to true, changes `addResolversToSchema` behavior to modify the original schema in place without recreating it. By default, a new schema will be returned without modification of the original schema.
+Additionally, the `updateResolversInPlace` property, when set to true, changes `addResolversToSchema` behavior to modify the original schema in place without recreating it. By default, a new schema will be returned without modification of the original schema.
 
 ### addSchemaLevelResolver(schema, rootResolveFunction)
 

--- a/website/docs/schema-delegation.md
+++ b/website/docs/schema-delegation.md
@@ -190,7 +190,7 @@ const resolvers = {
 
 #### context: Record<string, any>
 
-GraphQL context that is going to be passed to the subschema execution or subsciption call.
+GraphQL context that is going to be passed to the subschema execution or subscription call.
 
 #### info: GraphQLResolveInfo
 

--- a/website/docs/schema-loading.md
+++ b/website/docs/schema-loading.md
@@ -14,7 +14,7 @@ The user is given the option of implementing their own loader (implement the int
 
 The schema loading util is using loaders, and implemented using [chain-of-responsibility pattern](https://en.wikipedia.org/wiki/Chain-of-responsibility_pattern).
 
-Specifiying the loader is not necessary. The user need only provide the inputs. The utils will detect it automatically.
+Specifying the loader is not necessary. The user need only provide the inputs. The utils will detect it automatically.
 
 ## Usage
 

--- a/website/docs/schema-merging.md
+++ b/website/docs/schema-merging.md
@@ -357,7 +357,7 @@ const resolversArray = loadFilesSync(path.join(__dirname, './resolvers'));
 module.exports = mergeResolvers(resolversArray);
 ```
 
-> Beware that `mergeResolvers` is simply merging plain Javascript objects together.
+> Beware that `mergeResolvers` is simply merging plain JavaScript objects together.
 This means that you should be careful with Queries, Mutations or Subscriptions with naming conflicts.
 
 You can also load files with specified extensions by setting the extensions option.

--- a/website/docs/schema-wrapping.md
+++ b/website/docs/schema-wrapping.md
@@ -4,7 +4,7 @@ title: Schema wrapping
 description: Wrap schemas to automatically modify schemas, requests and results
 ---
 
-Schema wrapping (`@graphql-tools/wrap`) creates a modified version of a schema that proxies, or "wraps", the original unmodified schema. This technique is particularily useful when the original schema _cannot_ be changed, such as with [remote schemas](/docs/remote-schemas/).
+Schema wrapping (`@graphql-tools/wrap`) creates a modified version of a schema that proxies, or "wraps", the original unmodified schema. This technique is particularly useful when the original schema _cannot_ be changed, such as with [remote schemas](/docs/remote-schemas/).
 
 Schema wrapping works by creating a new "gateway" schema that simply delegates all operations to the original subschema. A series of _transforms_ are applied that may modify the shape of the gateway schema and all proxied operations; these operational transforms may modify an operation prior to delegation, or modify the subschema result prior to its return.
 

--- a/website/docs/schema-wrapping.md
+++ b/website/docs/schema-wrapping.md
@@ -263,9 +263,9 @@ transforms: [
 
 Custom transforms are fairly straightforward to write. They are simply objects with up to three methods:
 
-- `transformSchema`: recieves the original subschema and applies modifications to it, returning a modified wrapper (proxy) schema. This method runs once while initially wrapping the subschema.
-- `transformRequest`: recieves each request made to the wrapped schema. The shape of a request matches the wrapper schema, and must be returned in a shape that matches the original subschema.
-- `transformResult`: recieves each result returned from the original subschema. The shape of the result matches the original subschema, and must be returned in a shape that matches the wrapper schema.
+- `transformSchema`: receives the original subschema and applies modifications to it, returning a modified wrapper (proxy) schema. This method runs once while initially wrapping the subschema.
+- `transformRequest`: receives each request made to the wrapped schema. The shape of a request matches the wrapper schema, and must be returned in a shape that matches the original subschema.
+- `transformResult`: receives each result returned from the original subschema. The shape of the result matches the original subschema, and must be returned in a shape that matches the wrapper schema.
 
 The complete transform object API is as follows:
 

--- a/website/docs/schema-wrapping.md
+++ b/website/docs/schema-wrapping.md
@@ -333,7 +333,7 @@ const schema = wrapSchema({
 
 The `wrapSchema` method will produce a new schema with all queued `transformSchema` methods applied. Delegating resolvers are automatically generated to map from new schema root fields to old schema root fields. These resolvers should be sufficient for most common case so you don't have to implement your own.
 
-Delegating resolvers will apply all operation transforms defined by the wrapper's `Transform` objects. Each provided `transformRequest` functions will be applies in reverse order, until the request matches the original schema. The `tranformResult` functions will be applied in the opposite order until the result matches the final gateway schema.
+Delegating resolvers will apply all operation transforms defined by the wrapper's `Transform` objects. Each provided `transformRequest` functions will be applies in reverse order, until the request matches the original schema. The `transformResult` functions will be applied in the opposite order until the result matches the final gateway schema.
 
 In advanced cases, transforms may wish to create additional delegating root resolvers (for example, when hoisting a field into a root type). This is also possible. The wrapping schema is actually generated twice -- the first run results in a possibly non-executable version, while the second execution also includes the result of the first one within the `transformedSchema` argument so that an executable version with any new proxying resolvers can be created.
 

--- a/website/docs/stitch-schema-extensions.md
+++ b/website/docs/stitch-schema-extensions.md
@@ -148,7 +148,7 @@ Post: {
 },
 ```
 
-The `selectionSet` specifies the key field(s) needed from an object to query for its associations. For example, `Post.user` will require that a Post provide its `userId`. Rather than relying on incoming queries to manually request this key for the association, the selection set will automatically be included in subschema requests to guarentee that these fields are fetched. Dynamic selection sets are also possible by providing a function that receives a GraphQL `FieldNode` (the gateway field) and returns a `SelectionSetNode`.
+The `selectionSet` specifies the key field(s) needed from an object to query for its associations. For example, `Post.user` will require that a Post provide its `userId`. Rather than relying on incoming queries to manually request this key for the association, the selection set will automatically be included in subschema requests to guarantee that these fields are fetched. Dynamic selection sets are also possible by providing a function that receives a GraphQL `FieldNode` (the gateway field) and returns a `SelectionSetNode`.
 
 ### resolve
 

--- a/website/docs/stitch-schema-extensions.md
+++ b/website/docs/stitch-schema-extensions.md
@@ -79,7 +79,7 @@ export const schema = stitchSchemas({
 });
 ```
 
-The `typeDefs` option provides type extentions (using the `extend` keyword) that add additional fields into the _combined_ gateway schema, and therefore may cross-reference types from any subschema.
+The `typeDefs` option provides type extensions (using the `extend` keyword) that add additional fields into the _combined_ gateway schema, and therefore may cross-reference types from any subschema.
 
 However, these extensions alone won't do anything until they have corresponding resolvers. A complete example would look like this:
 

--- a/website/docs/stitch-type-merging.md
+++ b/website/docs/stitch-type-merging.md
@@ -488,7 +488,7 @@ If you're familiar with [Apollo Federation](https://www.apollographql.com/docs/a
 
 ## Canonical definitions
 
-Managing the gateway schema definition of each type and field becomes challenging as the same type names are introduced across subschemas. By default, the final definition of each named GraphQL element found in the stitched `subschemas` array provides its gateway definition. However, preferred definitions may be marked as `canonical` to recieve this final priority. Canonical definitions provide:
+Managing the gateway schema definition of each type and field becomes challenging as the same type names are introduced across subschemas. By default, the final definition of each named GraphQL element found in the stitched `subschemas` array provides its gateway definition. However, preferred definitions may be marked as `canonical` to receive this final priority. Canonical definitions provide:
 
 - an element's description (doc string).
 - an element's final directive values.


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #2597 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

https://github.com/jsoref/graphql-tools/commit/0a1de9e446d50ed1f248fd7c1a6170e25c2828c7#commitcomment-47151431

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] [Check Spelling Action](https://github.com/jsoref/graphql-tools/runs/1905567147?check_suite_focus=true) ([configuration](https://github.com/jsoref/graphql-tools/commit/0a1de9e446d50ed1f248fd7c1a6170e25c2828c7))

**Test Environment**:
- OS: Ubuntu 18.04.5 LTS
- `@graphql-tools/...`: 55d983a
- NodeJS:

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project -- This link is to a hypothetical document that does not exist -- see https://github.com/the-guild-org/Stack/tree/f7d539619092a2ce7fb713407c1406339de5f953 and https://github.com/the-guild-org/Stack/pull/9#issuecomment-778339770
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

I make individual commits by word family as generally objections are by family and it makes it much easier to rebase (this PR required a rebase and one resolution even before I posted it). I can trivially drop files by path or kind, just let me know. If you want things split by module / category (e.g. comments), let me know, depending on the slice, it may require more or less time/effort.