### PR TITLE
Fix bug handling single underscore type names

### DIFF
--- a/.changeset/friendly-coins-beam.md
+++ b/.changeset/friendly-coins-beam.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/utils': patch
+---
+
+fix(getResolversFromSchema) Fix resolvers for type names starting with a single underscore.

--- a/packages/load/tests/loaders/schema/schema-from-json.spec.ts
+++ b/packages/load/tests/loaders/schema/schema-from-json.spec.ts
@@ -27,7 +27,7 @@ describe('Schema From Export', () => {
       expect(isSchema(schema)).toBeTruthy();
       const introspectionSchema = require('./test-files/githunt.json').__schema;
       for (const typeName in schema.getTypeMap()) {
-        if (!typeName.startsWith('_')) {
+        if (!typeName.startsWith('__')) {
           const type = schema.getType(typeName);
           const introspectionType = introspectionSchema.types.find((t: { name: string; }) => t.name === typeName);
           if (type.description || introspectionType.description) {

--- a/packages/utils/src/getResolversFromSchema.ts
+++ b/packages/utils/src/getResolversFromSchema.ts
@@ -17,7 +17,7 @@ export function getResolversFromSchema(schema: GraphQLSchema): IResolvers {
   const typeMap = schema.getTypeMap();
 
   Object.keys(typeMap).forEach(typeName => {
-    if (!typeName.startsWith('_')) {
+    if (!typeName.startsWith('__')) {
       const type = typeMap[typeName];
 
       if (isScalarType(type)) {


### PR DESCRIPTION
Related https://github.com/ardatan/graphql-tools/issues/2955

## Description

Checks for a double underscore, rather than a single underscore.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I've tested this change locally against the Keystone project (where we discovered the bug) and verified that it fixes the issues we were seeing.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
