### PR TITLE
Properly bind resolver function to class instance

### DIFF
--- a/packages/schema/src/addResolversToSchema.ts
+++ b/packages/schema/src/addResolversToSchema.ts
@@ -130,13 +130,17 @@ export function addResolversToSchema(
             const fields = type.getFields();
             const field = fields[fieldName];
 
-            if (field == null && requireResolversToMatchSchema && requireResolversToMatchSchema !== 'ignore') {
-              throw new Error(`${typeName}.${fieldName} defined in resolvers, but not in schema`);
-            }
-
-            const fieldResolve = resolverValue[fieldName];
-            if (typeof fieldResolve !== 'function' && typeof fieldResolve !== 'object') {
-              throw new Error(`Resolver ${typeName}.${fieldName} must be object or function`);
+            if (field == null) {
+              // Field present in resolver but not in schema
+              if (requireResolversToMatchSchema && requireResolversToMatchSchema !== 'ignore') {
+                throw new Error(`${typeName}.${fieldName} defined in resolvers, but not in schema`);
+              }
+            } else {
+              // Field present in both the resolver and schema
+              const fieldResolve = resolverValue[fieldName];
+              if (typeof fieldResolve !== 'function' && typeof fieldResolve !== 'object') {
+                throw new Error(`Resolver ${typeName}.${fieldName} must be object or function`);
+              }
             }
           }
         });

--- a/packages/schema/src/addResolversToSchema.ts
+++ b/packages/schema/src/addResolversToSchema.ts
@@ -244,7 +244,7 @@ function addResolversToExistingSchema(
             const fieldResolve = resolverValue[fieldName];
             if (typeof fieldResolve === 'function') {
               // for convenience. Allows shorter syntax in resolver definition file
-              field.resolve = fieldResolve;
+              field.resolve = fieldResolve.bind(resolverValue);
             } else {
               setFieldProperties(field, fieldResolve);
             }
@@ -398,7 +398,7 @@ function createNewSchemaWithResolvers(
           const newFieldConfig = { ...fieldConfig };
           if (typeof fieldResolve === 'function') {
             // for convenience. Allows shorter syntax in resolver definition file
-            newFieldConfig.resolve = fieldResolve;
+            newFieldConfig.resolve = fieldResolve.bind(resolverValue);
           } else {
             setFieldProperties(newFieldConfig, fieldResolve);
           }

--- a/packages/schema/tests/schemaGenerator.test.ts
+++ b/packages/schema/tests/schemaGenerator.test.ts
@@ -737,6 +737,44 @@ describe('generating schema from shorthand', () => {
       expect(result).toEqual(solution as ExecutionResult),
     );
   });
+  
+  test('works with classes as resolvers', () => {
+    const typeDefs = `
+      type Query {
+        version: Int
+      }
+    `;
+    
+    const QueryResolver = class QueryResolver() {
+      private internalVersion: number = 1
+
+      version(root, args, context) {
+        return this.internalVersion
+      }
+    }
+
+    const resolvers = {
+      Query: new QueryResolver(),
+    };
+
+    const testQuery = `{
+      version
+    }`;
+
+    const solution = {
+      data: {
+        version: 1
+      },
+    };
+    const jsSchema = makeExecutableSchema({
+      typeDefs: typeDefs,
+      resolvers: resolvers,
+    });
+    const resultPromise = graphql(jsSchema, testQuery);
+    return resultPromise.then((result) =>
+      expect(result).toEqual(solution as ExecutionResult),
+    );
+  });
 
   describe('scalar types', () => {
     test('supports passing a GraphQLScalarType in resolveFunctions', () => {

--- a/packages/schema/tests/schemaGenerator.test.ts
+++ b/packages/schema/tests/schemaGenerator.test.ts
@@ -769,6 +769,9 @@ describe('generating schema from shorthand', () => {
     const jsSchema = makeExecutableSchema({
       typeDefs: typeDefs,
       resolvers: resolvers,
+      resolverValidationOptions: {
+        requireResolversToMatchSchema: 'ignore',
+      },
     });
     const resultPromise = graphql(jsSchema, testQuery);
     return resultPromise.then((result) =>

--- a/packages/schema/tests/schemaGenerator.test.ts
+++ b/packages/schema/tests/schemaGenerator.test.ts
@@ -746,9 +746,9 @@ describe('generating schema from shorthand', () => {
     `;
     
     const QueryResolver = class QueryResolver {
-      private internalVersion: number = 1
+      private internalVersion = 1
 
-      version(root, args, context) {
+      version(root: any, args: any, context: any) {
         return this.internalVersion
       }
     }

--- a/packages/schema/tests/schemaGenerator.test.ts
+++ b/packages/schema/tests/schemaGenerator.test.ts
@@ -745,7 +745,7 @@ describe('generating schema from shorthand', () => {
       }
     `;
     
-    const QueryResolver = class QueryResolver() {
+    const QueryResolver = class QueryResolver {
       private internalVersion: number = 1
 
       version(root, args, context) {


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

## Description

If resolvers are implemented as methods in a class and invoke this, then this leads to an error as this in undefined when the resolver is invoked. For example, the following does not work as `this` inside `myResolver` is undefined.

```ts
resolvers = {
   Query: new QueryResolver()
   ....
}

class QueryResolver() {
    private someVariable: string = 'a'

    myResolver(root, args, context) {
         return this.someVariable
    }
}
```
The reason for this bug is that the resolver method is invoked out of context without prior binding of `this` to the instance.

Related https://github.com/ardatan/graphql-tools/issues/3020.
<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?
Using unit tests in my project. In the PR https://github.com/JabRef/JabRefOnline/pull/159 the tests fail:
```
"errors": Array [
    +     [GraphQLError: Cannot read property 'authService' of undefined],
        ],
```
which is triggered by this line https://github.com/JabRef/JabRefOnline/pull/159/files#diff-8e682eac514240b1b973d62cf1a4cc23adb5919f9fa89fd9fa187bb8b578db95R24. The resolvers are created as new instances here:
https://github.com/JabRef/JabRefOnline/pull/159/files#diff-8e682eac514240b1b973d62cf1a4cc23adb5919f9fa89fd9fa187bb8b578db95R102-R106

But with the proposed changes it works (tested locally by changing the code in `node_modules/graphql-tools`).


**Test Environment**:
- OS: Win 10
- `@graphql-tools/schema`: 7.1.5,
- NodeJS: 15.6

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
