### PR TITLE
Make resoveType work when implemented in a class

### DIFF
--- a/packages/schema/src/addResolversToSchema.ts
+++ b/packages/schema/src/addResolversToSchema.ts
@@ -61,7 +61,7 @@ export function addResolversToSchema(
     ? extendResolversFromInterfaces(schema, inputResolvers)
     : inputResolvers;
 
-  Object.keys(resolvers).forEach(typeName => {
+  Object.getOwnPropertyNames(resolvers).forEach(typeName => {
     const resolverValue = resolvers[typeName];
     const resolverType = typeof resolverValue;
 
@@ -69,7 +69,7 @@ export function addResolversToSchema(
       if (resolverType !== 'function') {
         throw new Error(
           `"${typeName}" defined in resolvers, but has invalid value "${
-            (resolverValue as unknown) as string
+            resolverValue as unknown as string
           }". A schema resolver's value must be of type object or function.`
         );
       }
@@ -77,7 +77,7 @@ export function addResolversToSchema(
       if (resolverType !== 'object') {
         throw new Error(
           `"${typeName}" defined in resolvers, but has invalid value "${
-            (resolverValue as unknown) as string
+            resolverValue as unknown as string
           }". The resolver's value must be of type object.`
         );
       }
@@ -92,7 +92,7 @@ export function addResolversToSchema(
         throw new Error(`"${typeName}" defined in resolvers, but not in schema`);
       } else if (isSpecifiedScalarType(type)) {
         // allow -- without recommending -- overriding of specified scalar types
-        Object.keys(resolverValue).forEach(fieldName => {
+        Object.getOwnPropertyNames(resolverValue).forEach(fieldName => {
           if (fieldName.startsWith('__')) {
             type[fieldName.substring(2)] = resolverValue[fieldName];
           } else {
@@ -102,7 +102,7 @@ export function addResolversToSchema(
       } else if (isEnumType(type)) {
         const values = type.getValues();
 
-        Object.keys(resolverValue).forEach(fieldName => {
+        Object.getOwnPropertyNames(resolverValue).forEach(fieldName => {
           if (
             !fieldName.startsWith('__') &&
             !values.some(value => value.name === fieldName) &&
@@ -113,7 +113,7 @@ export function addResolversToSchema(
           }
         });
       } else if (isUnionType(type)) {
-        Object.keys(resolverValue).forEach(fieldName => {
+        Object.getOwnPropertyNames(resolverValue).forEach(fieldName => {
           if (
             !fieldName.startsWith('__') &&
             requireResolversToMatchSchema &&
@@ -125,7 +125,7 @@ export function addResolversToSchema(
           }
         });
       } else if (isObjectType(type) || isInterfaceType(type)) {
-        Object.keys(resolverValue).forEach(fieldName => {
+        Object.getOwnPropertyNames(resolverValue).forEach(fieldName => {
           if (!fieldName.startsWith('__')) {
             const fields = type.getFields();
             const field = fields[fieldName];
@@ -165,13 +165,13 @@ function addResolversToExistingSchema(
   defaultFieldResolver: GraphQLFieldResolver<any, any>
 ): GraphQLSchema {
   const typeMap = schema.getTypeMap();
-  Object.keys(resolvers).forEach(typeName => {
+  getAllPropertyNames(resolvers).forEach(typeName => {
     if (typeName !== '__schema') {
       const type = schema.getType(typeName);
       const resolverValue = resolvers[typeName];
 
       if (isScalarType(type)) {
-        Object.keys(resolverValue).forEach(fieldName => {
+        getAllPropertyNames(resolverValue).forEach(fieldName => {
           if (fieldName.startsWith('__')) {
             type[fieldName.substring(2)] = resolverValue[fieldName];
           } else if (fieldName === 'astNode' && type.astNode != null) {
@@ -200,7 +200,7 @@ function addResolversToExistingSchema(
         const config = type.toConfig();
         const enumValueConfigMap = config.values;
 
-        Object.keys(resolverValue).forEach(fieldName => {
+        getAllPropertyNames(resolverValue).forEach(fieldName => {
           if (fieldName.startsWith('__')) {
             config[fieldName.substring(2)] = resolverValue[fieldName];
           } else if (fieldName === 'astNode' && config.astNode != null) {
@@ -228,13 +228,13 @@ function addResolversToExistingSchema(
 
         typeMap[typeName] = new GraphQLEnumType(config);
       } else if (isUnionType(type)) {
-        Object.keys(resolverValue).forEach(fieldName => {
+        getAllPropertyNames(resolverValue).forEach(fieldName => {
           if (fieldName.startsWith('__')) {
             type[fieldName.substring(2)] = resolverValue[fieldName];
           }
         });
       } else if (isObjectType(type) || isInterfaceType(type)) {
-        Object.keys(resolverValue).forEach(fieldName => {
+        getAllPropertyNames(resolverValue).forEach(fieldName => {
           if (fieldName.startsWith('__')) {
             // this is for isTypeOf and resolveType and all the other stuff.
             type[fieldName.substring(2)] = resolverValue[fieldName];
@@ -286,7 +286,7 @@ function createNewSchemaWithResolvers(
       const config = type.toConfig();
       const resolverValue = resolvers[type.name];
       if (!isSpecifiedScalarType(type) && resolverValue != null) {
-        Object.keys(resolverValue).forEach(fieldName => {
+        getAllPropertyNames(resolverValue).forEach(fieldName => {
           if (fieldName.startsWith('__')) {
             config[fieldName.substring(2)] = resolverValue[fieldName];
           } else if (fieldName === 'astNode' && config.astNode != null) {
@@ -322,7 +322,7 @@ function createNewSchemaWithResolvers(
       const enumValueConfigMap = config.values;
 
       if (resolverValue != null) {
-        Object.keys(resolverValue).forEach(fieldName => {
+        getAllPropertyNames(resolverValue).forEach(fieldName => {
           if (fieldName.startsWith('__')) {
             config[fieldName.substring(2)] = resolverValue[fieldName];
           } else if (fieldName === 'astNode' && config.astNode != null) {
@@ -356,7 +356,7 @@ function createNewSchemaWithResolvers(
 
       if (resolverValue != null) {
         const config = type.toConfig();
-        Object.keys(resolverValue).forEach(fieldName => {
+        getAllPropertyNames(resolverValue).forEach(fieldName => {
           if (fieldName.startsWith('__')) {
             config[fieldName.substring(2)] = resolverValue[fieldName];
           }
@@ -370,7 +370,7 @@ function createNewSchemaWithResolvers(
       if (resolverValue != null) {
         const config = type.toConfig();
 
-        Object.keys(resolverValue).forEach(fieldName => {
+        getAllPropertyNames(resolverValue).forEach(fieldName => {
           if (fieldName.startsWith('__')) {
             config[fieldName.substring(2)] = resolverValue[fieldName];
           }
@@ -384,7 +384,7 @@ function createNewSchemaWithResolvers(
       if (resolverValue != null) {
         const config = type.toConfig();
 
-        Object.keys(resolverValue).forEach(fieldName => {
+        getAllPropertyNames(resolverValue).forEach(fieldName => {
           if (fieldName.startsWith('__')) {
             config[fieldName.substring(2)] = resolverValue[fieldName];
           }
@@ -431,4 +431,11 @@ function setFieldProperties(
   Object.keys(propertiesObj).forEach(propertyName => {
     field[propertyName] = propertiesObj[propertyName];
   });
+}
+
+function getAllPropertyNames(obj: any): string[] {
+  const prototype = Object.getPrototypeOf(obj);
+  let inherited = prototype ? getAllPropertyNames(prototype) : [];
+  inherited = inherited.filter(property => property !== 'constructor');
+  return [...new Set(Object.getOwnPropertyNames(obj).concat(inherited))];
 }

--- a/packages/schema/tests/schemaGenerator.test.ts
+++ b/packages/schema/tests/schemaGenerator.test.ts
@@ -737,14 +737,14 @@ describe('generating schema from shorthand', () => {
       expect(result).toEqual(solution as ExecutionResult),
     );
   });
-  
+
   test('works with classes as resolvers', () => {
     const typeDefs = `
       type Query {
         version: Int
       }
     `;
-    
+
     const QueryResolver = class QueryResolver {
       private internalVersion = 1
 
@@ -2612,6 +2612,34 @@ describe('interfaces', () => {
     });
     const response = await graphql(schema, query);
     expect(response.errors).not.toBeDefined();
+  });
+  test('does not throw if there is an interface resolveType resolver implemented in class', async () => {
+    const NodeResolver = class {
+      __resolveType ({ type }: { type: string }): string {
+        return type
+      }
+    }
+    const resolvers = {
+      Query: queryResolver,
+      Node: new NodeResolver(),
+    };
+    const schema = makeExecutableSchema({
+      typeDefs: testSchemaWithInterfaces,
+      resolvers,
+      resolverValidationOptions: { requireResolversForResolveType: 'error' },
+    });
+    const response = await graphql(schema, query);
+    expect(response.errors).not.toBeDefined();
+    expect(response.data).toEqual({
+      'node': {
+        '__typename': 'User',
+        'id': '1',
+      },
+      'user': {
+        'id': '1',
+        'name': 'Kim',
+      }
+    })
   });
   test('does not warn if requireResolversForResolveType is disabled and there are missing resolvers', () => {
     const resolvers = {


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

## Description

When the resolver of an interface type is implemented via a class, and contains a `__resolveType` function, then this function is not discovered properly and one gets the error `Type "..." is missing a "__resolveType" resolver.`. Reason for this is that only own enumerable properties from the resolver are taken into account, but the `__resolveType` function is coming from the prototype chain. I implemented a `getAllPropertyNames` function that takes all properties (enumerable or not) from the complete prototype chain into account.

Related # (issue)
<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):



## How Has This Been Tested?

Using the added unit test.

**Test Environment**:
- OS: Win 10
- `@graphql-tools/...`: master
- NodeJS:

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

I've restricted the validation of the resolver interface to take only own properties into account, because otherwise methods coming from the `Object` prototype lead to warnings as they are defined in the resolver but not schema.
