### PR TITLE
fix(visitResult): don't throw on encountering __typename in request (#2860) 

### DIFF
--- a/.changeset/young-swans-deliver.md
+++ b/.changeset/young-swans-deliver.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/utils': patch
+---
+
+fix(visitResult): don't throw on encountering \_\_typename in request (#2860)

--- a/packages/utils/src/visitResult.ts
+++ b/packages/utils/src/visitResult.ts
@@ -12,6 +12,7 @@ import {
   isObjectType,
   OperationDefinitionNode,
   GraphQLError,
+  TypeNameMetaFieldDef,
 } from 'graphql';
 
 import { Request, GraphQLExecutionContext, ExecutionResult } from './Interfaces';
@@ -197,7 +198,7 @@ function visitObjectValue(
   Object.keys(fieldNodeMap).forEach(responseKey => {
     const subFieldNodes = fieldNodeMap[responseKey];
     const fieldName = subFieldNodes[0].name.value;
-    const fieldType = fieldMap[fieldName].type;
+    const fieldType = fieldName === '__typename' ? TypeNameMetaFieldDef.type : fieldMap[fieldName].type;
 
     const newPathIndex = pathIndex + 1;
 

--- a/packages/utils/tests/visitResult.test.ts
+++ b/packages/utils/tests/visitResult.test.ts
@@ -42,6 +42,22 @@ describe('visiting results', () => {
     expect(visitedResult).toEqual(result);
   });
 
+  it('should visit with a request with introspection fields without throwing', async () => {
+    const introspectionRequest = {
+      document: parse('{ test { field __typename } }'),
+      variables: {}
+    };
+    const result = {
+      data: {
+        test: {
+          __typename: 'Test',
+          field: 'test',
+        },
+      },
+    };
+    expect(() => visitResult(result, introspectionRequest, schema, undefined)).not.toThrow();
+  });
+
   it('should successfully modify the result using an object type result visitor', async () => {
     const result = {
       data: {


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

## Description

visitResult fails if querying reserved fields. This PR currently does not have a solution for the problem, only a failing test is added to reproduce it.

Credit to @mjbcopland for creating the issue and writing the reproduction.

Related #2860 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):
https://codesandbox.io/s/happy-visvesvaraya-s9fk7

<!--
## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:
- OS:
- `@graphql-tools/...`:
- NodeJS:

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
