### PR TITLE
fix(import): handle nested imports correctly

### DIFF
--- a/.changeset/slimy-tools-decide.md
+++ b/.changeset/slimy-tools-decide.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/import': patch
+---
+
+fix(import): handle nested imports correctly

--- a/packages/import/tests/schema/fixtures/deep/a.graphql
+++ b/packages/import/tests/schema/fixtures/deep/a.graphql
@@ -1,0 +1,5 @@
+# import * from "b.graphql"
+
+type Query {
+  level: Level3
+}

--- a/packages/import/tests/schema/fixtures/deep/b.graphql
+++ b/packages/import/tests/schema/fixtures/deep/b.graphql
@@ -1,0 +1,13 @@
+type Level1 {
+  id: ID!
+}
+
+type Level2 {
+  id: ID!
+  level1: Level1
+}
+
+type Level3 {
+  id: ID!
+  level2: Level2
+}

--- a/packages/import/tests/schema/import-schema.spec.ts
+++ b/packages/import/tests/schema/import-schema.spec.ts
@@ -917,4 +917,27 @@ describe('importSchema', () => {
   `;
     expect(importSchema('fixtures/multiple-imports/schema.graphql')).toBeSimilarGqlDoc(expectedSDL);
   });
+
+  test('imports multi-level types without direct references', () => {
+    const expectedSDL = /* GraphQL */`\
+  type Level1 {
+    id: ID!
+  }
+  
+  type Level2 {
+    id: ID!
+    level1: Level1
+  }
+  
+  type Level3 {
+    id: ID!
+    level2: Level2
+  }
+
+  type Query {
+    level: Level3
+  }
+  `;
+    expect(importSchema('fixtures/deep/a.graphql')).toBeSimilarGqlDoc(expectedSDL);
+  });
 })


### PR DESCRIPTION
## Description

This adds a simple deeply nested graphql schema failing test. It proves that there is a bug with deep nested structures in the `import` package.

Related #1591

## Type of change

- [ ] (yet to be) Bug fix (non-breaking change which fixes an issue)
