### PR TITLE
chore(url-loader): Use compatible `graphq-ws` versioning

### DIFF
--- a/.changeset/tidy-dancers-dance.md
+++ b/.changeset/tidy-dancers-dance.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/url-loader': patch
+---
+
+chore(url-loader): Use compatible graphq-ws versioning

--- a/packages/loaders/url/package.json
+++ b/packages/loaders/url/package.json
@@ -45,7 +45,7 @@
     "form-data": "4.0.0",
     "tslib": "~2.2.0",
     "valid-url": "1.0.9",
-    "graphql-ws": "4.4.1",
+    "graphql-ws": "^4.4.1",
     "ws": "7.4.5",
     "sync-fetch": "0.3.0",
     "sse-z": "0.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7403,7 +7403,7 @@ graphql-upload@11.0.0, graphql-upload@^11.0.0:
     isobject "^4.0.0"
     object-path "^0.11.4"
 
-graphql-ws@4.4.1:
+graphql-ws@^4.4.1:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-4.4.1.tgz#69f472f362b57366af23265c6c6b967077b9d1dc"
   integrity sha512-kHgDohfRQFDdzXzLqsV4wZM141sO1ukaXW/RSLlmIUsxT4N3r/4eQYTbkeLd4yRXaDkmv/rYf1EHL09Y5KO+Uw==


### PR DESCRIPTION
I use semantic versioning and take extra care not to break anything in minor and patch bumps. `graphql-ws` bugs take the high priority lane and I release patches as soon as they get fixed.

I know you use the renovate bot to do the bumps for you; however, I still wouldnt use exact versioning to make sure the user always has the latest and the newest.

P.S. This is just a suggestion, feel free to close this PR in case you feel different about this.