### PR TITLE
[batch-delegate] Error paths use their batched indices

### DIFF
--- a/packages/batch-delegate/tests/errorPaths.test.ts
+++ b/packages/batch-delegate/tests/errorPaths.test.ts
@@ -1,0 +1,153 @@
+import { graphql, GraphQLError } from 'graphql';
+import { batchDelegateToSchema } from '@graphql-tools/batch-delegate';
+import { delegateToSchema } from '@graphql-tools/delegate';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { stitchSchemas } from '@graphql-tools/stitch';
+
+class NotFoundError extends GraphQLError {
+  constructor(id: unknown) {
+    super('Not Found', undefined, undefined, undefined, undefined, undefined, { id });
+  }
+}
+
+describe('preserves error path indices', () => {
+  const getProperty = jest.fn((id: unknown) => {
+    return new NotFoundError(id);
+  });
+
+  beforeEach(() => {
+    getProperty.mockClear();
+  });
+
+  const subschema = makeExecutableSchema({
+    typeDefs: /* GraphQL */ `
+      type Property {
+        id: ID!
+      }
+
+      type Object {
+        id: ID!
+        propertyId: ID!
+      }
+
+      type Query {
+        objects: [Object!]!
+        propertyById(id: ID!): Property
+        propertiesByIds(ids: [ID!]!): [Property]!
+      }
+    `,
+    resolvers: {
+      Query: {
+        objects: () => {
+          return [
+            { id: '1', propertyId: '1' },
+            { id: '2', propertyId: '1' },
+          ];
+        },
+        propertyById: (_, args) => getProperty(args.id),
+        propertiesByIds: (_, args) => args.ids.map(getProperty),
+      },
+    },
+  });
+
+  const subschemas = [subschema];
+  const typeDefs = /* GraphQL */ `
+    extend type Object {
+      property: Property
+    }
+  `;
+
+  const query = /* GraphQL */ `
+    query {
+      objects {
+        id
+        property {
+          id
+        }
+      }
+    }
+  `;
+
+  const expected = {
+    errors: [
+      {
+        message: 'Not Found',
+        extensions: { id: '1' },
+        path: ['objects', 0, 'property'],
+      },
+      {
+        message: 'Not Found',
+        extensions: { id: '1' },
+        path: ['objects', 1, 'property'],
+      },
+    ],
+    data: {
+      objects: [
+        {
+          id: '1',
+          property: null as null,
+        },
+        {
+          id: '2',
+          property: null as null,
+        },
+      ],
+    },
+  };
+
+  test('using delegateToSchema', async () => {
+    const schema = stitchSchemas({
+      subschemas,
+      typeDefs,
+      resolvers: {
+        Object: {
+          property: {
+            selectionSet: '{ propertyId }',
+            resolve: (source, _, context, info) => {
+              return delegateToSchema({
+                schema: subschema,
+                fieldName: 'propertyById',
+                args: { id: source.propertyId },
+                context,
+                info,
+              });
+            },
+          },
+        },
+      },
+    });
+
+    const result = await graphql(schema, query);
+
+    expect(getProperty).toBeCalledTimes(2);
+    expect(result).toMatchObject(expected);
+  });
+
+  test('using batchDelegateToSchema', async () => {
+    const schema = stitchSchemas({
+      subschemas,
+      typeDefs,
+      resolvers: {
+        Object: {
+          property: {
+            selectionSet: '{ propertyId }',
+            resolve: (source, _, context, info) => {
+              return batchDelegateToSchema({
+                schema: subschema,
+                fieldName: 'propertiesByIds',
+                key: source.propertyId,
+                context,
+                info,
+              });
+            },
+          },
+        },
+      },
+    });
+
+    const result = await graphql(schema, query);
+
+    expect(getProperty).toBeCalledTimes(1);
+    expect(result).toMatchObject(expected);
+  });
+});


### PR DESCRIPTION
## Description

Reproduction test case. When using an n-plus-one delegateToSchema, the result is as expected. When using batchDelegateToSchema, error paths are incorrect.

We expect the path to have index `1` as the error is for the second object, however it is the same error as at index `0` and is deduplicated in the batched request. The error returned has this deduplicated index instead of its actual index.

```diff
 FAIL  packages/batch-delegate/tests/errorPaths.test.ts
  ● preserves error path indices › using batchDelegateToSchema

    expect(received).toMatchObject(expected)

    - Expected  - 1
    + Received  + 1

    @@ -28,11 +28,11 @@
              "id": "1",
            },
            "message": "Not Found",
            "path": Array [
              "objects",
    -         1,
    +         0,
              "property",
            ],
          },
        ],
      }

      149 |
      150 |     expect(getProperty).toBeCalledTimes(1);
    > 151 |     expect(result).toMatchObject(expected);
          |                    ^
      152 |   });
      153 | });
      154 |

      at Object.<anonymous> (packages/batch-delegate/tests/errorPaths.test.ts:151:20)
```

Related #2950

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:
- OS:
- `@graphql-tools/...`:
- NodeJS:

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
