### PR TITLE
Copy apollo specific extensions for ObjectType

### DIFF
--- a/packages/utils/src/copy-custom-type-fields.ts
+++ b/packages/utils/src/copy-custom-type-fields.ts
@@ -1,11 +1,11 @@
-import { GraphQLNamedType } from 'graphql';
-
-const customFields = ['resolveObject', 'resolveReference'];
+import { GraphQLNamedType, GraphQLSchema } from 'graphql';
 
 export function copyCustomFields(
+  schema: GraphQLSchema,
   source: GraphQLNamedType,
   target: GraphQLNamedType
 ) {
+  const customFields: string[] = schema.extensions?.customFields ?? [];
   customFields.forEach(customField => {
     if (source[customField]) {
       target[customField] = source[customField];

--- a/packages/utils/src/copy-custom-type-fields.ts
+++ b/packages/utils/src/copy-custom-type-fields.ts
@@ -1,0 +1,15 @@
+import { GraphQLNamedType } from 'graphql';
+
+const customFields = ['resolveObject', 'resolveReference'];
+
+export function copyCustomFields(
+  source: GraphQLNamedType,
+  target: GraphQLNamedType
+) {
+  customFields.forEach(customField => {
+    if (source[customField]) {
+      target[customField] = source[customField];
+    }
+  });
+  return target;
+}

--- a/packages/utils/src/mapSchema.ts
+++ b/packages/utils/src/mapSchema.ts
@@ -46,6 +46,7 @@ import {
 
 import { rewireTypes } from './rewire';
 import { serializeInputValue, parseInputValue } from './transformInputValue';
+import { copyCustomFields } from './copy-custom-type-fields';
 
 export function mapSchema(schema: GraphQLSchema, schemaMapper: SchemaMapper = {}): GraphQLSchema {
   const newTypeMap = mapArguments(
@@ -364,10 +365,10 @@ function mapArguments(
       }
 
       if (isObjectType(originalType)) {
-        newTypeMap[typeName] = new GraphQLObjectType({
-          ...(config as unknown as GraphQLObjectTypeConfig<any, any>),
+        newTypeMap[typeName] = copyCustomFields(originalType, new GraphQLObjectType({
+          ...((config as unknown) as GraphQLObjectTypeConfig<any, any>),
           fields: newFieldConfigMap,
-        });
+        }));
       } else if (isInterfaceType(originalType)) {
         newTypeMap[typeName] = new GraphQLInterfaceType({
           ...(config as unknown as GraphQLInterfaceTypeConfig<any, any>),

--- a/packages/utils/src/mapSchema.ts
+++ b/packages/utils/src/mapSchema.ts
@@ -120,7 +120,7 @@ function mapTypes(
         continue;
       }
 
-      newTypeMap[typeName] = maybeNewType;
+      newTypeMap[typeName] = copyCustomFields(originalType, maybeNewType);
     }
   }
 

--- a/packages/utils/src/mapSchema.ts
+++ b/packages/utils/src/mapSchema.ts
@@ -120,7 +120,8 @@ function mapTypes(
         continue;
       }
 
-      newTypeMap[typeName] = copyCustomFields(originalType, maybeNewType);
+      newTypeMap[typeName] =
+        copyCustomFields(schema, originalType, maybeNewType!);
     }
   }
 
@@ -272,12 +273,15 @@ function mapFields(
       }
 
       if (isObjectType(originalType)) {
-        newTypeMap[typeName] = correctASTNodes(
+        newTypeMap[typeName] = copyCustomFields(
+          schema,
+          originalType,
+          correctASTNodes(
           new GraphQLObjectType({
             ...(config as GraphQLObjectTypeConfig<any, any>),
             fields: newFieldConfigMap,
           })
-        );
+        ));
       } else if (isInterfaceType(originalType)) {
         newTypeMap[typeName] = correctASTNodes(
           new GraphQLInterfaceType({
@@ -365,10 +369,14 @@ function mapArguments(
       }
 
       if (isObjectType(originalType)) {
-        newTypeMap[typeName] = copyCustomFields(originalType, new GraphQLObjectType({
-          ...((config as unknown) as GraphQLObjectTypeConfig<any, any>),
-          fields: newFieldConfigMap,
-        }));
+        newTypeMap[typeName] = copyCustomFields(
+          schema,
+          originalType,
+          new GraphQLObjectType({
+            ...((config as unknown) as GraphQLObjectTypeConfig<any, any>),
+            fields: newFieldConfigMap,
+          })
+        );
       } else if (isInterfaceType(originalType)) {
         newTypeMap[typeName] = new GraphQLInterfaceType({
           ...(config as unknown as GraphQLInterfaceTypeConfig<any, any>),

--- a/packages/utils/src/rewire.ts
+++ b/packages/utils/src/rewire.ts
@@ -27,7 +27,6 @@ import {
 } from 'graphql';
 
 import { getBuiltInForStub, isNamedStub } from './stub';
-import { copyCustomFields } from './copy-custom-type-fields';
 
 export function rewireTypes(
   originalTypeMap: Record<string, GraphQLNamedType | null>,
@@ -102,8 +101,7 @@ export function rewireTypes(
         fields: () => rewireFields(config.fields),
         interfaces: () => rewireNamedTypes(config.interfaces),
       };
-      const newType = new GraphQLObjectType(newConfig);
-      return copyCustomFields(type, newType);
+      return new GraphQLObjectType(newConfig);
     } else if (isInterfaceType(type)) {
       const config = (type as GraphQLInterfaceType).toConfig();
       const newConfig: any = {

--- a/packages/utils/src/rewire.ts
+++ b/packages/utils/src/rewire.ts
@@ -27,6 +27,7 @@ import {
 } from 'graphql';
 
 import { getBuiltInForStub, isNamedStub } from './stub';
+import { copyCustomFields } from './copy-custom-type-fields';
 
 export function rewireTypes(
   originalTypeMap: Record<string, GraphQLNamedType | null>,
@@ -101,7 +102,8 @@ export function rewireTypes(
         fields: () => rewireFields(config.fields),
         interfaces: () => rewireNamedTypes(config.interfaces),
       };
-      return new GraphQLObjectType(newConfig);
+      const newType = new GraphQLObjectType(newConfig);
+      return copyCustomFields(type, newType);
     } else if (isInterfaceType(type)) {
       const config = (type as GraphQLInterfaceType).toConfig();
       const newConfig: any = {

--- a/packages/utils/tests/mapSchema.test.ts
+++ b/packages/utils/tests/mapSchema.test.ts
@@ -1232,9 +1232,17 @@ describe('mapSchema', () => {
     expect(s._typeMap.TestType.resolveReference).toBeTruthy()
     expect(s._typeMap.TestType.resolveObject).toBeTruthy()
 
-    const mappedSchema = mapSchema(schema) as any
+    // ... retained through a noop mapping
+    let mappedSchema = mapSchema(schema) as any;
+    expect(mappedSchema._typeMap.TestType.resolveReference).toBeTruthy()
+    expect(mappedSchema._typeMap.TestType.resolveObject).toBeTruthy()
+
+    // ... retained through a simple objecttype copy mapping
+    mappedSchema = mapSchema(schema, {
+      [MapperKind.OBJECT_TYPE]: (type) => new GraphQLObjectType(type.toConfig())
+    });
 
     expect(mappedSchema._typeMap.TestType.resolveReference).toBeTruthy()
     expect(mappedSchema._typeMap.TestType.resolveObject).toBeTruthy()
-  })
+  });
 });

--- a/packages/utils/tests/mapSchema.test.ts
+++ b/packages/utils/tests/mapSchema.test.ts
@@ -1214,4 +1214,27 @@ describe('mapSchema', () => {
       expect(result.data).toEqual(expectedResult);
     });
   });
+
+  test('apollo extensions are retained', () => {
+    const schema = makeExecutableSchema({
+      typeDefs: `
+        type TestType {
+          id: ID!
+          properties: [String!]!
+        }
+      `,
+    });
+
+    const s = schema as any;
+    s._typeMap.TestType.resolveReference = () => {};
+    s._typeMap.TestType.resolveObject = () => {};
+
+    expect(s._typeMap.TestType.resolveReference).toBeTruthy()
+    expect(s._typeMap.TestType.resolveObject).toBeTruthy()
+
+    const mappedSchema = mapSchema(schema) as any
+
+    expect(mappedSchema._typeMap.TestType.resolveReference).toBeTruthy()
+    expect(mappedSchema._typeMap.TestType.resolveObject).toBeTruthy()
+  })
 });

--- a/packages/utils/tests/mapSchema.test.ts
+++ b/packages/utils/tests/mapSchema.test.ts
@@ -1225,6 +1225,9 @@ describe('mapSchema', () => {
       `,
     });
 
+    // This is required to specify any additional fields to copy
+    schema.extensions = { customFields: ['resolveObject', 'resolveReference'] };
+
     const s = schema as any;
     s._typeMap.TestType.resolveReference = () => {};
     s._typeMap.TestType.resolveObject = () => {};
@@ -1239,7 +1242,12 @@ describe('mapSchema', () => {
 
     // ... retained through a simple objecttype copy mapping
     mappedSchema = mapSchema(schema, {
-      [MapperKind.OBJECT_TYPE]: (type) => new GraphQLObjectType(type.toConfig())
+      [MapperKind.OBJECT_TYPE]: (type) => {
+        const newType = new GraphQLObjectType(type.toConfig());
+        newType.resolveObject = type.resolveObject;
+        newType.resolveReference = type.resolveReference;
+        return newType;
+      }
     });
 
     expect(mappedSchema._typeMap.TestType.resolveReference).toBeTruthy()


### PR DESCRIPTION

## Description

Two Apollo specific extensions; `__resolveReference` and `__resolveObject` are lost when using `mapSchema`

This PR provides a simplistic fix of this issue by explicitly copying these properties if they exists.
It is a quick fix for the related issue.

Related #2687


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

This has been tested through a unit test that is part of the change

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

