### PR TITLE
BugFix: Handle parsing endpoints when there are no mutations

### DIFF
--- a/.changeset/grumpy-months-nail.md
+++ b/.changeset/grumpy-months-nail.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/resolvers-composition': patch
+---
+
+BugFix: Handle parsing endpoints when there are no mutations #3076

--- a/packages/resolvers-composition/src/resolvers-composition.ts
+++ b/packages/resolvers-composition/src/resolvers-composition.ts
@@ -50,8 +50,12 @@ function resolveRelevantMappings<Resolvers extends Record<string, any> = Record<
     }
 
     if (fieldName === '*') {
+      const endpoints = resolvers[typeName];
+      if (!endpoints) {
+          return []
+      }
       return flatten(
-        Object.keys(resolvers[typeName]).map(field =>
+        Object.keys(endpoints).map(field =>
           resolveRelevantMappings(resolvers, `${typeName}.${field}`, allMappings)
         )
       ).filter(mapItem => !allMappings[mapItem]);


### PR DESCRIPTION
## Description

Bug fix - Checking if there are any endpoints before treating them as an array.
On a specific occasion there were no mutations so trying to do Object.keys(undefined) threw an exception. 

Related https://github.com/ardatan/graphql-tools/issues/3075
<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
