### PR TITLE
Added Github action for Declarative label declaration, Standard Labels added for The Guild  

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,117 @@
+- color: 1d76db
+  description: ''
+  name: automerge
+- color: b60205
+  description: Prevents production or dev due to perf, bug, build error, etc..
+  name: blocking
+- color: fc2929
+  description: ''
+  name: bug
+- color: b60205
+  description: ''
+  name: bugfix
+- color: 1f6d01
+  description: ''
+  name: chore
+- color: 0366d6
+  description: Pull requests that update a dependency file
+  name: dependencies
+- color: ededed
+  description: ''
+  name: design-limitation
+- color: c2e0c6
+  description: Focuses on documentation changes
+  name: docs
+- color: cccccc
+  description: ''
+  name: duplicate
+- color: d4c5f9
+  description: ''
+  name: easy
+- color: 84b6eb
+  description: ''
+  name: enhancement
+- color: 0e8a16
+  description: ''
+  name: external-bug
+- color: a2eeef
+  description: New addition or enhancement to existing solutions
+  name: feature
+- color: ededed
+  description: ''
+  name: fixed
+- color: 7057ff
+  description: Issues that are suitable for first-time contributors.
+  name: good first issue
+- color: 7057ff
+  description: PR's that are suitable for first-time contributors to review.
+  name: good first review
+- color: ededed
+  description: ''
+  name: greenkeeper
+- color: 42f44e
+  description: ❤ Has a reproduction in a codesandbox or single minimal repository
+  name: has-reproduction
+- color: '159818'
+  description: ''
+  name: help wanted
+- color: c2e0c6
+  description: ''
+  name: import
+- color: ededed
+  description: ''
+  name: in progress
+- color: e6e6e6
+  description: ''
+  name: in progress by contributor
+- color: e6e6e6
+  description: ''
+  name: invalid
+- color: 1d76db
+  description: ''
+  name: loaders
+- color: d93f0b
+  description: ''
+  name: needs-reproduction
+- color: cc317c
+  description: ''
+  name: question
+- color: ededed
+  description: ''
+  name: ready
+- color: d13078
+  description: ''
+  name: repro-only-pr
+- color: fbca04
+  description: ''
+  name: requires documentation fix
+- color: 0052cc
+  description: ''
+  name: schema merging
+- color: 5df492
+  description: ''
+  name: schema stitching
+- color: 0e8a16
+  description: ''
+  name: testing
+- color: ededed
+  description: ''
+  name: to do
+- color: fff2c9
+  description: ''
+  name: v5
+- color: 254faa
+  description: ''
+  name: v6
+- color: b75409
+  description: ''
+  name: waiting for answer
+- color: ffbae9
+  description: ''
+  name: waiting on contributor
+- color: dfff8e
+  description: Fixed/resolved, and waiting for the next stable release
+  name: waiting-for-release
+- color: ffffff
+  description: ''
+  name: wontfix

--- a/.github/workflows/github.yml
+++ b/.github/workflows/github.yml
@@ -1,0 +1,18 @@
+name: Sync labels
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - .github/labels.yml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: micnncim/action-label-syncer@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          manifest: .github/labels.yml
+          prune: false


### PR DESCRIPTION
## Description

@Urigo was looking to standardize the labels used in all the repos across The Guild to enable easier management. This PR is for the same.

- All labels are declared declaratively now with the help of this action to sync the same: https://github.com/micnncim/action-label-syncer
- Master Labels for all the repos are managed in this repo: https://github.com/the-guild-org/shared-resources and are pushed to all the repos using PAT whenever changes are made there
- Repo specific labels are added to the repo with an action to help them sync

**NOTE:** This does not remove any of the existing labels or changes the labels in the existing issues to avoid any trouble. It just adds new ones. Relabelling of issues would be required in the future

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

This is how it looks in the codegen repo - its similar here

![image](https://user-images.githubusercontent.com/1165845/114175928-29a84f00-9958-11eb-9b2f-11f6434b6ee8.png)

![image](https://user-images.githubusercontent.com/1165845/114175938-2dd46c80-9958-11eb-9778-a99dd255a67f.png)

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project

**CC:** @dotansimha 