### PR TITLE
chore(stitch) export typescript package types + cleanup

### DIFF
--- a/packages/stitch/src/index.ts
+++ b/packages/stitch/src/index.ts
@@ -3,3 +3,4 @@ export { createMergedTypeResolver } from './createMergedTypeResolver';
 export { forwardArgsToSelectionSet } from './selectionSetArgs';
 
 export * from './subschemaConfigTransforms';
+export * from './types';

--- a/packages/stitch/src/stitchingInfo.ts
+++ b/packages/stitch/src/stitchingInfo.ts
@@ -15,9 +15,9 @@ import {
 
 import { parseSelectionSet, TypeMap, IResolvers, IFieldResolverOptions } from '@graphql-tools/utils';
 
-import { MergedTypeResolver, Subschema, SubschemaConfig } from '@graphql-tools/delegate';
+import { MergedTypeResolver, Subschema, SubschemaConfig, MergedTypeInfo, StitchingInfo } from '@graphql-tools/delegate';
 
-import { MergeTypeCandidate, MergedTypeInfo, StitchingInfo, MergeTypeFilter } from './types';
+import { MergeTypeCandidate, MergeTypeFilter } from './types';
 
 import { createMergedTypeResolver } from './createMergedTypeResolver';
 

--- a/packages/stitch/src/typeCandidates.ts
+++ b/packages/stitch/src/typeCandidates.ts
@@ -11,12 +11,12 @@ import {
 } from 'graphql';
 
 import { wrapSchema } from '@graphql-tools/wrap';
-import { Subschema, SubschemaConfig } from '@graphql-tools/delegate';
+import { Subschema, SubschemaConfig, StitchingInfo } from '@graphql-tools/delegate';
 import { GraphQLParseOptions, ITypeDefinitions, rewireTypes, TypeMap } from '@graphql-tools/utils';
 import { buildDocumentFromTypeDefinitions } from '@graphql-tools/schema';
 
 import typeFromAST from './typeFromAST';
-import { MergeTypeCandidate, MergeTypeFilter, OnTypeConflict, StitchingInfo, TypeMergingOptions } from './types';
+import { MergeTypeCandidate, MergeTypeFilter, OnTypeConflict, TypeMergingOptions } from './types';
 import { mergeCandidates } from './mergeCandidates';
 import { extractDefinitions } from './definitions';
 

--- a/packages/stitch/src/types.ts
+++ b/packages/stitch/src/types.ts
@@ -11,8 +11,8 @@ import {
   GraphQLEnumValueConfig,
   GraphQLEnumType,
 } from 'graphql';
-import { ITypeDefinitions, TypeMap } from '@graphql-tools/utils';
-import { MergedTypeResolver, Subschema, SubschemaConfig } from '@graphql-tools/delegate';
+import { ITypeDefinitions } from '@graphql-tools/utils';
+import { Subschema, SubschemaConfig } from '@graphql-tools/delegate';
 import { IExecutableSchemaDefinition } from '@graphql-tools/schema';
 
 export interface MergeTypeCandidate<TContext = Record<string, any>> {

--- a/packages/stitch/src/types.ts
+++ b/packages/stitch/src/types.ts
@@ -50,25 +50,6 @@ export type MergeTypeFilter<TContext = Record<string, any>> = (
   typeName: string
 ) => boolean;
 
-export interface MergedTypeInfo<TContext = Record<string, any>> {
-  typeName: string;
-  targetSubschemas: Map<Subschema<any, any, any, TContext>, Array<Subschema<any, any, any, TContext>>>;
-  uniqueFields: Record<string, Subschema<any, any, any, TContext>>;
-  nonUniqueFields: Record<string, Array<Subschema<any, any, any, TContext>>>;
-  typeMaps: Map<GraphQLSchema | SubschemaConfig<any, any, any, TContext>, TypeMap>;
-  selectionSets: Map<Subschema<any, any, any, TContext>, SelectionSetNode>;
-  fieldSelectionSets: Map<Subschema<any, any, any, TContext>, Record<string, SelectionSetNode>>;
-  resolvers: Map<Subschema<any, any, any, TContext>, MergedTypeResolver<TContext>>;
-}
-
-export interface StitchingInfo<TContext = Record<string, any>> {
-  subschemaMap: Map<GraphQLSchema | SubschemaConfig<any, any, any, TContext>, Subschema<any, any, any, TContext>>;
-  selectionSetsByType: Record<string, SelectionSetNode>;
-  selectionSetsByField: Record<string, Record<string, SelectionSetNode>>;
-  dynamicSelectionSetsByField: Record<string, Record<string, Array<(node: FieldNode) => SelectionSetNode>>>;
-  mergedTypes: Record<string, MergedTypeInfo<TContext>>;
-}
-
 export interface IStitchSchemasOptions<TContext = Record<string, any>>
   extends Omit<IExecutableSchemaDefinition<TContext>, 'typeDefs'> {
   subschemas?: Array<


### PR DESCRIPTION
Exports type definitions from the Stitch package to make them available for TypeScript introspection. Should address https://github.com/ardatan/graphql-tools/issues/2865.

In the process, the `StitchingInfo` and `MergedTypeInfo` types are removed from the `stitch` package in favor of using the primary definitions in the `delegate` package.