### PR TITLE
Merge prototypes of resolvers

### DIFF
--- a/packages/merge/src/merge-resolvers.ts
+++ b/packages/merge/src/merge-resolvers.ts
@@ -55,17 +55,18 @@ export function mergeResolvers<TContext, T extends ResolversDefinition<TContext>
     return singleDefinition;
   }
 
-  const resolversFactories = new Array<ResolversFactory<TContext>>();
-  const resolvers = new Array<IResolvers<any, TContext>>();
+  type TFactory = (...args: any[]) => T;
+  const resolversFactories = new Array<TFactory>();
+  const resolvers = new Array<T>();
 
   for (let resolversDefinition of resolversDefinitions) {
     if (Array.isArray(resolversDefinition)) {
       resolversDefinition = mergeResolvers(resolversDefinition);
     }
     if (typeof resolversDefinition === 'function') {
-      resolversFactories.push(resolversDefinition as ResolversFactory<TContext>);
+      resolversFactories.push(resolversDefinition as unknown as TFactory);
     } else if (typeof resolversDefinition === 'object') {
-      resolvers.push(resolversDefinition as IResolvers<any, TContext>);
+      resolvers.push(resolversDefinition);
     }
   }
   let result: T = {} as T;
@@ -75,7 +76,7 @@ export function mergeResolvers<TContext, T extends ResolversDefinition<TContext>
       return resolvers.concat(resultsOfFactories).reduce(mergeDeep, {});
     }) as any;
   } else {
-    result = resolvers.reduce(mergeDeep, {});
+    result = resolvers.reduce(mergeDeep, {} as T);
   }
   if (options && options.exclusions) {
     for (const exclusion of options.exclusions) {

--- a/packages/utils/src/mergeDeep.ts
+++ b/packages/utils/src/mergeDeep.ts
@@ -12,30 +12,27 @@ export function mergeDeep<T extends object, S extends any[]>(
     return target as any;
   }
   const output = {};
+  Object.setPrototypeOf(output, Object.create(Object.getPrototypeOf(target)));
   for (const source of [target, ...sources]) {
     if (isObject(target) && isObject(source)) {
-      for (const key in source) {
-        if (isObject(source[key])) {
-          if (!(key in target)) {
-            Object.assign(output, { [key]: source[key] });
-          } else {
-            output[key] = mergeDeep(target[key], source[key]);
-          }
-        } else {
-          Object.assign(output, { [key]: source[key] });
-        }
-      }
-
       const outputPrototype = Object.getPrototypeOf(output);
       const sourcePrototype = Object.getPrototypeOf(source);
       if (sourcePrototype) {
-        if (outputPrototype) {
-          Object.getOwnPropertyNames(sourcePrototype).forEach(key => {
-            const descriptor = Object.getOwnPropertyDescriptor(sourcePrototype, key);
-            Object.defineProperty(outputPrototype, key, descriptor);
-          });
+        Object.getOwnPropertyNames(sourcePrototype).forEach(key => {
+          const descriptor = Object.getOwnPropertyDescriptor(sourcePrototype, key);
+          Object.defineProperty(outputPrototype, key, descriptor);
+        });
+      }
+
+      for (const key in source) {
+        if (isObject(source[key])) {
+          if (!(key in output)) {
+            Object.assign(output, { [key]: source[key] });
+          } else {
+            output[key] = mergeDeep(output[key], source[key]);
+          }
         } else {
-          Object.setPrototypeOf(output, sourcePrototype);
+          Object.assign(output, { [key]: source[key] });
         }
       }
     }

--- a/packages/utils/src/mergeDeep.ts
+++ b/packages/utils/src/mergeDeep.ts
@@ -7,7 +7,7 @@ type UnboxIntersection<T> = T extends { 0: infer U } ? U : never;
 export function mergeDeep<T extends object, S extends any[]>(
   target: T,
   ...sources: S
-): T & UnboxIntersection<UnionToIntersection<BoxedTupleTypes<S>>> {
+): T & UnboxIntersection<UnionToIntersection<BoxedTupleTypes<S>>> & any {
   if (isScalarType(target)) {
     return target as any;
   }

--- a/packages/utils/tests/mergeDeep.test.ts
+++ b/packages/utils/tests/mergeDeep.test.ts
@@ -39,6 +39,7 @@ describe('mergeDeep', () => {
     const merged = mergeDeep({ one: new ClassA()}, { one: new ClassB()})
     expect(merged.one.a()).toEqual('a')
     expect(merged.one.b()).toEqual('b')
+    expect(merged.a).toBeUndefined()
   })
 
   test('strips property symbols', () => {

--- a/packages/utils/tests/mergeDeep.test.ts
+++ b/packages/utils/tests/mergeDeep.test.ts
@@ -1,0 +1,54 @@
+import { mergeDeep } from '@graphql-tools/utils'
+
+describe('mergeDeep', () => {
+  test('merges prototypes', () => {
+    const ClassA = class {
+      a() {
+        return 'a'
+      }
+    }
+    const ClassB = class {
+      b() {
+        return 'b'
+      }
+    }
+
+    const merged = mergeDeep(new ClassA(), new ClassB())
+    expect(merged.a()).toEqual('a')
+    expect(merged.b()).toEqual('b')
+  })
+
+  test('merges deeply', () => {
+    const x = { a: { one: 1 } }
+    const y = { a: { two: 2 } }
+    expect(mergeDeep(x, y)).toEqual({ a: { one: 1, two: 2 } })
+  })
+
+  test('merges prototype deeply', () => {
+    const ClassA = class {
+      a() {
+        return 'a'
+      }
+    }
+    const ClassB = class {
+      b() {
+        return 'b'
+      }
+    }
+
+    const merged = mergeDeep({ one: new ClassA()}, { one: new ClassB()})
+    expect(merged.one.a()).toEqual('a')
+    expect(merged.one.b()).toEqual('b')
+  })
+
+  test('strips property symbols', () => {
+    const x = {}
+    const symbol = Symbol('symbol')
+    x[symbol] = 'value'
+    const y = { a: 2 }
+
+    const merged = mergeDeep(x, y)
+    expect(merged).toStrictEqual({ a: 2 })
+    expect(Object.getOwnPropertySymbols(merged)).toEqual([])
+  })
+})


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

## Description

The `mergeDeep` function only merged enumerable properties of the objects, and ignored methods / properties from the prototype chain. This is fixed, and a few tests are added for this method as well.

Related #3038
<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):



## How Has This Been Tested?

Using the added unit tests

**Test Environment**:
- OS: Win 10
- `@graphql-tools/...`: master branch
- NodeJS: 

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments


