### PR TITLE
args from keys cornercase tests

### DIFF
--- a/packages/stitching-directives/src/properties.ts
+++ b/packages/stitching-directives/src/properties.ts
@@ -49,12 +49,7 @@ export function getProperties(object: Record<string, any>, propertyTree: Propert
 
     const prop = object[key];
 
-    if (Array.isArray(prop)) {
-      newObject[key] = prop.map(item => getProperties(item, subKey));
-      return;
-    }
-
-    newObject[key] = getProperties(prop, subKey);
+    newObject[key] = deepMap(prop, (item) => getProperties(item, subKey));
   });
 
   return newObject;
@@ -66,4 +61,12 @@ export function propertyTreeFromPaths(paths: Array<Array<string>>): PropertyTree
     addProperty(propertyTree, path, null);
   });
   return propertyTree;
+}
+
+function deepMap(arrayOrItem: any, fn: (item: any) => any): any {
+  if (Array.isArray(arrayOrItem)) {
+    return arrayOrItem.map(nestedArrayOrItem => deepMap(nestedArrayOrItem, fn));
+  }
+
+  return fn(arrayOrItem);
 }


### PR DESCRIPTION
## Description

Add tests to make sure that key selectionSets work consistently between SDL directives and MergeTypeConfigs.

One test currently failing (lists within lists).

Related #2735

## Type of change

- [ ] Add tests

**Test Environment**:
- OS: Mac OS 11.0.1
- `@graphql-tools/stitching-directives`: 1.3.1
- NodeJS: 14.15.1

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
