### PR TITLE
enhance(docs) clarify batchDelegateToSchema results implicit contract

### DIFF
--- a/website/docs/stitch-schema-extensions.md
+++ b/website/docs/stitch-schema-extensions.md
@@ -226,6 +226,8 @@ Internally, `batchDelegateToSchema` wraps a single `delegateToSchema` call in a 
 > - The Array of values must be the same length as the Array of keys.
 > - Each index in the Array of values must correspond to the same index in the Array of keys.
 
+If the query you're delegating to doesn't conform to these expectations, you can provide a custom [valuesFromResults](https://www.graphql-tools.com/docs/api/interfaces/batch_delegate_src.createbatchdelegatefnoptions/#valuesfromresults) function to transform it appropriately.
+
 Batch delegation is generally preferable over plain delegation because it eliminates the redundancy of requesting the same field across an array of parent objects. Even so, delegation costs can add up because there is still one subschema request made _per batched field_&mdash;for remote services, this may create many network requests sent to the same service. Consider enabling an additional layer of network-level batching with a package such as [apollo-link-batch-http](https://www.apollographql.com/docs/link/links/batch-http/) to consolidate requests per subschema.
 
 ## Passing gateway arguments

--- a/website/docs/stitch-schema-extensions.md
+++ b/website/docs/stitch-schema-extensions.md
@@ -222,7 +222,9 @@ const schema = stitchSchemas({
 });
 ```
 
-Internally, `batchDelegateToSchema` wraps a single `delegateToSchema` call in a [DataLoader](https://www.npmjs.com/package/dataloader) scoped by context, field, arguments, and query selection. It assumes that the delegated operation will return an array of objects matching the gateway field's named GraphQL type (ex: a `User` field delegates to a `[User]` query). If this is not the case, then you should manually provide a `returnType` option citing the expected GraphQL return type.
+Internally, `batchDelegateToSchema` wraps a single `delegateToSchema` call in a [DataLoader](https://www.npmjs.com/package/dataloader) scoped by context, field, arguments, and query selection. It assumes that the delegated operation will return an array of objects matching the gateway field's named GraphQL type (ex: a `User` field delegates to a `[User]` query). If this is not the case, then you should manually provide a `returnType` option citing the expected GraphQL return type. Since it is a thin wrapper around `DataLoader`, it also makes the following assumptions on the results:
+> - The Array of values must be the same length as the Array of keys.
+> - Each index in the Array of values must correspond to the same index in the Array of keys.
 
 Batch delegation is generally preferable over plain delegation because it eliminates the redundancy of requesting the same field across an array of parent objects. Even so, delegation costs can add up because there is still one subschema request made _per batched field_&mdash;for remote services, this may create many network requests sent to the same service. Consider enabling an additional layer of network-level batching with a package such as [apollo-link-batch-http](https://www.apollographql.com/docs/link/links/batch-http/) to consolidate requests per subschema.
 


### PR DESCRIPTION
## Description

The DataLoader documentation explicitly mentions that 
> - The Array of values must be the same length as the Array of keys.
> - Each index in the Array of values must correspond to the same index in the Array of keys.

This implicit contract should be made explicit in this documentation as well. Otherwise it might be assumed that it would get the correct results based on the key. 

