### PR TITLE
 __ is reserved for introspection

### DIFF
--- a/.changeset/gentle-foxes-look.md
+++ b/.changeset/gentle-foxes-look.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/utils': patch
+---
+
+\_\_ is reserved for introspection

--- a/packages/utils/src/stub.ts
+++ b/packages/utils/src/stub.ts
@@ -39,7 +39,7 @@ export function createNamedStub(
   return new constructor({
     name,
     fields: {
-      __fake: {
+      _fake: {
         type: GraphQLString,
       },
     },
@@ -67,7 +67,7 @@ export function isNamedStub(type: GraphQLNamedType): boolean {
   if (isObjectType(type) || isInterfaceType(type) || isInputObjectType(type)) {
     const fields = type.getFields();
     const fieldNames = Object.keys(fields);
-    return fieldNames.length === 1 && fields[fieldNames[0]].name === '__fake';
+    return fieldNames.length === 1 && fields[fieldNames[0]].name === '_fake';
   }
 
   return false;


### PR DESCRIPTION
Related #2804
```
graphql "__fake" must not begin with "__", which is reserved by GraphQL introspection.
```

c.f. https://github.com/graphql/graphql-spec/pull/244

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

