### PR TITLE
Add generic pruning filter option

### DIFF
--- a/.changeset/kind-houses-collect.md
+++ b/.changeset/kind-houses-collect.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/utils': minor
+---
+
+Add generic pruning filter option

--- a/packages/utils/src/prune.ts
+++ b/packages/utils/src/prune.ts
@@ -62,6 +62,11 @@ export function pruneSchema(schema: GraphQLSchema, options: PruneSchemaOptions =
 
   return mapSchema(schema, {
     [MapperKind.TYPE]: (type: GraphQLNamedType) => {
+      // If we should NOT prune the type, return it immediately as unmodified
+      if (options.skipPruning && options.skipPruning(type)) {
+        return type;
+      }
+
       if (isObjectType(type) || isInputObjectType(type)) {
         if (
           (!Object.keys(type.getFields()).length && !options.skipEmptyCompositeTypePruning) ||

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -1,4 +1,4 @@
-import { GraphQLEnumType, GraphQLInputObjectType, GraphQLScalarType } from 'graphql';
+import { GraphQLEnumType, GraphQLInputObjectType, GraphQLNamedType, GraphQLScalarType } from 'graphql';
 
 export interface SchemaPrintOptions {
   /**
@@ -22,10 +22,18 @@ export type Maybe<T> = null | undefined | T;
 
 export type Constructor<T> = new (...args: any[]) => T;
 
+export type PruneSchemaFilter = (type: GraphQLNamedType) => boolean;
+
 /**
  * Options for removing unused types from the schema
  */
 export interface PruneSchemaOptions {
+  /**
+   * Return true to skip pruning this type. This check will run first before any other options.
+   * This can be helpful for schemas that support type extensions like Apollo Federation.
+   */
+  skipPruning?: PruneSchemaFilter;
+
   /**
    * Set to `true` to skip pruning object types or interfaces with no no fields
    */

--- a/packages/utils/tests/prune.test.ts
+++ b/packages/utils/tests/prune.test.ts
@@ -1,5 +1,6 @@
-import { buildSchema } from 'graphql';
+import { buildSchema, GraphQLNamedType } from 'graphql';
 import { pruneSchema } from '../src/prune';
+import { PruneSchemaFilter } from '../src';
 
 describe('pruneSchema', () => {
   test('can handle recursive input types', () => {
@@ -43,6 +44,22 @@ describe('pruneSchema', () => {
     expect(result.getType('Unused')).toBeUndefined();
   });
 
+  test('does not remove unused objects when skipUnusedTypesPruning is true', () => {
+    const schema = buildSchema(`
+      type Unused {
+        value: String
+      }
+
+      type Query {
+        foo: Boolean
+      }
+      `);
+    const result = pruneSchema(schema, {
+      skipUnusedTypesPruning: true
+    });
+    expect(result.getType('Unused')).toBeDefined();
+  });
+
   test('removes unused input objects', () => {
     const schema = buildSchema(`
       input Unused {
@@ -57,6 +74,22 @@ describe('pruneSchema', () => {
     expect(result.getType('Unused')).toBeUndefined();
   });
 
+  test('does not remove unused input objects when skipUnusedTypesPruning is true', () => {
+    const schema = buildSchema(`
+      input Unused {
+        value: String
+      }
+
+      type Query {
+        foo: Boolean
+      }
+      `);
+    const result = pruneSchema(schema, {
+      skipUnusedTypesPruning: true
+    });
+    expect(result.getType('Unused')).toBeDefined();
+  });
+
   test('removes unused unions', () => {
     const schema = buildSchema(`
       union Unused
@@ -67,6 +100,21 @@ describe('pruneSchema', () => {
       `);
     const result = pruneSchema(schema);
     expect(result.getType('Unused')).toBeUndefined();
+  });
+
+  test('does not remove unused unions when skipEmptyUnionPruning is true', () => {
+    const schema = buildSchema(`
+      union Unused
+
+      type Query {
+        foo: Boolean
+      }
+      `);
+    const result = pruneSchema(schema, {
+      skipEmptyUnionPruning: true,
+      skipUnusedTypesPruning: true
+    });
+    expect(result.getType('Unused')).toBeDefined();
   });
 
   test('removes unused interfaces', () => {
@@ -83,6 +131,23 @@ describe('pruneSchema', () => {
     expect(result.getType('Unused')).toBeUndefined();
   });
 
+  test('does not remove unused interfaces when skipUnimplementedInterfacesPruning is true', () => {
+    const schema = buildSchema(`
+      interface Unused {
+        value: String
+      }
+
+      type Query {
+        foo: Boolean
+      }
+      `);
+    const result = pruneSchema(schema, {
+      skipUnimplementedInterfacesPruning: true,
+      skipUnusedTypesPruning: true
+    });
+    expect(result.getType('Unused')).toBeDefined();
+  });
+
   test('removes top level objects with no fields', () => {
     const schema = buildSchema(`
       type Query {
@@ -93,6 +158,21 @@ describe('pruneSchema', () => {
       `);
     const result = pruneSchema(schema);
     expect(result.getMutationType()).toBeUndefined();
+  });
+
+  test('does not removes objects with no fields when skipEmptyCompositeTypePruning is true', () => {
+    const schema = buildSchema(`
+      type Query {
+        foo: Boolean
+      }
+      
+      type Foo
+    `);
+    const result = pruneSchema(schema, {
+      skipUnusedTypesPruning: true,
+      skipEmptyCompositeTypePruning: true
+    });
+    expect(result.getType('Foo')).toBeDefined();
   });
 
   test('removes unused interfaces when implementations are unused', () => {
@@ -143,5 +223,30 @@ describe('pruneSchema', () => {
     `);
     const result = pruneSchema(schema);
     expect(result.getType('UnimplementedInterface')).toBeDefined();
+  });
+
+  test('does not prune types that match the filter', () => {
+    const schema = buildSchema(`
+      directive @bar on OBJECT
+    
+      type CustomType @bar {
+        value: String
+      }
+
+      type Query {
+        foo: Boolean
+      }
+    `);
+
+    // Do not prune any type that has the @bar directive
+    const doNotPruneTypeWithBar: PruneSchemaFilter = (type: GraphQLNamedType) => {
+      return !!type.astNode?.directives?.find(it => it.name.value === 'bar');
+    };
+
+    const result = pruneSchema(schema, {
+      skipPruning: doNotPruneTypeWithBar
+    });
+
+    expect(result.getType('CustomType')).toBeDefined();
   });
 });


### PR DESCRIPTION
## Description

`pruneSchema` accepts a secondary parameter, `PruneSchemaOptions`. This object contains properties like `skipEmptyCompositeTypePruning` and `skipEmptyUnionPruning` which allow you to skip specific use cases of pruning. We can also add another option `skipPruning` which is a function that accepts the `GraphQLNamedType` and returns true when we should not prune a specific type.

This would help solve issues around pruning [Apollo Federation](https://www.apollographql.com/docs/federation/) schemas but it is also a general purpose filter that anyone can use when pruning schemas.

Related #2723

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

```ts
test('does not prune types that match the filter', () => {
    const schema = buildSchema(`
      directive @bar on OBJECT
    
      type CustomType @bar {
        value: String
      }

      type Query {
        foo: Boolean
      }
    `);

    // Do not prune any type that has the @bar directive
    const doNotPruneTypeWithBar: PruneSchemaFilter = (type: GraphQLNamedType) => {
      return !!type.astNode?.directives?.find(it => it.name.value === 'bar');
    };

    const result = pruneSchema(schema, {
      skipPruning: doNotPruneTypeWithBar
    });

    expect(result.getType('CustomType')).toBeDefined();
  });
```

**Test Environment**:
- OS: MacOS
- `@graphql-tools/util`:
- NodeJS: 14

## Checklist:

- [X] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests and linter rules pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

