### PR TITLE
batch-delagate: create failing test for aliasing bug

### DIFF
--- a/.changeset/sixty-tools-teach.md
+++ b/.changeset/sixty-tools-teach.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/wrap': patch
+---
+
+fix(TransformQuery): pass delegation context to query and result transformers for required flexibility

--- a/packages/batch-delegate/tests/aliasing.test.ts
+++ b/packages/batch-delegate/tests/aliasing.test.ts
@@ -1,0 +1,99 @@
+import { graphql } from 'graphql';
+
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { batchDelegateToSchema } from '@graphql-tools/batch-delegate';
+import { stitchSchemas } from '@graphql-tools/stitch';
+
+describe('batch delegation with query aliasing', () => {
+  test('works with valuesFromResults returning plain objects', async () => {
+    let numCalls = 0;
+
+    const chirpSchema = makeExecutableSchema({
+      typeDefs: `
+        type Chirp {
+          chirpedAtUserId: ID!
+        }
+
+        type Query {
+          trendingChirps: [Chirp]
+        }
+      `,
+      resolvers: {
+        Query: {
+          trendingChirps: () => [{ chirpedAtUserId: 1 }, { chirpedAtUserId: 2 }]
+        }
+      }
+    });
+
+    // Mocked author schema
+    const authorSchema = makeExecutableSchema({
+      typeDefs: `
+        type User {
+          id: String!
+          email: String
+        }
+
+        type Query {
+          usersByIds(ids: [ID!]): [User]
+        }
+      `,
+      resolvers: {
+        Query: {
+          usersByIds: (_root, args) => {
+            numCalls++;
+            return args.ids.map((id: string) => ({ id, email: `${id}@test.com` }));
+          }
+        }
+      }
+    });
+
+    const linkTypeDefs = `
+      extend type Chirp {
+        chirpedAtUser: User
+      }
+    `;
+
+    const stitchedSchema = stitchSchemas({
+      subschemas: [chirpSchema, authorSchema],
+      typeDefs: linkTypeDefs,
+      resolvers: {
+        Chirp: {
+          chirpedAtUser: {
+            selectionSet: `{ chirpedAtUserId }`,
+            resolve(chirp, _args, context, info) {
+              return batchDelegateToSchema({
+                schema: authorSchema,
+                operation: 'query',
+                fieldName: 'usersByIds',
+                key: chirp.chirpedAtUserId,
+                argsFromKeys: (ids) => ({ ids }),
+                context,
+                info,
+                valuesFromResults: (results, ids) =>
+                  // return plain object with no symbols
+                  ids.map((id) => ({ ...results.find((r) => r.id === id) }))
+              });
+            },
+          },
+        },
+      },
+    });
+
+    const query = `
+      query {
+        trendingChirps {
+          chirpedAtUser {
+            id
+            username: email
+          }
+        }
+      }
+    `;
+
+    const result = await graphql(stitchedSchema, query);
+
+    expect(numCalls).toEqual(1);
+    expect(result.errors).toBeUndefined();
+    expect(result.data.trendingChirps[0].chirpedAtUser.username).not.toBe(null);
+  });
+});

--- a/packages/batch-delegate/tests/aliasing.test.ts
+++ b/packages/batch-delegate/tests/aliasing.test.ts
@@ -1,4 +1,4 @@
-import { graphql, GraphQLList, Kind, GraphQLNonNull } from 'graphql';
+import { graphql, GraphQLList, Kind } from 'graphql';
 
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { batchDelegateToSchema } from '@graphql-tools/batch-delegate';
@@ -90,22 +90,17 @@ describe('batch delegation with query aliasing', () => {
         User: {
           books: {
             selectionSet: `{ id }`,
-            async resolve(user, _args, context, info) {
-              const books =  await batchDelegateToSchema({
-                schema: bookSchema,
-                operation: 'query',
-                fieldName: 'booksByUserIds',
-                key: user.id,
-                argsFromKeys: (userIds) => ({ userIds }),
-                context,
-                info,
-                transforms: [queryTransform],
-                returnType: new GraphQLList(new GraphQLList(info.schema.getType('Book')))
-              });
-              console.log('symbols for books: ', Object.getOwnPropertySymbols(books[0]));
-
-              return books
-            },
+            resolve: (user, _args, context, info) => batchDelegateToSchema({
+              schema: bookSchema,
+              operation: 'query',
+              fieldName: 'booksByUserIds',
+              key: user.id,
+              argsFromKeys: (userIds) => ({ userIds }),
+              context,
+              info,
+              transforms: [queryTransform],
+              returnType: new GraphQLList(new GraphQLList(info.schema.getType('Book')))
+            }),
           },
         },
       },

--- a/packages/batch-delegate/tests/aliasing.test.ts
+++ b/packages/batch-delegate/tests/aliasing.test.ts
@@ -5,8 +5,8 @@ import { batchDelegateToSchema } from '@graphql-tools/batch-delegate';
 import { stitchSchemas } from '@graphql-tools/stitch';
 import { TransformQuery } from '@graphql-tools/wrap'
 
-describe('batch delegation with query aliasing', () => {
-  test('works with valuesFromResults returning plain objects', async () => {
+describe('works with complex transforms', () => {
+  test('using TransformQuery instead of valuesFromResults', async () => {
     const bookSchema = makeExecutableSchema({
       typeDefs: `
         type Book {
@@ -72,14 +72,14 @@ describe('batch delegation with query aliasing', () => {
           { kind: Kind.FIELD, name: { kind: Kind.NAME, value: 'books' }, selectionSet }
         ]
       }),
-      resultTransformer: (results, { userIds }) => {
+      resultTransformer: (results, { args: userIds }) => {
         const booksByUserIds = results.reduce(
           (acc: any, { userId, books }: { userId: string, books: any[] }) => {
             acc[userId] = books
             return acc
           }, {});
         const orderedAndUnwrapped = userIds.map((id: any) => booksByUserIds[id]);
-        return orderedAndUnwrapped
+        return orderedAndUnwrapped;
       }
     });
 

--- a/packages/batch-delegate/tests/aliasing.test.ts
+++ b/packages/batch-delegate/tests/aliasing.test.ts
@@ -100,7 +100,7 @@ describe('batch delegation with query aliasing', () => {
                 context,
                 info,
                 transforms: [queryTransform],
-                returnType: new GraphQLList(new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(bookSchema.getType('Book')))))
+                returnType: new GraphQLList(new GraphQLList(info.schema.getType('Book')))
               });
               console.log('symbols for books: ', Object.getOwnPropertySymbols(books[0]));
 

--- a/packages/batch-delegate/tests/withTransforms.test.ts
+++ b/packages/batch-delegate/tests/withTransforms.test.ts
@@ -72,7 +72,8 @@ describe('works with complex transforms', () => {
           { kind: Kind.FIELD, name: { kind: Kind.NAME, value: 'books' }, selectionSet }
         ]
       }),
-      resultTransformer: (results, { args: userIds }) => {
+      resultTransformer: (results, delegationContext) => {
+        const userIds = delegationContext.args.userIds;
         const booksByUserIds = results.reduce(
           (acc: any, { userId, books }: { userId: string, books: any[] }) => {
             acc[userId] = books

--- a/packages/wrap/src/transforms/TransformQuery.ts
+++ b/packages/wrap/src/transforms/TransformQuery.ts
@@ -9,7 +9,7 @@ export type QueryTransformer = (
   fragments: Record<string, FragmentDefinitionNode>
 ) => SelectionSetNode;
 
-export type ResultTransformer = (result: any) => any;
+export type ResultTransformer = (result: any, args: any) => any;
 
 export type ErrorPathTransformer = (path: ReadonlyArray<string | number>) => Array<string | number>;
 
@@ -79,10 +79,10 @@ export default class TransformQuery implements Transform {
 
   public transformResult(
     originalResult: ExecutionResult,
-    _delegationContext: DelegationContext,
+    delegationContext: DelegationContext,
     _transformationContext: Record<string, any>
   ): ExecutionResult {
-    const data = this.transformData(originalResult.data);
+    const data = this.transformData(originalResult.data, delegationContext);
     const errors = originalResult.errors;
     return {
       data,
@@ -90,7 +90,7 @@ export default class TransformQuery implements Transform {
     };
   }
 
-  private transformData(data: any): any {
+  private transformData(data: any, delegationContext: DelegationContext): any {
     const leafIndex = this.path.length - 1;
     let index = 0;
     let newData = data;
@@ -105,7 +105,7 @@ export default class TransformQuery implements Transform {
         index++;
         next = this.path[index];
       }
-      newData[next] = this.resultTransformer(newData[next]);
+      newData[next] = this.resultTransformer(newData[next], delegationContext.args);
     }
     return newData;
   }


### PR DESCRIPTION
## Description
`delegateToSchema` conditionally applies `defaultMergedResolver` based on whether the object is external. An object is determined to be external based on whether it has the symbol UNPATHED_ERRORS_SYMBOL.

Removing the symbol in `batchDelegateToSchema.valuesFromResult` by returning plain js objects breaks query aliasing.

This PR currently just contains a failing test to reproduce the bug


Related # (issue)
[#2829](https://github.com/ardatan/graphql-tools/issues/2829)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

