### PR TITLE
fix(mock): avoid __typename does not exist error

### DIFF
--- a/.changeset/warm-buckets-applaud.md
+++ b/.changeset/warm-buckets-applaud.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/mock': patch
+---
+
+Avoid `__typename does not exist` error

--- a/packages/mock/src/MockStore.ts
+++ b/packages/mock/src/MockStore.ts
@@ -1,5 +1,6 @@
 import {
   GraphQLSchema,
+  GraphQLString,
   isObjectType,
   isScalarType,
   getNullableType,
@@ -509,6 +510,10 @@ export class MockStore implements IMockStore {
   }
 
   private getFieldType(typeName: string, fieldName: string) {
+    if (fieldName === '__typename') {
+      return GraphQLString;
+    }
+
     const type = this.getType(typeName);
 
     const field = type.getFields()[fieldName];


### PR DESCRIPTION
## Description

I ran into a very mysterious error when working with `@graphql-tools/mock` and abstract types:

```
__typename does not exist on type ConcreteType
```

This seems to occur under some specific circumstances:

1. A selection is made against an interface
2. A selection is made against a non-null object field on the interface
3. The explicit mocks contain a `__typename` on the interface
4. The explicit mocks do not contain the aforementioned object field

I've tried to capture this in a new test case, which fails on master but is handled with this patch. I also have an external repro here:

https://github.com/72636c/graphql-tools-mock-typename

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Added new Jest test case
- [x] Monkey-patched existing repositories

**Test Environment**:
- OS: macOS 10.15.7
- `@graphql-tools/mock`: 8.1.2
- NodeJS: 14

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules