### PR TITLE
Properly skip validation when requested

### DIFF
--- a/.changeset/shaggy-news-greet.md
+++ b/.changeset/shaggy-news-greet.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/schema': minor
+---
+
+Add option to skip schema validation in `makeExecutableSchema` (`assumeValidSchema`)

--- a/packages/schema/src/addResolversToSchema.ts
+++ b/packages/schema/src/addResolversToSchema.ts
@@ -69,7 +69,7 @@ export function addResolversToSchema(
       if (resolverType !== 'function') {
         throw new Error(
           `"${typeName}" defined in resolvers, but has invalid value "${
-            (resolverValue as unknown) as string
+            resolverValue as unknown as string
           }". A schema resolver's value must be of type object or function.`
         );
       }
@@ -77,7 +77,7 @@ export function addResolversToSchema(
       if (resolverType !== 'object') {
         throw new Error(
           `"${typeName}" defined in resolvers, but has invalid value "${
-            (resolverValue as unknown) as string
+            resolverValue as unknown as string
           }". The resolver's value must be of type object.`
         );
       }
@@ -152,7 +152,7 @@ export function addResolversToSchema(
     ? addResolversToExistingSchema(schema, resolvers, defaultFieldResolver)
     : createNewSchemaWithResolvers(schema, resolvers, defaultFieldResolver);
 
-  if (requireResolversForResolveType || requireResolversForResolveType !== 'ignore') {
+  if (requireResolversForResolveType && requireResolversForResolveType !== 'ignore') {
     checkForResolveTypeResolver(schema, requireResolversForResolveType);
   }
 

--- a/packages/schema/src/buildSchemaFromTypeDefinitions.ts
+++ b/packages/schema/src/buildSchemaFromTypeDefinitions.ts
@@ -8,21 +8,22 @@ import { concatenateTypeDefs } from './concatenateTypeDefs';
 export function buildSchemaFromTypeDefinitions(
   typeDefinitions: ITypeDefinitions,
   parseOptions?: GraphQLParseOptions,
-  noExtensionExtraction?: boolean
+  noExtensionExtraction?: boolean,
+  assumeValidSchema?: boolean
 ): GraphQLSchema {
   const document = buildDocumentFromTypeDefinitions(typeDefinitions, parseOptions);
 
   if (noExtensionExtraction) {
-    return buildASTSchema(document);
+    return buildASTSchema(document, { assumeValid: assumeValidSchema });
   }
 
   const { typesAst, extensionsAst } = filterAndExtractExtensionDefinitions(document);
 
-  const backcompatOptions = { commentDescriptions: true };
-  let schema: GraphQLSchema = buildASTSchema(typesAst, backcompatOptions);
+  const buildAstOptions = { assumeValid: assumeValidSchema, commentDescriptions: true };
+  let schema: GraphQLSchema = buildASTSchema(typesAst, buildAstOptions);
 
   if (extensionsAst.definitions.length > 0) {
-    schema = extendSchema(schema, extensionsAst, backcompatOptions);
+    schema = extendSchema(schema, extensionsAst, buildAstOptions);
   }
 
   return schema;

--- a/packages/schema/src/makeExecutableSchema.ts
+++ b/packages/schema/src/makeExecutableSchema.ts
@@ -69,6 +69,7 @@ export function makeExecutableSchema<TContext = any>({
   pruningOptions,
   updateResolversInPlace = false,
   noExtensionExtraction = false,
+  assumeValidSchema = false,
 }: IExecutableSchemaDefinition<TContext>) {
   // Validate and clean up arguments
   if (typeof resolverValidationOptions !== 'object') {
@@ -93,7 +94,10 @@ export function makeExecutableSchema<TContext = any>({
         updateResolversInPlace,
       });
 
-      if (Object.keys(resolverValidationOptions).length > 0) {
+      if (
+        Object.keys(resolverValidationOptions).length > 0 &&
+        Object.values(resolverValidationOptions).some(o => o !== 'ignore')
+      ) {
         assertResolversPresent(schemaWithResolvers, resolverValidationOptions);
       }
 
@@ -140,7 +144,12 @@ export function makeExecutableSchema<TContext = any>({
     schemaTransforms.push(pruneSchema);
   }
 
-  const schemaFromTypeDefs = buildSchemaFromTypeDefinitions(typeDefs, parseOptions, noExtensionExtraction);
+  const schemaFromTypeDefs = buildSchemaFromTypeDefinitions(
+    typeDefs,
+    parseOptions,
+    noExtensionExtraction,
+    assumeValidSchema
+  );
 
   return schemaTransforms.reduce((schema, schemaTransform) => schemaTransform(schema), schemaFromTypeDefs);
 }

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -75,6 +75,10 @@ export interface IExecutableSchemaDefinition<TContext = any> {
    * Do not extract and apply extensions separately and leave it to `buildASTSchema`
    */
   noExtensionExtraction?: boolean;
+  /**
+   * Assume schema is valid (so skip all validation)
+   */
+  assumeValidSchema?: boolean;
 }
 
 export type ExecutableSchemaTransformation = (schema: GraphQLSchema) => GraphQLSchema;


### PR DESCRIPTION
## Description

- Resolver validation was incorrectly ran when it was supposed to be skipped, causing extra work in makeExecutableSchema
- Add option to skip schema validation when building schema in makeExecutableSchema

Related #3056 #3057

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:
- OS:
- `@graphql-tools/...`:
- NodeJS:

## Checklist:

- [X] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests and linter rules pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
