### PR TITLE
Make executors not generic over context types

### DIFF
--- a/.changeset/lucky-mayflies-shout.md
+++ b/.changeset/lucky-mayflies-shout.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/utils': minor
+---
+
+Make executors not generic over context types

--- a/packages/utils/src/executor.ts
+++ b/packages/utils/src/executor.ts
@@ -9,31 +9,18 @@ export interface ExecutionParams<TArgs = Record<string, any>, TContext = any> {
   info?: GraphQLResolveInfo;
 }
 
-export type AsyncExecutor<TBaseContext = Record<string, any>> = <
+export type AsyncExecutor<TContext = Record<string, any>> = <
   TReturn = Record<string, any>,
-  TArgs = Record<string, any>,
-  TContext = TBaseContext
+  TArgs = Record<string, any>
 >(
   params: ExecutionParams<TArgs, TContext>
 ) => Promise<ExecutionResult<TReturn>>;
-export type SyncExecutor<TBaseContext = Record<string, any>> = <
-  TReturn = Record<string, any>,
-  TArgs = Record<string, any>,
-  TContext = TBaseContext
->(
+export type SyncExecutor<TContext = Record<string, any>> = <TReturn = Record<string, any>, TArgs = Record<string, any>>(
   params: ExecutionParams<TArgs, TContext>
 ) => ExecutionResult<TReturn>;
-export type Executor<TBaseContext = Record<string, any>> = <
-  TReturn = Record<string, any>,
-  TArgs = Record<string, any>,
-  TContext = TBaseContext
->(
+export type Executor<TContext = Record<string, any>> = <TReturn = Record<string, any>, TArgs = Record<string, any>>(
   params: ExecutionParams<TArgs, TContext>
 ) => ExecutionResult<TReturn> | Promise<ExecutionResult<TReturn>>;
-export type Subscriber<TBaseContext = Record<string, any>> = <
-  TReturn = Record<string, any>,
-  TArgs = Record<string, any>,
-  TContext = TBaseContext
->(
+export type Subscriber<TContext = Record<string, any>> = <TReturn = Record<string, any>, TArgs = Record<string, any>>(
   params: ExecutionParams<TArgs, TContext>
 ) => Promise<AsyncIterator<ExecutionResult<TReturn>> | ExecutionResult<TReturn>>;

--- a/packages/utils/src/executor.ts
+++ b/packages/utils/src/executor.ts
@@ -9,18 +9,31 @@ export interface ExecutionParams<TArgs = Record<string, any>, TContext = any> {
   info?: GraphQLResolveInfo;
 }
 
-export type AsyncExecutor<TContext = Record<string, any>> = <
+export type AsyncExecutor<TBaseContext = Record<string, any>> = <
   TReturn = Record<string, any>,
-  TArgs = Record<string, any>
+  TArgs = Record<string, any>,
+  TContext extends TBaseContext = TBaseContext
 >(
   params: ExecutionParams<TArgs, TContext>
 ) => Promise<ExecutionResult<TReturn>>;
-export type SyncExecutor<TContext = Record<string, any>> = <TReturn = Record<string, any>, TArgs = Record<string, any>>(
+export type SyncExecutor<TBaseContext = Record<string, any>> = <
+  TReturn = Record<string, any>,
+  TArgs = Record<string, any>,
+  TContext extends TBaseContext = TBaseContext
+>(
   params: ExecutionParams<TArgs, TContext>
 ) => ExecutionResult<TReturn>;
-export type Executor<TContext = Record<string, any>> = <TReturn = Record<string, any>, TArgs = Record<string, any>>(
+export type Executor<TBaseContext = Record<string, any>> = <
+  TReturn = Record<string, any>,
+  TArgs = Record<string, any>,
+  TContext extends TBaseContext = TBaseContext
+>(
   params: ExecutionParams<TArgs, TContext>
 ) => ExecutionResult<TReturn> | Promise<ExecutionResult<TReturn>>;
-export type Subscriber<TContext = Record<string, any>> = <TReturn = Record<string, any>, TArgs = Record<string, any>>(
+export type Subscriber<TBaseContext = Record<string, any>> = <
+  TReturn = Record<string, any>,
+  TArgs = Record<string, any>,
+  TContext extends TBaseContext = TBaseContext
+>(
   params: ExecutionParams<TArgs, TContext>
 ) => Promise<AsyncIterator<ExecutionResult<TReturn>> | ExecutionResult<TReturn>>;


### PR DESCRIPTION
## Description

See https://github.com/ardatan/graphql-tools/pull/2749 and
https://github.com/ardatan/graphql-tools/commit/58fd4b285ae9eff9c2098c5d589a14cfa0f03718
for some history.

There's still one more problem however: an Executor is still a generic
function over any possible context type. <TContext = TBaseContext>
merely sets a default if the function is called without explicit type 
arguments, but implementation is still required to work with any other 
type that may be passed for `TContext`.
                            
Since context exists to hold application-specific information, requiring
executors to be generic is not useful. An application's implementation 
of resolvers, executors, subscribers, etc. will only work with that 
application's context type and can't be generic.

An example of how the previous typing fails in my server implementation:

```ts
import { ExecutionParams, Executor } from '@graphql-tools/utils';
import { Context } from '../context';

async function apiExecutor({
  document,
  variables,
  context,
}: ExecutionParams<Record<string, any>, Context>): Promise<Record<string, any>> {
  const query = print(document);
  const result = await context!.connectors.internalApiConnector.post('/graphql', {
    query,
    variables,
  });
  return result;
}

const myExecutor: Executor<Context> = apiExecutor;
```

Fails to compile with:

```
src/data/schema.ts:36:7 - error TS2322: Type '({ document, variables, context, }: ExecutionParams<Record<string, any>, Context>) => Promise<Record<string, any>>' is not assignable to type 'Executor<Context>'.
  Types of parameters '__0' and 'params' are incompatible.
    Type 'ExecutionParams<TArgs, TContext>' is not assignable to type 'ExecutionParams<Record<string, any>, Context>'.
      Type 'TContext' is not assignable to type 'Context'.

36 const myExecutor: Executor<Context> = apiExecutor;
         ~~~~~~~~~~
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)
Though I could see an argument for this being a bug fix, or a breaking change. 🤷 

## How Has This Been Tested?

I've tested in my graphql server implementation and I'm able to get it to compile without type errors or other shenanigans like casting to `any`

**Test Environment**:
- OS: MacOS 10.15.7
- @graphql-tools/batch-delegate@7.0.2
- @graphql-tools/batch-execute@7.1.2
- @graphql-tools/delegate@7.1.5
- @graphql-tools/graphql-file-loader@6.2.7
- @graphql-tools/import@6.3.0
- @graphql-tools/load@6.2.8
- @graphql-tools/merge@6.2.14
- @graphql-tools/mock@8.1.3
- @graphql-tools/schema@7.1.5
- @graphql-tools/stitch@7.5.3
- @graphql-tools/url-loader@6.10.1
- @graphql-tools/utils@7.9.1
- @graphql-tools/wrap@7.0.8
- NodeJS: v12.22.1
- tsc 4.1.3

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
