### PR TITLE
Safer use of `Object.prototype.hasOwnProperty`

### DIFF
--- a/.changeset/fifty-wombats-help.md
+++ b/.changeset/fifty-wombats-help.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/mock': patch
+---
+
+Safer use of Object.prototype.hasOwnProperty #3069

--- a/packages/mock/src/types.ts
+++ b/packages/mock/src/types.ts
@@ -190,7 +190,7 @@ export type Ref<KeyT extends KeyTypeConstraints = string> = {
 };
 
 export function isRef<KeyT extends KeyTypeConstraints = string>(maybeRef: unknown): maybeRef is Ref<KeyT> {
-  return maybeRef && typeof maybeRef === 'object' && maybeRef.hasOwnProperty('$ref');
+  return maybeRef && typeof maybeRef === 'object' && Object.prototype.hasOwnProperty.call(maybeRef, '$ref');
 }
 
 export function assertIsRef<KeyT extends KeyTypeConstraints = string>(

--- a/packages/mock/src/types.ts
+++ b/packages/mock/src/types.ts
@@ -190,7 +190,7 @@ export type Ref<KeyT extends KeyTypeConstraints = string> = {
 };
 
 export function isRef<KeyT extends KeyTypeConstraints = string>(maybeRef: unknown): maybeRef is Ref<KeyT> {
-  return maybeRef && typeof maybeRef === 'object' && Object.prototype.hasOwnProperty.call(maybeRef, '$ref');
+  return maybeRef && typeof maybeRef === 'object' && '$ref' in maybeRef;
 }
 
 export function assertIsRef<KeyT extends KeyTypeConstraints = string>(


### PR DESCRIPTION
Fixes an error I get when GraphQL JS passes a prototypeless object into the resolver

```
ReferenceError: maybeRef is not defined
    at eval (eval at <anonymous> (/Users/mattalexander/Projects/edge-sites-schema/tests/regression.test.js:67:7), <anonymous>:1:38)
    at forEach (/projectpath/tests/regression.test.js:67:7)
    at Array.forEach (<anonymous>)
    at Object.<anonymous> (/projectpath/tests/regression.test.js:65:17)
```

<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Related # (issue)
<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:
- OS:
- `@graphql-tools/...`:
- NodeJS:

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
