### PR TITLE
Make executors generic types

### DIFF
--- a/packages/delegate/src/types.ts
+++ b/packages/delegate/src/types.ts
@@ -127,20 +127,18 @@ export interface ExecutionParams<TArgs = Record<string, any>, TContext = any> {
   info?: GraphQLResolveInfo;
 }
 
-export type AsyncExecutor = <
+export type AsyncExecutor<
   TReturn = Record<string, any>,
   TArgs = Record<string, any>,
   TContext = Record<string, any>
->(
-  params: ExecutionParams<TArgs, TContext>
-) => Promise<ExecutionResult<TReturn>>;
-export type SyncExecutor = <TReturn = Record<string, any>, TArgs = Record<string, any>, TContext = Record<string, any>>(
+> = (params: ExecutionParams<TArgs, TContext>) => Promise<ExecutionResult<TReturn>>;
+export type SyncExecutor<TReturn = Record<string, any>, TArgs = Record<string, any>, TContext = Record<string, any>> = (
   params: ExecutionParams<TArgs, TContext>
 ) => ExecutionResult<TReturn>;
-export type Executor = <TReturn = Record<string, any>, TArgs = Record<string, any>, TContext = Record<string, any>>(
+export type Executor<TReturn = Record<string, any>, TArgs = Record<string, any>, TContext = Record<string, any>> = (
   params: ExecutionParams<TArgs, TContext>
 ) => ExecutionResult<TReturn> | Promise<ExecutionResult<TReturn>>;
-export type Subscriber = <TReturn = Record<string, any>, TArgs = Record<string, any>, TContext = Record<string, any>>(
+export type Subscriber<TReturn = Record<string, any>, TArgs = Record<string, any>, TContext = Record<string, any>> = (
   params: ExecutionParams<TArgs, TContext>
 ) => Promise<AsyncIterator<ExecutionResult<TReturn>> | ExecutionResult<TReturn>>;
 

--- a/packages/delegate/src/types.ts
+++ b/packages/delegate/src/types.ts
@@ -127,18 +127,19 @@ export interface ExecutionParams<TArgs = Record<string, any>, TContext = any> {
   info?: GraphQLResolveInfo;
 }
 
-export type AsyncExecutor<
+export type AsyncExecutor<TContext = Record<string, any>> = <
   TReturn = Record<string, any>,
-  TArgs = Record<string, any>,
-  TContext = Record<string, any>
-> = (params: ExecutionParams<TArgs, TContext>) => Promise<ExecutionResult<TReturn>>;
-export type SyncExecutor<TReturn = Record<string, any>, TArgs = Record<string, any>, TContext = Record<string, any>> = (
+  TArgs = Record<string, any>
+>(
+  params: ExecutionParams<TArgs, TContext>
+) => Promise<ExecutionResult<TReturn>>;
+export type SyncExecutor<TContext = Record<string, any>> = <TReturn = Record<string, any>, TArgs = Record<string, any>>(
   params: ExecutionParams<TArgs, TContext>
 ) => ExecutionResult<TReturn>;
-export type Executor<TReturn = Record<string, any>, TArgs = Record<string, any>, TContext = Record<string, any>> = (
+export type Executor<TContext = Record<string, any>> = <TReturn = Record<string, any>, TArgs = Record<string, any>>(
   params: ExecutionParams<TArgs, TContext>
 ) => ExecutionResult<TReturn> | Promise<ExecutionResult<TReturn>>;
-export type Subscriber<TReturn = Record<string, any>, TArgs = Record<string, any>, TContext = Record<string, any>> = (
+export type Subscriber<TContext = Record<string, any>> = <TReturn = Record<string, any>, TArgs = Record<string, any>>(
   params: ExecutionParams<TArgs, TContext>
 ) => Promise<AsyncIterator<ExecutionResult<TReturn>> | ExecutionResult<TReturn>>;
 

--- a/packages/loaders/url/src/index.ts
+++ b/packages/loaders/url/src/index.ts
@@ -257,11 +257,11 @@ export class UrlLoader implements DocumentLoader<LoadFromUrlOptions> {
       url: WS_URL,
       webSocketImpl,
     });
-    return async <TReturn>({ document, variables }: { document: DocumentNode; variables: any }) => {
+    return async ({ document, variables }: { document: DocumentNode; variables: any }) => {
       const query = print(document);
       return observableToAsyncIterable({
         subscribe: observer => {
-          const unsubscribe = subscriptionClient.subscribe<TReturn>(
+          const unsubscribe = subscriptionClient.subscribe(
             {
               query,
               variables,
@@ -277,7 +277,7 @@ export class UrlLoader implements DocumentLoader<LoadFromUrlOptions> {
   }
 
   buildSSESubscriber(pointer: string, eventSourceOptions?: SubscriptionOptions['eventSourceOptions']): Subscriber {
-    return async <TReturn>({ document, variables }: { document: DocumentNode; variables: any }) => {
+    return async ({ document, variables }: { document: DocumentNode; variables: any }) => {
       const query = print(document);
       return observableToAsyncIterable({
         subscribe: observer => {
@@ -293,7 +293,7 @@ export class UrlLoader implements DocumentLoader<LoadFromUrlOptions> {
               ...eventSourceOptions,
             },
             onNext: data => {
-              const parsedData: TReturn = JSON.parse(data);
+              const parsedData = JSON.parse(data);
               observer.next(parsedData);
             },
             onError: data => {


### PR DESCRIPTION
## Description

Previously, executors were required to be generic over all possible types that might be used for `context`. This is rather frustrating: the user of graphql-tools will probably define just one type they want to use for context, and expect that type to be used by all their resolvers, executors, etc. Requiring executors to be generic over every possible type for context means the executor can't take advantage of any of the specifics of one user's context implementation, which rather defeats the purpose.

Elsewhere there are things which take a `TContext` type argument, for example [`IDelegateToSchemaOptions`](https://github.com/ardatan/graphql-tools/blob/3eb72fd0d1de0076f7f26a5f9656b9126dd8537b/packages/delegate/src/types.ts#L62-L80). Making `TContext` an argument of the type, rather than the function, allows these things to declare they want an `Executor` that takes a `TContext` which has already been specified, rather than an `Executor` that's generic over any context type.

Related #1585

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

This program compiles with no errors, and with the typing of `context` retained:

```ts
import { ExecutionParams, SubschemaConfig } from './types';
import { ExecutionResult } from '@graphql-tools/utils';
import { buildSchema, GraphQLSchema } from 'graphql';

const schema: GraphQLSchema = buildSchema(`
  type User {
    id: String
    name: String
  }

  type Query {
    user(id: String): User
  }
`);

type MyContext = { foo: number };

// This is a very explicitly typed implementation of an AsyncExecutor.
async function executor<TReturn, TArgs>({
  context,
}: ExecutionParams<TArgs, MyContext>): Promise<ExecutionResult<TReturn>> { 
  const n: number = context.foo; n;
  return {};
}

export const config: SubschemaConfig<any, any, any, MyContext> = { 
  schema,
  executor: executor,
};

// With less typing, it still compiles.
async function implicitExecutor({ context }: { context?: MyContext }) { 
  const n: number = context.foo; n;
  return {};
}

export const implicitConfig: SubschemaConfig<any, any, any, MyContext> = { 
  schema,
  executor: implicitExecutor,
};
```

**Test Environment**:
- OS: macOS 10.15.7
- `@graphql-tools/...`: Not sure what I'm supposed to answer here. I tested the version proposed in the PR?
- NodeJS: v15.11.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
