### PR TITLE
Small refactor and fixes in printSchemaWithDirectives and improvements in other packages

### DIFF
--- a/.changeset/heavy-peaches-search.md
+++ b/.changeset/heavy-peaches-search.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/utils': patch
+---
+
+fix(utils): fix missing default value of input object type field

--- a/.changeset/sweet-humans-draw.md
+++ b/.changeset/sweet-humans-draw.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/utils': minor
+---
+
+enhance(utils): Extract getDocumentNodeFromSchema from printSchemaWithDirectives

--- a/.changeset/young-chairs-float.md
+++ b/.changeset/young-chairs-float.md
@@ -1,0 +1,7 @@
+---
+'@graphql-tools/load': patch
+'@graphql-tools/module-loader': patch
+'@graphql-tools/merge': patch
+---
+
+enhance(load/module-loader/merge): use getDocumentNodeFromSchema instead of parse and printSchemaWithDirectives together

--- a/packages/load/package.json
+++ b/packages/load/package.json
@@ -26,7 +26,7 @@
     "graphql-type-json": "0.3.2"
   },
   "dependencies": {
-    "@graphql-tools/utils": "^7.0.0",
+    "@graphql-tools/utils": "^7.3.0",
     "@graphql-tools/merge": "^6.2.5",
     "globby": "11.0.2",
     "import-from": "3.0.0",

--- a/packages/load/src/load-typedefs/collect-sources.ts
+++ b/packages/load/src/load-typedefs/collect-sources.ts
@@ -1,5 +1,5 @@
-import { Source, isDocumentString, parseGraphQLSDL, asArray, printSchemaWithDirectives } from '@graphql-tools/utils';
-import { isSchema, Kind, parse } from 'graphql';
+import { Source, isDocumentString, parseGraphQLSDL, asArray, getDocumentNodeFromSchema } from '@graphql-tools/utils';
+import { isSchema, Kind } from 'graphql';
 import isGlob from 'is-glob';
 import { LoadTypedefsOptions } from '../load-typedefs';
 import { loadFile, loadFileSync } from './load-file';
@@ -296,7 +296,7 @@ function addResultOfCustomLoader({
       source: {
         location: pointer,
         schema: result,
-        document: parse(printSchemaWithDirectives(result)),
+        document: getDocumentNodeFromSchema(result),
       },
       pointer,
       noCache: true,

--- a/packages/loaders/module/package.json
+++ b/packages/loaders/module/package.json
@@ -20,7 +20,7 @@
     "graphql": "^14.0.0 || ^15.0.0"
   },
   "dependencies": {
-    "@graphql-tools/utils": "^7.0.0",
+    "@graphql-tools/utils": "^7.3.0",
     "tslib": "~2.1.0"
   },
   "publishConfig": {

--- a/packages/loaders/module/src/index.ts
+++ b/packages/loaders/module/src/index.ts
@@ -2,7 +2,7 @@ import { parse, isSchema } from 'graphql';
 import {
   UniversalLoader,
   fixSchemaAst,
-  printSchemaWithDirectives,
+  getDocumentNodeFromSchema,
   SingleFileOptions,
   Source,
 } from '@graphql-tools/utils';
@@ -86,7 +86,7 @@ export class ModuleLoader implements UniversalLoader {
       return {
         schema,
         get document() {
-          return parse(printSchemaWithDirectives(schema, options));
+          return getDocumentNodeFromSchema(schema);
         },
         location: pointer,
       };

--- a/packages/merge/package.json
+++ b/packages/merge/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@graphql-tools/schema": "^7.0.0",
-    "@graphql-tools/utils": "^7.0.0",
+    "@graphql-tools/utils": "^7.3.0",
     "tslib": "~2.1.0"
   },
   "publishConfig": {

--- a/packages/merge/src/typedefs-mergers/merge-typedefs.ts
+++ b/packages/merge/src/typedefs-mergers/merge-typedefs.ts
@@ -2,7 +2,7 @@ import { DefinitionNode, DocumentNode, GraphQLSchema, parse, Source, Kind, isSch
 import { isSourceTypes, isStringTypes, isSchemaDefinition } from './utils';
 import { MergedResultMap, mergeGraphQLNodes } from './merge-nodes';
 import { resetComments, printWithComments } from './comments';
-import { createSchemaDefinition, printSchemaWithDirectives } from '@graphql-tools/utils';
+import { createSchemaDefinition, getDocumentNodeFromSchema } from '@graphql-tools/utils';
 
 type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
 type CompareFn<T> = (a: T, b: T) => number;
@@ -115,7 +115,7 @@ export function mergeGraphQLTypes(
         type = mergeTypeDefs(type);
       }
       if (isSchema(type)) {
-        return parse(printSchemaWithDirectives(type));
+        return getDocumentNodeFromSchema(type);
       } else if (isStringTypes(type) || isSourceTypes(type)) {
         return parse(type);
       }

--- a/packages/utils/src/isDocumentNode.ts
+++ b/packages/utils/src/isDocumentNode.ts
@@ -1,5 +1,5 @@
-import { ASTNode, DocumentNode } from 'graphql';
+import { DocumentNode, Kind } from 'graphql';
 
 export function isDocumentNode(object: any): object is DocumentNode {
-  return (object as ASTNode).kind !== undefined;
+  return object && typeof object === 'object' && 'kind' in object && object.kind === Kind.DOCUMENT;
 }

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -12,9 +12,11 @@ export interface SchemaPrintOptions {
   commentDescriptions?: boolean;
 }
 
-export interface PrintSchemaWithDirectivesOptions extends SchemaPrintOptions {
+export interface GetDocumentNodeFromSchemaOptions {
   pathToDirectivesInExtensions?: Array<string>;
 }
+
+export type PrintSchemaWithDirectivesOptions = SchemaPrintOptions & GetDocumentNodeFromSchemaOptions;
 
 export type Maybe<T> = null | undefined | T;
 

--- a/packages/utils/tests/print-schema-with-directives.spec.ts
+++ b/packages/utils/tests/print-schema-with-directives.spec.ts
@@ -319,6 +319,7 @@ describe('printSchemaWithDirectives', () => {
 
         input SomeInputType @INPUT_OBJECT {
           someInputField: String @INPUT_FIELD_DEFINITION
+          someOtherInputField: Int = 1
         }
     `;
     const schema = buildSchema(typeDefs);


### PR DESCRIPTION
- Instead of printing every single generated astNode, collect all astNode to create a `DocumentNode` and print it
- Extract that code to another function that creates `DocumentNode` from `GraphQLSchema` -> `getDocumentNodeFromSchema`
- Replace `parse(printSchemaWithDirectives(` with new `getDocumentNodeFromSchema`
- Take `defaultValue` of an input value while creating astNode from the field of GraphQLInputObjectType; Related #2610
