### PR TITLE
Fix pruneSchema with unused interfaces

### DIFF
--- a/packages/utils/src/prune.ts
+++ b/packages/utils/src/prune.ts
@@ -76,10 +76,11 @@ export function pruneSchema(schema: GraphQLSchema, options: PruneSchemaOptions =
           return null;
         }
       } else if (isInterfaceType(type)) {
+        const implementations = pruningContext.implementations[type.name] || {};
+
         if (
           (!Object.keys(type.getFields()).length && !options.skipEmptyCompositeTypePruning) ||
-          (!Object.keys(pruningContext.implementations[type.name]).length &&
-            !options.skipUnimplementedInterfacesPruning) ||
+          (!Object.keys(implementations).length && !options.skipUnimplementedInterfacesPruning) ||
           (pruningContext.unusedTypes[type.name] && !options.skipUnusedTypesPruning)
         ) {
           return null;

--- a/packages/utils/tests/prune.test.ts
+++ b/packages/utils/tests/prune.test.ts
@@ -1,5 +1,4 @@
 import { buildSchema } from 'graphql';
-
 import { pruneSchema } from '../src/prune';
 
 describe('prune', () => {
@@ -14,5 +13,121 @@ describe('prune', () => {
       }
       `);
     pruneSchema(schema);
+  });
+
+  test('removes unused enums', () => {
+    const schema = buildSchema(`
+      enum Unused {
+        VALUE
+      }
+
+      type Query {
+        foo: Boolean
+      }
+      `);
+    const result = pruneSchema(schema);
+    expect(result.getType('Unused')).toBeUndefined();
+  });
+
+  test('removes unused objects', () => {
+    const schema = buildSchema(`
+      type Unused {
+        value: String
+      }
+
+      type Query {
+        foo: Boolean
+      }
+      `);
+    const result = pruneSchema(schema);
+    expect(result.getType('Unused')).toBeUndefined();
+  });
+
+  test('removes unused input objects', () => {
+    const schema = buildSchema(`
+      input Unused {
+        value: String
+      }
+
+      type Query {
+        foo: Boolean
+      }
+      `);
+    const result = pruneSchema(schema);
+    expect(result.getType('Unused')).toBeUndefined();
+  });
+
+  test('removes unused unions', () => {
+    const schema = buildSchema(`
+      union Unused
+
+      type Query {
+        foo: Boolean
+      }
+      `);
+    const result = pruneSchema(schema);
+    expect(result.getType('Unused')).toBeUndefined();
+  });
+
+  test('removes unused interfaces', () => {
+    const schema = buildSchema(`
+      interface Unused {
+        value: String
+      }
+
+      type Query {
+        foo: Boolean
+      }
+      `);
+    const result = pruneSchema(schema);
+    expect(result.getType('Unused')).toBeUndefined();
+  });
+
+  test('removes top level objects with no fields', () => {
+    const schema = buildSchema(`
+      type Query {
+        foo: Boolean
+      }
+      
+      type Mutation
+      `);
+    const result = pruneSchema(schema);
+    expect(result.getMutationType()).toBeUndefined();
+  });
+
+  test('removes unused interfaces when implementations are unused', () => {
+    const schema = buildSchema(`
+      interface UnusedInterface {
+        value: String
+      }
+      
+      type UnusedType implements UnusedInterface {
+        value: String
+      }
+
+      type Query {
+        foo: Boolean
+      }
+      `);
+    const result = pruneSchema(schema);
+    expect(result.getType('UnusedType')).toBeUndefined();
+    expect(result.getType('UnusedInterface')).toBeUndefined();
+  });
+
+  test('removes unused unions when implementations are unused', () => {
+    const schema = buildSchema(`
+      union UnusedUnion = UnusedType
+      
+      type UnusedType {
+        value: String
+      }
+
+      type Query {
+        foo: Boolean
+      }
+      `);
+    const result = pruneSchema(schema);
+    expect(result.getType('UnusedType')).toBeUndefined();
+    expect(result.getType('UnusedUnion')).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Description

`pruneSchema` blows up with a schema with an unused interface is passed in.

This is a valid schema but an exception is thrown when passing it to `pruneSchema`

```graphql
interface Unused {
    value: String
}

type Query {
    foo: Boolean
}
```


Resolves https://github.com/ardatan/graphql-tools/issues/2709

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
```ts
test('removes unused interfaces', () => {
  const schema = buildSchema(`
    interface Unused {
      value: String
    }

    type Query {
      foo: Boolean
    }
  `);
  const result = pruneSchema(schema);
  expect(result.getType('Unused')).toBeUndefined();
});
```

**Test Environment**:
- OS: MacOS
- `@graphql-tools/utils`:
- NodeJS: 12,14,15

## Checklist:

- [X] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~ (bug fix)
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests and linter rules pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
