### PR TITLE
fix(load-files): fix ignored file bug when filename finishes with ext…

### DIFF
--- a/packages/load-files/src/index.ts
+++ b/packages/load-files/src/index.ts
@@ -141,7 +141,7 @@ export function loadFilesSync<T = any>(
 
       const extension = extname(path);
 
-      if (extension.endsWith('.js') || extension.endsWith('.ts') || execOptions.useRequire) {
+      if (extension === '.js' || extension === '.ts' || execOptions.useRequire) {
         const fileExports = (execOptions.requireMethod ? execOptions.requireMethod : require)(path);
         const extractedExport = extractExports(fileExports, execOptions.exportNames);
 
@@ -187,7 +187,7 @@ const checkExtension = (
 ) => {
   if (ignoredExtensions) {
     for (const ignoredExtension of ignoredExtensions) {
-      if (path.endsWith(ignoredExtension)) {
+      if (path.endsWith(`.${ignoredExtension}`)) {
         return false;
       }
     }
@@ -198,7 +198,7 @@ const checkExtension = (
   }
 
   for (const extension of extensions) {
-    if (path.endsWith(extension)) {
+    if (path.endsWith(`.${extension}`)) {
       return true;
     }
   }

--- a/packages/load-files/tests/file-scanner.spec.ts
+++ b/packages/load-files/tests/file-scanner.spec.ts
@@ -1,16 +1,22 @@
-import { loadFilesSync, loadFiles } from '@graphql-tools/load-files';
+import { loadFilesSync, loadFiles, LoadFilesOptions } from '@graphql-tools/load-files';
 import { print } from 'graphql';
 
-function testSchemaDir({ path, expected, note, extensions, ignoreIndex }: { path: string; expected: any; note: string; extensions?: string[] | null; ignoreIndex?: boolean }) {
-  it(`SYNC: should return the correct schema results for path: ${path} (${note})`, () => {
-    const options = {
+function testSchemaDir({ path, expected, note, extensions, ignoreIndex }: TestDirOptions) {
+  let options: LoadFilesOptions;
+
+  beforeEach(() => {
+    options = {
       ignoreIndex,
       globOptions: {
         cwd: __dirname
       },
       requireMethod: jest.requireActual,
+      ...(extensions && { extensions }),
     };
-    const result = loadFilesSync(path, extensions ? { ...options, extensions } : options);
+  });
+
+  it(`SYNC: should return the correct schema results for path: ${path} (${note})`, () => {
+    const result = loadFilesSync(path, options);
 
     expect(result.length).toBe(expected.length);
     expect(result.map(res => {
@@ -22,14 +28,7 @@ function testSchemaDir({ path, expected, note, extensions, ignoreIndex }: { path
   });
 
   it(`ASYNC: should return the correct schema results for path: ${path} (${note})`, async () => {
-    const options = {
-      ignoreIndex,
-      globOptions: {
-        cwd: __dirname
-      },
-      requireMethod: jest.requireActual,
-    };
-    const result = await loadFiles(path, extensions ? { ...options, extensions } : options);
+    const result = await loadFiles(path, options);
 
     expect(result.length).toBe(expected.length);
     expect(result.map(res => {
@@ -41,20 +40,26 @@ function testSchemaDir({ path, expected, note, extensions, ignoreIndex }: { path
   });
 }
 
-function testResolversDir({ path, expected, note, extensions, compareValue, ignoreIndex }: { path: string; expected: any; note: string; extensions?: string[]; compareValue?: boolean; ignoreIndex?: boolean }) {
+function testResolversDir({ path, expected, note, extensions, compareValue, ignoreIndex, ignoredExtensions }: TestDirOptions) {
   if (typeof compareValue === 'undefined') {
     compareValue = true;
   }
+  let options: LoadFilesOptions;
 
-  it(`SYNC: should return the correct resolvers results for path: ${path} (${note})`, () => {
-    const options = {
+  beforeEach(() => {
+    options = {
       ignoreIndex,
       globOptions: {
         cwd: __dirname
       },
       requireMethod: jest.requireActual,
+      ...(extensions && { extensions }),
+      ...(ignoredExtensions && { ignoredExtensions }),
     };
-    const result = loadFilesSync(path, extensions ? { ...options, extensions } : options);
+  });
+
+  it(`SYNC: should return the correct resolvers results for path: ${path} (${note})`, () => {
+    const result = loadFilesSync(path, options);
 
     expect(result.length).toBe(expected.length);
 
@@ -64,14 +69,7 @@ function testResolversDir({ path, expected, note, extensions, compareValue, igno
   });
 
   it(`ASYNC: should return the correct resolvers results for path: ${path} (${note})`, async () => {
-    const options = {
-      ignoreIndex,
-      globOptions: {
-        cwd: __dirname
-      },
-      requireMethod: jest.requireActual,
-    };
-    const result = await loadFiles(path, extensions ? { ...options, extensions } : options);
+    const result = await loadFiles(path, options);
 
     expect(result.length).toBe(expected.length);
 
@@ -215,5 +213,27 @@ describe('file scanner', function() {
       expected: [{ MyType: { f: 1 } }],
       note: 'non-directory pattern',
     });
+    testResolversDir({
+      path: './test-assets/6/*.resolvers.js',
+      expected: [{ MyType: { f: 1 } }],
+      note: 'non-directory pattern',
+    });
+    testResolversDir({
+      path: './test-assets/13',
+      extensions: ['js'],
+      ignoredExtensions: ['s.js'],
+      expected: [{ MyType: { f: 1 } }],
+      note: 'include path finishing in s.js but do not include paths finishing in .s.js',
+    });
   });
 });
+
+interface TestDirOptions {
+  path: string;
+  expected: any;
+  note: string;
+  extensions?: string[];
+  compareValue?: boolean;
+  ignoreIndex?: boolean;
+  ignoredExtensions?: string[];
+}

--- a/packages/load-files/tests/file-scanner.spec.ts
+++ b/packages/load-files/tests/file-scanner.spec.ts
@@ -214,11 +214,6 @@ describe('file scanner', function() {
       note: 'non-directory pattern',
     });
     testResolversDir({
-      path: './test-assets/6/*.resolvers.js',
-      expected: [{ MyType: { f: 1 } }],
-      note: 'non-directory pattern',
-    });
-    testResolversDir({
       path: './test-assets/13',
       extensions: ['js'],
       ignoredExtensions: ['s.js'],

--- a/packages/load-files/tests/test-assets/13/1.a.b.resolvers.js
+++ b/packages/load-files/tests/test-assets/13/1.a.b.resolvers.js
@@ -1,0 +1,7 @@
+const resolvers = {
+  MyType: {
+    f: 1,
+  },
+};
+
+module.exports = resolvers;

--- a/packages/load-files/tests/test-assets/13/1.a.b.resolvers.s.js
+++ b/packages/load-files/tests/test-assets/13/1.a.b.resolvers.s.js
@@ -1,0 +1,7 @@
+const resolvers = {
+  MyType: {
+    f: 1,
+  },
+};
+
+module.exports = resolvers;


### PR DESCRIPTION
fix ignored file bug when filename finishes with extension

<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

## Description

We add a `.` before the `ignoredExtension` to make sure that we check only for extensions and not for part of the filename

Related #2652

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Added unit tests to the package
- Tests are passing with the changes and failing without.

**Test Environment**:
- OS: MacOS
- `@graphql-tools/...`: 6.2.3
- NodeJS: 14.15.5

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules