### PR TITLE
Remove info from ExecutionParams and add operationType

### DIFF
--- a/.changeset/lazy-turtles-dress.md
+++ b/.changeset/lazy-turtles-dress.md
@@ -1,0 +1,12 @@
+---
+'@graphql-tools/batch-execute': major
+'@graphql-tools/delegate': major
+'@graphql-tools/links': major
+'@graphql-tools/utils': major
+'@graphql-tools/wrap': major
+---
+
+BREAKING CHANGES;
+
+- Drop unnecessary `GraphQLResolveInfo` in `ExecutionParams`
+- Add required `operationType: OperationTypeNode` field in `ExecutionParams`

--- a/.changeset/lazy-turtles-dress.md
+++ b/.changeset/lazy-turtles-dress.md
@@ -11,6 +11,7 @@ BREAKING CHANGES;
 - Rename `Request` to `ExecutionRequest`
 - Drop unnecessary `GraphQLResolveInfo` in `ExecutionRequest`
 - Add required `operationType: OperationTypeNode` field in `ExecutionRequest`
+- Add `context` in `createRequest` and `createRequestInfo` instead of `delegateToSchema`
 
 > It doesn't rely on info.operation.operationType to allow the user to call an operation from different root type.
 And it doesn't call getOperationAST again and again to get operation type from the document/operation because we have it in Request and ExecutionParams

--- a/.changeset/lazy-turtles-dress.md
+++ b/.changeset/lazy-turtles-dress.md
@@ -8,9 +8,17 @@
 
 BREAKING CHANGES;
 
-- Drop unnecessary `GraphQLResolveInfo` in `ExecutionParams`
-- Add required `operationType: OperationTypeNode` field in `ExecutionParams`
+- Rename `Request` to `ExecutionRequest`
+- Drop unnecessary `GraphQLResolveInfo` in `ExecutionRequest`
+- Add required `operationType: OperationTypeNode` field in `ExecutionRequest`
+
+> It doesn't rely on info.operation.operationType to allow the user to call an operation from different root type.
+And it doesn't call getOperationAST again and again to get operation type from the document/operation because we have it in Request and ExecutionParams
+https://github.com/ardatan/graphql-tools/pull/3166/files#diff-d4824895ea613dcc1f710c3ac82e952fe0ca12391b671f70d9f2d90d5656fdceR38
 
 Improvements;
-
 - Memoize `defaultExecutor` for a single `GraphQLSchema` so allow `getBatchingExecutor` to memoize `batchingExecutor` correctly.
+- And there is no different `defaultExecutor` is created for `subscription` and other operation types. Only one executor is used.
+
+> Batch executor is memoized by `executor` reference but `createDefaultExecutor` didn't memoize the default executor so this memoization wasn't working correctly on `batch-execute` side.
+https://github.com/ardatan/graphql-tools/blob/remove-info-executor/packages/batch-execute/src/getBatchingExecutor.ts#L9

--- a/.changeset/lazy-turtles-dress.md
+++ b/.changeset/lazy-turtles-dress.md
@@ -10,3 +10,7 @@ BREAKING CHANGES;
 
 - Drop unnecessary `GraphQLResolveInfo` in `ExecutionParams`
 - Add required `operationType: OperationTypeNode` field in `ExecutionParams`
+
+Improvements;
+
+- Memoize `defaultExecutor` for a single `GraphQLSchema` so allow `getBatchingExecutor` to memoize `batchingExecutor` correctly.

--- a/packages/batch-execute/src/createBatchingExecutor.ts
+++ b/packages/batch-execute/src/createBatchingExecutor.ts
@@ -2,7 +2,7 @@ import DataLoader from 'dataloader';
 
 import { ValueOrPromise } from 'value-or-promise';
 
-import { Request, Executor, ExecutionResult } from '@graphql-tools/utils';
+import { ExecutionRequest, Executor, ExecutionResult } from '@graphql-tools/utils';
 
 import { mergeRequests } from './mergeRequests';
 import { splitResult } from './splitResult';
@@ -12,24 +12,24 @@ export function createBatchingExecutor(
   dataLoaderOptions?: DataLoader.Options<any, any, any>,
   extensionsReducer: (
     mergedExtensions: Record<string, any>,
-    request: Request
+    request: ExecutionRequest
   ) => Record<string, any> = defaultExtensionsReducer
 ): Executor {
   const loader = new DataLoader(createLoadFn(executor, extensionsReducer), dataLoaderOptions);
-  return (request: Request) => {
+  return (request: ExecutionRequest) => {
     return request.operationType === 'subscription' ? executor(request) : loader.load(request);
   };
 }
 
 function createLoadFn(
   executor: Executor,
-  extensionsReducer: (mergedExtensions: Record<string, any>, request: Request) => Record<string, any>
+  extensionsReducer: (mergedExtensions: Record<string, any>, request: ExecutionRequest) => Record<string, any>
 ) {
-  return async (requests: ReadonlyArray<Request>): Promise<Array<ExecutionResult>> => {
-    const execBatches: Array<Array<Request>> = [];
+  return async (requests: ReadonlyArray<ExecutionRequest>): Promise<Array<ExecutionResult>> => {
+    const execBatches: Array<Array<ExecutionRequest>> = [];
     let index = 0;
     const request = requests[index];
-    let currentBatch: Array<Request> = [request];
+    let currentBatch: Array<ExecutionRequest> = [request];
     execBatches.push(currentBatch);
 
     const operationType = request.operationType;
@@ -64,7 +64,10 @@ function createLoadFn(
   };
 }
 
-function defaultExtensionsReducer(mergedExtensions: Record<string, any>, request: Request): Record<string, any> {
+function defaultExtensionsReducer(
+  mergedExtensions: Record<string, any>,
+  request: ExecutionRequest
+): Record<string, any> {
   const newExtensions = request.extensions;
   if (newExtensions != null) {
     Object.assign(mergedExtensions, newExtensions);

--- a/packages/batch-execute/src/getBatchingExecutor.ts
+++ b/packages/batch-execute/src/getBatchingExecutor.ts
@@ -4,7 +4,7 @@ import { Request, Executor } from '@graphql-tools/utils';
 import { createBatchingExecutor } from './createBatchingExecutor';
 import { memoize2of4 } from './memoize';
 
-export const getBatchingExecutor = memoize2of4(function (
+export const getBatchingExecutor = memoize2of4(function getBatchingExecutor(
   _context: Record<string, any>,
   executor: Executor,
   dataLoaderOptions?: DataLoader.Options<any, any, any> | undefined,

--- a/packages/batch-execute/src/getBatchingExecutor.ts
+++ b/packages/batch-execute/src/getBatchingExecutor.ts
@@ -1,6 +1,6 @@
 import DataLoader from 'dataloader';
 
-import { Request, Executor } from '@graphql-tools/utils';
+import { ExecutionRequest, Executor } from '@graphql-tools/utils';
 import { createBatchingExecutor } from './createBatchingExecutor';
 import { memoize2of4 } from './memoize';
 
@@ -8,7 +8,9 @@ export const getBatchingExecutor = memoize2of4(function getBatchingExecutor(
   _context: Record<string, any>,
   executor: Executor,
   dataLoaderOptions?: DataLoader.Options<any, any, any> | undefined,
-  extensionsReducer?: undefined | ((mergedExtensions: Record<string, any>, request: Request) => Record<string, any>)
+  extensionsReducer?:
+    | undefined
+    | ((mergedExtensions: Record<string, any>, request: ExecutionRequest) => Record<string, any>)
 ): Executor {
   return createBatchingExecutor(executor, dataLoaderOptions, extensionsReducer);
 });

--- a/packages/batch-execute/src/mergeRequests.ts
+++ b/packages/batch-execute/src/mergeRequests.ts
@@ -102,6 +102,7 @@ export function mergeRequests(
     variables: mergedVariables,
     extensions: mergedExtensions,
     context: requests[0].context,
+    info: requests[0].info,
     operationType: requests[0].operationType,
   };
 }

--- a/packages/batch-execute/src/mergeRequests.ts
+++ b/packages/batch-execute/src/mergeRequests.ts
@@ -17,7 +17,7 @@ import {
   FieldNode,
 } from 'graphql';
 
-import { Request, Maybe } from '@graphql-tools/utils';
+import { ExecutionRequest } from '@graphql-tools/utils';
 
 import { createPrefix } from './prefix';
 
@@ -56,9 +56,9 @@ import { createPrefix } from './prefix';
  *   }
  */
 export function mergeRequests(
-  requests: Array<Request>,
-  extensionsReducer: (mergedExtensions: Record<string, any>, request: Request) => Record<string, any>
-): Request {
+  requests: Array<ExecutionRequest>,
+  extensionsReducer: (mergedExtensions: Record<string, any>, request: ExecutionRequest) => Record<string, any>
+): ExecutionRequest {
   const mergedVariables: Record<string, any> = Object.create(null);
   const mergedVariableDefinitions: Array<VariableDefinitionNode> = [];
   const mergedSelections: Array<SelectionNode> = [];
@@ -106,7 +106,7 @@ export function mergeRequests(
   };
 }
 
-function prefixRequest(prefix: string, request: Request): Request {
+function prefixRequest(prefix: string, request: ExecutionRequest): ExecutionRequest {
   let document = aliasTopLevelFields(prefix, request.document);
   const executionVariables = request.variables ?? {};
   const variableNames = Object.keys(executionVariables);

--- a/packages/batch-execute/src/mergeRequests.ts
+++ b/packages/batch-execute/src/mergeRequests.ts
@@ -15,7 +15,6 @@ import {
   ASTKindToNode,
   InlineFragmentNode,
   FieldNode,
-  OperationTypeNode,
 } from 'graphql';
 
 import { Request, Maybe } from '@graphql-tools/utils';
@@ -66,15 +65,12 @@ export function mergeRequests(
   const mergedFragmentDefinitions: Array<FragmentDefinitionNode> = [];
   let mergedExtensions: Record<string, any> = Object.create(null);
 
-  let operation: Maybe<OperationTypeNode>;
-
   for (const index in requests) {
     const request = requests[index];
     const prefixedRequests = prefixRequest(createPrefix(index), request);
 
     for (const def of prefixedRequests.document.definitions) {
       if (isOperationDefinition(def)) {
-        operation = def.operation;
         mergedSelections.push(...def.selectionSet.selections);
         if (def.variableDefinitions) {
           mergedVariableDefinitions.push(...def.variableDefinitions);
@@ -88,13 +84,9 @@ export function mergeRequests(
     mergedExtensions = extensionsReducer(mergedExtensions, request);
   }
 
-  if (operation == null) {
-    throw new Error('Could not identify operation type. Did the document only include fragment definitions?');
-  }
-
   const mergedOperationDefinition: OperationDefinitionNode = {
     kind: Kind.OPERATION_DEFINITION,
-    operation,
+    operation: requests[0].operationType,
     variableDefinitions: mergedVariableDefinitions,
     selectionSet: {
       kind: Kind.SELECTION_SET,
@@ -110,7 +102,7 @@ export function mergeRequests(
     variables: mergedVariables,
     extensions: mergedExtensions,
     context: requests[0].context,
-    operationType: operation,
+    operationType: requests[0].operationType,
   };
 }
 

--- a/packages/batch-execute/src/mergeRequests.ts
+++ b/packages/batch-execute/src/mergeRequests.ts
@@ -110,7 +110,7 @@ export function mergeRequests(
     variables: mergedVariables,
     extensions: mergedExtensions,
     context: requests[0].context,
-    info: requests[0].info,
+    operationType: operation,
   };
 }
 
@@ -137,6 +137,7 @@ function prefixRequest(prefix: string, request: Request): Request {
   return {
     document,
     variables: prefixedVariables,
+    operationType: request.operationType,
   };
 }
 

--- a/packages/delegate/src/Transformer.ts
+++ b/packages/delegate/src/Transformer.ts
@@ -1,4 +1,4 @@
-import { Request, ExecutionResult } from '@graphql-tools/utils';
+import { ExecutionRequest, ExecutionResult } from '@graphql-tools/utils';
 
 import { DelegationContext, DelegationBinding, Transform } from './types';
 
@@ -25,9 +25,9 @@ export class Transformer<TContext = Record<string, any>> {
     this.transformations.push({ transform, context });
   }
 
-  public transformRequest(originalRequest: Request) {
+  public transformRequest(originalRequest: ExecutionRequest) {
     return this.transformations.reduce(
-      (request: Request, transformation: Transformation) =>
+      (request: ExecutionRequest, transformation: Transformation) =>
         transformation.transform.transformRequest != null
           ? transformation.transform.transformRequest(request, this.delegationContext, transformation.context)
           : request,

--- a/packages/delegate/src/createRequest.ts
+++ b/packages/delegate/src/createRequest.ts
@@ -176,6 +176,7 @@ export function createRequest({
     variables: newVariables,
     rootValue: targetRootValue,
     operationName: targetOperationName,
+    operationType: targetOperation,
   };
 }
 

--- a/packages/delegate/src/createRequest.ts
+++ b/packages/delegate/src/createRequest.ts
@@ -53,6 +53,7 @@ export function createRequestFromInfo({
     selectionSet,
     fieldNodes,
     context,
+    info,
   });
 }
 
@@ -70,6 +71,7 @@ export function createRequest({
   selectionSet,
   fieldNodes,
   context,
+  info,
 }: ICreateRequest): ExecutionRequest {
   let newSelectionSet: SelectionSetNode | undefined;
   let argumentNodeMap: Record<string, ArgumentNode>;
@@ -181,6 +183,7 @@ export function createRequest({
     operationName: targetOperationName,
     operationType: targetOperation,
     context,
+    info,
   };
 }
 

--- a/packages/delegate/src/createRequest.ts
+++ b/packages/delegate/src/createRequest.ts
@@ -37,6 +37,7 @@ export function createRequestFromInfo({
   fieldName = info.fieldName,
   selectionSet,
   fieldNodes = info.fieldNodes,
+  context,
 }: ICreateRequestFromInfo): ExecutionRequest {
   return createRequest({
     sourceSchema: info.schema,
@@ -51,6 +52,7 @@ export function createRequestFromInfo({
     targetFieldName: fieldName,
     selectionSet,
     fieldNodes,
+    context,
   });
 }
 
@@ -67,6 +69,7 @@ export function createRequest({
   targetFieldName,
   selectionSet,
   fieldNodes,
+  context,
 }: ICreateRequest): ExecutionRequest {
   let newSelectionSet: SelectionSetNode | undefined;
   let argumentNodeMap: Record<string, ArgumentNode>;
@@ -177,6 +180,7 @@ export function createRequest({
     rootValue: targetRootValue,
     operationName: targetOperationName,
     operationType: targetOperation,
+    context,
   };
 }
 

--- a/packages/delegate/src/createRequest.ts
+++ b/packages/delegate/src/createRequest.ts
@@ -16,7 +16,7 @@ import {
   DocumentNode,
 } from 'graphql';
 
-import { Request, serializeInputValue, updateArgument } from '@graphql-tools/utils';
+import { ExecutionRequest, serializeInputValue, updateArgument } from '@graphql-tools/utils';
 import { ICreateRequestFromInfo, ICreateRequest } from './types';
 
 export function getDelegatingOperation(parentType: GraphQLObjectType, schema: GraphQLSchema): OperationTypeNode {
@@ -37,7 +37,7 @@ export function createRequestFromInfo({
   fieldName = info.fieldName,
   selectionSet,
   fieldNodes = info.fieldNodes,
-}: ICreateRequestFromInfo): Request {
+}: ICreateRequestFromInfo): ExecutionRequest {
   return createRequest({
     sourceSchema: info.schema,
     sourceParentType: info.parentType,
@@ -67,7 +67,7 @@ export function createRequest({
   targetFieldName,
   selectionSet,
   fieldNodes,
-}: ICreateRequest): Request {
+}: ICreateRequest): ExecutionRequest {
   let newSelectionSet: SelectionSetNode | undefined;
   let argumentNodeMap: Record<string, ArgumentNode>;
 

--- a/packages/delegate/src/delegateToSchema.ts
+++ b/packages/delegate/src/delegateToSchema.ts
@@ -152,7 +152,6 @@ function getDelegationContext<TContext>({
       subschemaConfig: subschemaOrSubschemaConfig,
       targetSchema,
       operation,
-      operationName: request.operationName,
       fieldName: targetFieldName,
       args,
       context,

--- a/packages/delegate/src/delegateToSchema.ts
+++ b/packages/delegate/src/delegateToSchema.ts
@@ -51,6 +51,7 @@ export function delegateToSchema<TContext = Record<string, any>, TArgs = any>(
     fieldName = info.fieldName,
     selectionSet,
     fieldNodes,
+    context,
   } = options;
 
   const request = createRequestFromInfo({
@@ -61,6 +62,7 @@ export function delegateToSchema<TContext = Record<string, any>, TArgs = any>(
     fieldNodes,
     rootValue: rootValue ?? (schema as SubschemaConfig).rootValue,
     operationName,
+    context,
   });
 
   return delegateRequest({
@@ -91,17 +93,9 @@ export function delegateRequest<TContext = Record<string, any>, TArgs = any>(
     validateRequest(delegationContext, processedRequest.document);
   }
 
-  const { context, operation } = delegationContext;
-
   const executor = getExecutor(delegationContext);
 
-  return new ValueOrPromise(() =>
-    executor({
-      ...processedRequest,
-      context,
-      operationType: operation,
-    })
-  )
+  return new ValueOrPromise(() => executor(processedRequest))
     .then(originalResult => {
       if (isAsyncIterable(originalResult)) {
         // "subscribe" to the subscription result and map the result through the transforms

--- a/packages/delegate/src/delegateToSchema.ts
+++ b/packages/delegate/src/delegateToSchema.ts
@@ -111,21 +111,20 @@ export function delegateRequest<TContext = Record<string, any>, TArgs = any>(
 function getDelegationContext<TContext>({
   request,
   schema,
-  operation = request.operationType,
   fieldName,
   returnType,
   args,
-  context,
   info,
   transforms = [],
   transformedSchema,
   skipTypeMerging = false,
 }: IDelegateRequestOptions<TContext>): DelegationContext<TContext> {
+  const { operationType: operation, context, operationName, document } = request;
   let operationDefinition: Maybe<OperationDefinitionNode>;
   let targetFieldName: string;
 
   if (fieldName == null) {
-    operationDefinition = getOperationAST(request.document, request.operationName);
+    operationDefinition = getOperationAST(document, operationName);
     if (operationDefinition == null) {
       throw new Error('Cannot infer main operation from the provided document.');
     }

--- a/packages/delegate/src/delegateToSchema.ts
+++ b/packages/delegate/src/delegateToSchema.ts
@@ -132,8 +132,8 @@ function getDelegationContext<TContext>({
 
   if (fieldName == null) {
     operationDefinition = getOperationAST(request.document, request.operationName);
-    if (!operationDefinition) {
-      throw new Error('Could not identify the main operation of the document.');
+    if (operationDefinition == null) {
+      throw new Error('Cannot infer main operation from the provided document.');
     }
     targetFieldName = (operationDefinition?.selectionSet.selections[0] as unknown as FieldDefinitionNode).name.value;
   } else {

--- a/packages/delegate/src/delegateToSchema.ts
+++ b/packages/delegate/src/delegateToSchema.ts
@@ -242,7 +242,7 @@ function createDefaultExecutor(schema: GraphQLSchema): Executor {
       }
       return execute(executionArgs);
     } as Executor;
-    defaultExecutorCache.set(defaultExecutor);
+    defaultExecutorCache.set(schema, defaultExecutor);
   }
   return defaultExecutor;
 }

--- a/packages/delegate/src/delegateToSchema.ts
+++ b/packages/delegate/src/delegateToSchema.ts
@@ -19,7 +19,7 @@ import { getBatchingExecutor } from '@graphql-tools/batch-execute';
 import {
   mapAsyncIterator,
   Executor,
-  Request,
+  ExecutionRequest,
   Maybe,
   AggregateError,
   isAsyncIterable,
@@ -228,7 +228,7 @@ function createDefaultExecutor(schema: GraphQLSchema): Executor {
       rootValue,
       operationName,
       operationType,
-    }: Request) {
+    }: ExecutionRequest) {
       const executionArgs: ExecutionArgs = {
         schema,
         document,

--- a/packages/delegate/src/delegateToSchema.ts
+++ b/packages/delegate/src/delegateToSchema.ts
@@ -117,7 +117,7 @@ export function delegateRequest<TContext = Record<string, any>, TArgs = any>(
 function getDelegationContext<TContext>({
   request,
   schema,
-  operation,
+  operation = request.operationType,
   fieldName,
   returnType,
   args,
@@ -128,14 +128,7 @@ function getDelegationContext<TContext>({
   skipTypeMerging = false,
 }: IDelegateRequestOptions<TContext>): DelegationContext<TContext> {
   let operationDefinition: Maybe<OperationDefinitionNode>;
-  let targetOperation: Maybe<OperationTypeNode>;
   let targetFieldName: string;
-
-  if (operation == null) {
-    targetOperation = request.operationType;
-  } else {
-    targetOperation = operation;
-  }
 
   if (fieldName == null) {
     operationDefinition = getOperationAST(request.document, request.operationName);
@@ -158,13 +151,13 @@ function getDelegationContext<TContext>({
       subschema: schema,
       subschemaConfig: subschemaOrSubschemaConfig,
       targetSchema,
-      operation: targetOperation,
+      operation,
+      operationName: request.operationName,
       fieldName: targetFieldName,
       args,
       context,
       info,
-      returnType:
-        returnType ?? info?.returnType ?? getDelegationReturnType(targetSchema, targetOperation, targetFieldName),
+      returnType: returnType ?? info?.returnType ?? getDelegationReturnType(targetSchema, operation, targetFieldName),
       transforms:
         subschemaOrSubschemaConfig.transforms != null
           ? subschemaOrSubschemaConfig.transforms.concat(transforms)
@@ -180,15 +173,13 @@ function getDelegationContext<TContext>({
     subschema: schema,
     subschemaConfig: undefined,
     targetSchema: subschemaOrSubschemaConfig,
-    operation: targetOperation,
+    operation,
     fieldName: targetFieldName,
     args,
     context,
     info,
     returnType:
-      returnType ??
-      info?.returnType ??
-      getDelegationReturnType(subschemaOrSubschemaConfig, targetOperation, targetFieldName),
+      returnType ?? info?.returnType ?? getDelegationReturnType(subschemaOrSubschemaConfig, operation, targetFieldName),
     transforms,
     transformedSchema: transformedSchema ?? subschemaOrSubschemaConfig,
     skipTypeMerging,

--- a/packages/delegate/src/index.ts
+++ b/packages/delegate/src/index.ts
@@ -9,4 +9,4 @@ export * from './resolveExternalValue';
 export * from './subschemaConfig';
 export * from './transforms';
 export * from './types';
-export { Executor, AsyncExecutor, SyncExecutor, Request } from '@graphql-tools/utils';
+export { Executor, AsyncExecutor, SyncExecutor, ExecutionRequest as Request } from '@graphql-tools/utils';

--- a/packages/delegate/src/index.ts
+++ b/packages/delegate/src/index.ts
@@ -9,4 +9,3 @@ export * from './resolveExternalValue';
 export * from './subschemaConfig';
 export * from './transforms';
 export * from './types';
-export { Executor, AsyncExecutor, SyncExecutor, ExecutionRequest as Request } from '@graphql-tools/utils';

--- a/packages/delegate/src/transforms/AddArgumentsAsVariables.ts
+++ b/packages/delegate/src/transforms/AddArgumentsAsVariables.ts
@@ -10,7 +10,7 @@ import {
   VariableDefinitionNode,
 } from 'graphql';
 
-import { getDefinedRootType, Request, serializeInputValue, updateArgument } from '@graphql-tools/utils';
+import { getDefinedRootType, ExecutionRequest, serializeInputValue, updateArgument } from '@graphql-tools/utils';
 
 import { Transform, DelegationContext } from '../types';
 
@@ -28,10 +28,10 @@ export default class AddArgumentsAsVariables implements Transform {
   }
 
   public transformRequest(
-    originalRequest: Request,
+    originalRequest: ExecutionRequest,
     delegationContext: DelegationContext,
     _transformationContext: Record<string, any>
-  ): Request {
+  ): ExecutionRequest {
     const { document, variables } = addVariablesToRootField(delegationContext.targetSchema, originalRequest, this.args);
 
     return {
@@ -44,7 +44,7 @@ export default class AddArgumentsAsVariables implements Transform {
 
 function addVariablesToRootField(
   targetSchema: GraphQLSchema,
-  originalRequest: Request,
+  originalRequest: ExecutionRequest,
   args: Record<string, any>
 ): {
   document: DocumentNode;

--- a/packages/delegate/src/transforms/AddSelectionSets.ts
+++ b/packages/delegate/src/transforms/AddSelectionSets.ts
@@ -1,6 +1,6 @@
 import { SelectionSetNode, TypeInfo, Kind, FieldNode, SelectionNode, print } from 'graphql';
 
-import { Maybe, Request } from '@graphql-tools/utils';
+import { Maybe, ExecutionRequest } from '@graphql-tools/utils';
 
 import { Transform, DelegationContext } from '../types';
 import { memoize2 } from '../memoize';
@@ -21,10 +21,10 @@ export default class AddSelectionSets implements Transform {
   }
 
   public transformRequest(
-    originalRequest: Request,
+    originalRequest: ExecutionRequest,
     delegationContext: DelegationContext,
     transformationContext: Record<string, any>
-  ): Request {
+  ): ExecutionRequest {
     return this.transformer.transformRequest(originalRequest, delegationContext, transformationContext);
   }
 }

--- a/packages/delegate/src/transforms/AddTypenameToAbstract.ts
+++ b/packages/delegate/src/transforms/AddTypenameToAbstract.ts
@@ -10,16 +10,16 @@ import {
   isAbstractType,
 } from 'graphql';
 
-import { Maybe, Request } from '@graphql-tools/utils';
+import { Maybe, ExecutionRequest } from '@graphql-tools/utils';
 
 import { Transform, DelegationContext } from '../types';
 
 export default class AddTypenameToAbstract implements Transform {
   public transformRequest(
-    originalRequest: Request,
+    originalRequest: ExecutionRequest,
     delegationContext: DelegationContext,
     _transformationContext: Record<string, any>
-  ): Request {
+  ): ExecutionRequest {
     const document = addTypenameToAbstract(delegationContext.targetSchema, originalRequest.document);
     return {
       ...originalRequest,

--- a/packages/delegate/src/transforms/ExpandAbstractTypes.ts
+++ b/packages/delegate/src/transforms/ExpandAbstractTypes.ts
@@ -15,16 +15,16 @@ import {
   visitWithTypeInfo,
 } from 'graphql';
 
-import { implementsAbstractType, Request } from '@graphql-tools/utils';
+import { implementsAbstractType, ExecutionRequest } from '@graphql-tools/utils';
 
 import { Transform, DelegationContext } from '../types';
 
 export default class ExpandAbstractTypes implements Transform {
   public transformRequest(
-    originalRequest: Request,
+    originalRequest: ExecutionRequest,
     delegationContext: DelegationContext,
     _transformationContext: Record<string, any>
-  ): Request {
+  ): ExecutionRequest {
     const targetSchema = delegationContext.targetSchema;
     const { possibleTypesMap, interfaceExtensionsMap } = extractPossibleTypes(
       delegationContext.info.schema,

--- a/packages/delegate/src/transforms/FilterToSchema.ts
+++ b/packages/delegate/src/transforms/FilterToSchema.ts
@@ -21,16 +21,16 @@ import {
   isInterfaceType,
 } from 'graphql';
 
-import { Request, implementsAbstractType, TypeMap, getDefinedRootType } from '@graphql-tools/utils';
+import { ExecutionRequest, implementsAbstractType, TypeMap, getDefinedRootType } from '@graphql-tools/utils';
 
 import { Transform, DelegationContext } from '../types';
 
 export default class FilterToSchema implements Transform {
   public transformRequest(
-    originalRequest: Request,
+    originalRequest: ExecutionRequest,
     delegationContext: DelegationContext,
     _transformationContext: Record<string, any>
-  ): Request {
+  ): ExecutionRequest {
     return {
       ...originalRequest,
       ...filterToSchema(delegationContext.targetSchema, originalRequest.document, originalRequest.variables),

--- a/packages/delegate/src/transforms/VisitSelectionSets.ts
+++ b/packages/delegate/src/transforms/VisitSelectionSets.ts
@@ -13,7 +13,13 @@ import {
   DefinitionNode,
 } from 'graphql';
 
-import { Request, collectFields, GraphQLExecutionContext, Maybe, getDefinedRootType } from '@graphql-tools/utils';
+import {
+  ExecutionRequest,
+  collectFields,
+  GraphQLExecutionContext,
+  Maybe,
+  getDefinedRootType,
+} from '@graphql-tools/utils';
 
 import { Transform, DelegationContext } from '../types';
 
@@ -27,10 +33,10 @@ export default class VisitSelectionSets implements Transform {
   }
 
   public transformRequest(
-    originalRequest: Request,
+    originalRequest: ExecutionRequest,
     delegationContext: DelegationContext,
     _transformationContext: Record<string, any>
-  ): Request {
+  ): ExecutionRequest {
     const document = visitSelectionSets(
       originalRequest,
       delegationContext.info.schema,
@@ -45,7 +51,7 @@ export default class VisitSelectionSets implements Transform {
 }
 
 function visitSelectionSets(
-  request: Request,
+  request: ExecutionRequest,
   schema: GraphQLSchema,
   initialType: GraphQLOutputType,
   visitor: VisitSelectionSetsVisitor

--- a/packages/delegate/src/transforms/WrapConcreteTypes.ts
+++ b/packages/delegate/src/transforms/WrapConcreteTypes.ts
@@ -13,7 +13,7 @@ import {
   FragmentDefinitionNode,
 } from 'graphql';
 
-import { getRootTypeNames, Request } from '@graphql-tools/utils';
+import { getRootTypeNames, ExecutionRequest } from '@graphql-tools/utils';
 
 import { Transform, DelegationContext } from '../types';
 
@@ -21,10 +21,10 @@ import { Transform, DelegationContext } from '../types';
 
 export default class WrapConcreteTypes implements Transform {
   public transformRequest(
-    originalRequest: Request,
+    originalRequest: ExecutionRequest,
     delegationContext: DelegationContext,
     _transformationContext: Record<string, any>
-  ): Request {
+  ): ExecutionRequest {
     const document = wrapConcreteTypes(
       delegationContext.returnType,
       delegationContext.targetSchema,

--- a/packages/delegate/src/types.ts
+++ b/packages/delegate/src/types.ts
@@ -112,6 +112,7 @@ export interface ICreateRequest {
   selectionSet?: SelectionSetNode;
   fieldNodes?: ReadonlyArray<FieldNode>;
   context?: any;
+  info?: GraphQLResolveInfo;
 }
 
 export interface MergedTypeInfo<TContext = Record<string, any>> {

--- a/packages/delegate/src/types.ts
+++ b/packages/delegate/src/types.ts
@@ -14,7 +14,7 @@ import {
 
 import DataLoader from 'dataloader';
 
-import { Request, ExecutionResult, Executor, TypeMap } from '@graphql-tools/utils';
+import { ExecutionRequest, ExecutionResult, Executor, TypeMap } from '@graphql-tools/utils';
 
 import { Subschema } from './Subschema';
 import { OBJECT_SUBSCHEMA_SYMBOL, FIELD_SUBSCHEMA_MAP_SYMBOL, UNPATHED_ERRORS_SYMBOL } from './symbols';
@@ -25,10 +25,10 @@ export type SchemaTransform<TContext = Record<any, string>> = (
   transformedSchema?: GraphQLSchema
 ) => GraphQLSchema;
 export type RequestTransform<T = Record<string, any>> = (
-  originalRequest: Request,
+  originalRequest: ExecutionRequest,
   delegationContext: DelegationContext,
   transformationContext: T
-) => Request;
+) => ExecutionRequest;
 export type ResultTransform<T = Record<string, any>> = (
   originalResult: ExecutionResult,
   delegationContext: DelegationContext,
@@ -85,7 +85,7 @@ export interface IDelegateToSchemaOptions<TContext = Record<string, any>, TArgs 
 
 export interface IDelegateRequestOptions<TContext = Record<string, any>, TArgs = Record<string, any>>
   extends IDelegateToSchemaOptions<TContext, TArgs> {
-  request: Request;
+  request: ExecutionRequest;
 }
 
 export interface ICreateRequestFromInfo {
@@ -137,7 +137,7 @@ export type CreateProxyingResolverFn<TContext = Record<string, any>> = (
 ) => GraphQLFieldResolver<any, TContext>;
 
 export interface BatchingOptions<K = any, V = any, C = K> {
-  extensionsReducer?: (mergedExtensions: Record<string, any>, request: Request) => Record<string, any>;
+  extensionsReducer?: (mergedExtensions: Record<string, any>, request: ExecutionRequest) => Record<string, any>;
   dataLoaderOptions?: DataLoader.Options<K, V, C>;
 }
 

--- a/packages/delegate/src/types.ts
+++ b/packages/delegate/src/types.ts
@@ -56,7 +56,6 @@ export interface DelegationContext<TContext = Record<string, any>> {
   transforms: Array<Transform<any, TContext>>;
   transformedSchema: GraphQLSchema;
   skipTypeMerging: boolean;
-  operationName?: string;
 }
 
 export type DelegationBinding<TContext = Record<string, any>> = (

--- a/packages/delegate/src/types.ts
+++ b/packages/delegate/src/types.ts
@@ -95,6 +95,7 @@ export interface ICreateRequestFromInfo {
   fieldName?: string;
   selectionSet?: SelectionSetNode;
   fieldNodes?: ReadonlyArray<FieldNode>;
+  context?: any;
 }
 
 export interface ICreateRequest {
@@ -110,6 +111,7 @@ export interface ICreateRequest {
   targetFieldName: string;
   selectionSet?: SelectionSetNode;
   fieldNodes?: ReadonlyArray<FieldNode>;
+  context?: any;
 }
 
 export interface MergedTypeInfo<TContext = Record<string, any>> {

--- a/packages/delegate/tests/batchExecution.test.ts
+++ b/packages/delegate/tests/batchExecution.test.ts
@@ -1,9 +1,10 @@
 import { graphql, execute, ExecutionResult } from 'graphql';
 
 import { makeExecutableSchema } from '@graphql-tools/schema';
-import { delegateToSchema, SubschemaConfig, Request, SyncExecutor, Executor } from '../src';
+import { delegateToSchema, SubschemaConfig } from '../src';
 import { stitchSchemas } from '@graphql-tools/stitch';
 import { FilterObjectFields } from '@graphql-tools/wrap';
+import { ExecutionRequest, Executor, SyncExecutor } from '@graphql-tools/utils';
 
 describe('batch execution', () => {
   it('should batch', async () => {
@@ -27,7 +28,7 @@ describe('batch execution', () => {
     const innerSubschemaConfig: SubschemaConfig = {
       schema: innerSchema,
       batch: true,
-      executor: ((request: Request): ExecutionResult => {
+      executor: ((request: ExecutionRequest): ExecutionResult => {
         executions++;
         return execute(innerSchema, request.document, undefined, request.context, request.variables) as ExecutionResult;
       }) as SyncExecutor
@@ -104,7 +105,7 @@ describe('batch execution', () => {
 
     let executions = 0;
 
-    const executor = ((request: Request): ExecutionResult => {
+    const executor = ((request: ExecutionRequest): ExecutionResult => {
       executions++;
       return execute(innerSchemaA, request.document, undefined, request.context, request.variables) as ExecutionResult;
     }) as Executor;

--- a/packages/links/src/linkToExecutor.ts
+++ b/packages/links/src/linkToExecutor.ts
@@ -6,20 +6,19 @@ import { Executor, Request, ExecutionResult, observableToAsyncIterable } from '@
 
 export const linkToExecutor =
   (link: ApolloLink): Executor =>
-  async <TReturn, TArgs, TContext>(request: Request<TArgs, TContext>) => {
-    const { document, variables, extensions, context, info, operationName } = request;
+    async <TReturn, TArgs, TContext>(params: Request<TArgs, TContext>) => {
+    const { document, variables, extensions, context, operationType, operationName } = params;
     const observable = execute(link, {
       query: document,
       variables,
       context: {
         graphqlContext: context,
-        graphqlResolveInfo: info,
         clientAwareness: {},
       },
       extensions,
       operationName,
     }) as Observable<ExecutionResult<TReturn>>;
-    if (info?.operation.operation === 'subscription') {
+    if (operationType === 'subscription') {
       return observableToAsyncIterable<ExecutionResult<TReturn>>(observable)[Symbol.asyncIterator]();
     }
     return toPromise(observable);

--- a/packages/links/src/linkToExecutor.ts
+++ b/packages/links/src/linkToExecutor.ts
@@ -2,11 +2,11 @@ import { toPromise } from '@apollo/client/core';
 import { ApolloLink, execute } from '@apollo/client/link/core';
 import { Observable } from '@apollo/client/utilities';
 
-import { Executor, Request, ExecutionResult, observableToAsyncIterable } from '@graphql-tools/utils';
+import { Executor, ExecutionRequest, ExecutionResult, observableToAsyncIterable } from '@graphql-tools/utils';
 
 export const linkToExecutor =
   (link: ApolloLink): Executor =>
-    async <TReturn, TArgs, TContext>(params: Request<TArgs, TContext>) => {
+  async <TReturn, TArgs, TContext>(params: ExecutionRequest<TArgs, TContext>) => {
     const { document, variables, extensions, context, operationType, operationName } = params;
     const observable = execute(link, {
       query: document,

--- a/packages/links/src/linkToExecutor.ts
+++ b/packages/links/src/linkToExecutor.ts
@@ -7,12 +7,13 @@ import { Executor, ExecutionRequest, ExecutionResult, observableToAsyncIterable 
 export const linkToExecutor =
   (link: ApolloLink): Executor =>
   async <TReturn, TArgs, TContext>(params: ExecutionRequest<TArgs, TContext>) => {
-    const { document, variables, extensions, context, operationType, operationName } = params;
+    const { document, variables, extensions, context, operationType, operationName, info } = params;
     const observable = execute(link, {
       query: document,
       variables,
       context: {
         graphqlContext: context,
+        graphqlResolveInfo: info,
         clientAwareness: {},
       },
       extensions,

--- a/packages/loaders/url/src/index.ts
+++ b/packages/loaders/url/src/index.ts
@@ -295,12 +295,12 @@ export class UrlLoader implements Loader<LoadFromUrlOptions> {
       variables,
       operationName,
       extensions,
+      operationType,
     }: Request<any, any, any, ExecutionExtensions>) => {
       const controller = new AbortController();
       let method = defaultMethod;
       if (options?.useGETForQueries) {
-        const operationAst = getOperationAST(document, operationName);
-        if (operationAst?.operation === 'query') {
+        if (operationType === 'query') {
           method = 'GET';
         } else {
           method = defaultMethod;
@@ -610,7 +610,7 @@ export class UrlLoader implements Loader<LoadFromUrlOptions> {
         throw new Error(`No valid operations found: ${params.operationName || ''}`);
       }
       if (
-        operationAst.operation === 'subscription' ||
+        params.operationType === 'subscription' ||
         isLiveQueryOperationDefinitionNode(operationAst, params.variables as Record<string, any>)
       ) {
         return subscriptionExecutor(params);

--- a/packages/loaders/url/src/index.ts
+++ b/packages/loaders/url/src/index.ts
@@ -11,7 +11,7 @@ import {
   BaseLoaderOptions,
   observableToAsyncIterable,
   isAsyncIterable,
-  Request,
+  ExecutionRequest,
   mapAsyncIterator,
   withCancel,
   parseGraphQLSDL,
@@ -296,7 +296,7 @@ export class UrlLoader implements Loader<LoadFromUrlOptions> {
       operationName,
       extensions,
       operationType,
-    }: Request<any, any, any, ExecutionExtensions>) => {
+    }: ExecutionRequest<any, any, any, ExecutionExtensions>) => {
       const controller = new AbortController();
       let method = defaultMethod;
       if (options?.useGETForQueries) {
@@ -463,7 +463,7 @@ export class UrlLoader implements Loader<LoadFromUrlOptions> {
       webSocketImpl
     );
 
-    return async <TReturn, TArgs>({ document, variables, operationName }: Request<TArgs>) => {
+    return async <TReturn, TArgs>({ document, variables, operationName }: ExecutionRequest<TArgs>) => {
       return observableToAsyncIterable(
         subscriptionClient.request({
           query: document,

--- a/packages/stitch/tests/errors.test.ts
+++ b/packages/stitch/tests/errors.test.ts
@@ -1,9 +1,8 @@
 import { graphql, GraphQLError, buildSchema } from 'graphql';
 
-import { Executor } from '@graphql-tools/delegate';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { stitchSchemas } from '@graphql-tools/stitch';
-import { assertSome, ExecutionResult } from '@graphql-tools/utils';
+import { assertSome, ExecutionResult, Executor } from '@graphql-tools/utils';
 
 describe('passes along errors for missing fields on list', () => {
   test('if non-null', async () => {

--- a/packages/stitch/tests/fixtures/schemas.ts
+++ b/packages/stitch/tests/fixtures/schemas.ts
@@ -682,8 +682,8 @@ export const subscriptionSchema: GraphQLSchema = makeExecutableSchema({
 });
 
 function makeExecutorFromSchema(schema: GraphQLSchema) {
-  return async <TReturn, TArgs, TContext>({ document, variables, context, info }: Request<TArgs, TContext>) => {
-    if (info?.operation.operation === 'subscription') {
+  return async <TReturn, TArgs, TContext>({ document, variables, context, operationType }: Request<TArgs, TContext>) => {
+    if (operationType === 'subscription') {
       const result = subscribe(
         schema,
         document,

--- a/packages/stitch/tests/fixtures/schemas.ts
+++ b/packages/stitch/tests/fixtures/schemas.ts
@@ -22,10 +22,11 @@ import {
   ExecutionResult,
   mapAsyncIterator,
   isAsyncIterable,
+  ExecutionRequest,
 } from '@graphql-tools/utils';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 
-import { Request, SubschemaConfig } from '@graphql-tools/delegate';
+import { SubschemaConfig } from '@graphql-tools/delegate';
 
 export class CustomError extends GraphQLError {
   constructor(message: string, extensions: Record<string, any>) {
@@ -682,7 +683,7 @@ export const subscriptionSchema: GraphQLSchema = makeExecutableSchema({
 });
 
 function makeExecutorFromSchema(schema: GraphQLSchema) {
-  return async <TReturn, TArgs, TContext>({ document, variables, context, operationType }: Request<TArgs, TContext>) => {
+  return async <TReturn, TArgs, TContext>({ document, variables, context, operationType }: ExecutionRequest<TArgs, TContext>) => {
     if (operationType === 'subscription') {
       const result = subscribe(
         schema,

--- a/packages/utils/src/Interfaces.ts
+++ b/packages/utils/src/Interfaces.ts
@@ -59,7 +59,7 @@ export interface ExecutionResult<TData = Record<string, any>> extends GraphQLExe
   extensions?: Record<string, any>;
 }
 
-export interface Request<
+export interface ExecutionRequest<
   TArgs extends Record<string, any> = Record<string, any>,
   TContext = any,
   TRootValue = any,

--- a/packages/utils/src/Interfaces.ts
+++ b/packages/utils/src/Interfaces.ts
@@ -48,6 +48,7 @@ import {
   GraphQLType,
   Source,
   DefinitionNode,
+  OperationTypeNode,
 } from 'graphql';
 
 // graphql-js < v15 backwards compatible ExecutionResult
@@ -65,6 +66,7 @@ export interface Request<
   TExtensions = Record<string, any>
 > {
   document: DocumentNode;
+  operationType: OperationTypeNode;
   variables?: TArgs;
   extensions?: TExtensions;
   operationName?: string;
@@ -72,7 +74,6 @@ export interface Request<
   rootValue?: TRootValue;
   // If the request originates within execution of a parent request, it may contain the parent context and info
   context?: TContext;
-  info?: GraphQLResolveInfo;
 }
 
 // graphql-js non-exported typings

--- a/packages/utils/src/Interfaces.ts
+++ b/packages/utils/src/Interfaces.ts
@@ -74,6 +74,7 @@ export interface ExecutionRequest<
   rootValue?: TRootValue;
   // If the request originates within execution of a parent request, it may contain the parent context and info
   context?: TContext;
+  info?: GraphQLResolveInfo;
 }
 
 // graphql-js non-exported typings

--- a/packages/utils/src/executor.ts
+++ b/packages/utils/src/executor.ts
@@ -1,4 +1,4 @@
-import { ExecutionResult, Request } from './Interfaces';
+import { ExecutionResult, ExecutionRequest } from './Interfaces';
 
 type MaybePromise<T> = Promise<T> | T;
 type MaybeAsyncIterableIterator<T> = AsyncIterableIterator<T> | T;
@@ -10,7 +10,7 @@ export type AsyncExecutor<TBaseContext = Record<string, any>, TBaseExtensions = 
   TRoot = any,
   TExtensions extends TBaseExtensions = TBaseExtensions
 >(
-  request: Request<TArgs, TContext, TRoot, TExtensions>
+  request: ExecutionRequest<TArgs, TContext, TRoot, TExtensions>
 ) => Promise<MaybeAsyncIterableIterator<ExecutionResult<TReturn>>>;
 
 export type SyncExecutor<TBaseContext = Record<string, any>, TBaseExtensions = Record<string, any>> = <
@@ -20,7 +20,7 @@ export type SyncExecutor<TBaseContext = Record<string, any>, TBaseExtensions = R
   TRoot = any,
   TExtensions extends TBaseExtensions = TBaseExtensions
 >(
-  request: Request<TArgs, TContext, TRoot, TExtensions>
+  request: ExecutionRequest<TArgs, TContext, TRoot, TExtensions>
 ) => ExecutionResult<TReturn>;
 
 export type Executor<TBaseContext = Record<string, any>, TBaseExtensions = Record<string, any>> = <
@@ -30,5 +30,5 @@ export type Executor<TBaseContext = Record<string, any>, TBaseExtensions = Recor
   TRoot = any,
   TExtensions extends TBaseExtensions = TBaseExtensions
 >(
-  request: Request<TArgs, TContext, TRoot, TExtensions>
+  request: ExecutionRequest<TArgs, TContext, TRoot, TExtensions>
 ) => MaybePromise<MaybeAsyncIterableIterator<ExecutionResult<TReturn>>>;

--- a/packages/utils/src/visitResult.ts
+++ b/packages/utils/src/visitResult.ts
@@ -15,7 +15,7 @@ import {
   TypeNameMetaFieldDef,
 } from 'graphql';
 
-import { Request, GraphQLExecutionContext, ExecutionResult } from './Interfaces';
+import { ExecutionRequest, GraphQLExecutionContext, ExecutionResult } from './Interfaces';
 import { collectFields } from './collectFields';
 import { Maybe } from '@graphql-tools/utils';
 
@@ -77,7 +77,7 @@ export function visitErrors(
 }
 export function visitResult(
   result: ExecutionResult,
-  request: Request,
+  request: ExecutionRequest,
   schema: GraphQLSchema,
   resultVisitorMap?: ResultVisitorMap,
   errorVisitorMap?: ErrorVisitorMap

--- a/packages/utils/tests/visitResult.test.ts
+++ b/packages/utils/tests/visitResult.test.ts
@@ -22,6 +22,7 @@ describe('visiting results', () => {
   const request = {
     document: parse('{ test { field } }'),
     variables: {},
+    operationType: 'query' as const
   };
 
   it('should visit without throwing', async () => {
@@ -45,7 +46,8 @@ describe('visiting results', () => {
   it('should visit with a request with introspection fields without throwing', async () => {
     const introspectionRequest = {
       document: parse('{ test { field __typename } }'),
-      variables: {}
+      variables: {},
+      operationType: 'query' as const
     };
     const result = {
       data: {
@@ -226,6 +228,7 @@ describe('visiting nested results', () => {
       }
     }`),
     variables: {},
+    operationType: 'query' as const,
   };
 
   it('should work', async () => {
@@ -293,6 +296,7 @@ describe('visiting nested results', () => {
       }
     }`),
     variables: {},
+    operationType: 'query' as const,
   };
 
   it('should work', async () => {
@@ -352,6 +356,7 @@ describe('visiting errors', () => {
   const request = {
     document: parse('{ test { field } }'),
     variables: {},
+    operationType: 'query' as const,
   };
 
   it('should allow visiting without an errorVisitor', async () => {

--- a/packages/wrap/src/introspect.ts
+++ b/packages/wrap/src/introspect.ts
@@ -56,6 +56,7 @@ export function introspectSchema(
   return new ValueOrPromise(() =>
     executor({
       document: parsedIntrospectionQuery,
+      operationType: 'query',
       context,
     })
   )

--- a/packages/wrap/src/transforms/ExtractField.ts
+++ b/packages/wrap/src/transforms/ExtractField.ts
@@ -1,6 +1,6 @@
 import { visit, Kind, SelectionSetNode, BREAK, FieldNode } from 'graphql';
 
-import { Request } from '@graphql-tools/utils';
+import { ExecutionRequest } from '@graphql-tools/utils';
 
 import { Transform, DelegationContext } from '@graphql-tools/delegate';
 
@@ -14,10 +14,10 @@ export default class ExtractField implements Transform {
   }
 
   public transformRequest(
-    originalRequest: Request,
+    originalRequest: ExecutionRequest,
     _delegationContext: DelegationContext,
     _transformationContext: Record<string, any>
-  ): Request {
+  ): ExecutionRequest {
     let fromSelection: SelectionSetNode | undefined;
     const ourPathFrom = JSON.stringify(this.from);
     const ourPathTo = JSON.stringify(this.to);

--- a/packages/wrap/src/transforms/FilterInputObjectFields.ts
+++ b/packages/wrap/src/transforms/FilterInputObjectFields.ts
@@ -1,6 +1,6 @@
 import { GraphQLSchema, GraphQLInputFieldConfig } from 'graphql';
 
-import { Request, InputFieldFilter } from '@graphql-tools/utils';
+import { ExecutionRequest, InputFieldFilter } from '@graphql-tools/utils';
 
 import { Transform, DelegationContext, SubschemaConfig } from '@graphql-tools/delegate';
 
@@ -29,10 +29,10 @@ export default class FilterInputObjectFields implements Transform {
   }
 
   public transformRequest(
-    originalRequest: Request,
+    originalRequest: ExecutionRequest,
     delegationContext: DelegationContext,
     transformationContext: Record<string, any>
-  ): Request {
+  ): ExecutionRequest {
     return this.transformer.transformRequest(originalRequest, delegationContext, transformationContext);
   }
 }

--- a/packages/wrap/src/transforms/HoistField.ts
+++ b/packages/wrap/src/transforms/HoistField.ts
@@ -9,7 +9,13 @@ import {
   GraphQLFieldResolver,
 } from 'graphql';
 
-import { appendObjectFields, removeObjectFields, Request, ExecutionResult, relocatedError } from '@graphql-tools/utils';
+import {
+  appendObjectFields,
+  removeObjectFields,
+  ExecutionRequest,
+  ExecutionResult,
+  relocatedError,
+} from '@graphql-tools/utils';
 
 import { Transform, defaultMergedResolver, DelegationContext, SubschemaConfig } from '@graphql-tools/delegate';
 
@@ -153,10 +159,10 @@ export default class HoistField implements Transform {
   }
 
   public transformRequest(
-    originalRequest: Request,
+    originalRequest: ExecutionRequest,
     delegationContext: DelegationContext,
     transformationContext: Record<string, any>
-  ): Request {
+  ): ExecutionRequest {
     return this.transformer.transformRequest(originalRequest, delegationContext, transformationContext);
   }
 

--- a/packages/wrap/src/transforms/MapFields.ts
+++ b/packages/wrap/src/transforms/MapFields.ts
@@ -1,6 +1,6 @@
 import { GraphQLSchema } from 'graphql';
 
-import { Request, FieldNodeMappers, ExecutionResult } from '@graphql-tools/utils';
+import { ExecutionRequest, FieldNodeMappers, ExecutionResult } from '@graphql-tools/utils';
 
 import { Transform, DelegationContext, SubschemaConfig } from '@graphql-tools/delegate';
 
@@ -85,10 +85,10 @@ export default class MapFields<TContext> implements Transform<any, TContext> {
   }
 
   public transformRequest(
-    originalRequest: Request,
+    originalRequest: ExecutionRequest,
     delegationContext: DelegationContext,
     transformationContext: Record<string, any>
-  ): Request {
+  ): ExecutionRequest {
     return this._getTransformer().transformRequest(originalRequest, delegationContext, transformationContext);
   }
 

--- a/packages/wrap/src/transforms/MapLeafValues.ts
+++ b/packages/wrap/src/transforms/MapLeafValues.ts
@@ -14,7 +14,7 @@ import {
 } from 'graphql';
 
 import {
-  Request,
+  ExecutionRequest,
   ExecutionResult,
   visitResult,
   ResultVisitorMap,
@@ -27,7 +27,7 @@ import { Transform, DelegationContext, SubschemaConfig } from '@graphql-tools/de
 import { LeafValueTransformer } from '../types';
 
 export interface MapLeafValuesTransformationContext {
-  transformedRequest: Request;
+  transformedRequest: ExecutionRequest;
 }
 
 export default class MapLeafValues implements Transform<MapLeafValuesTransformationContext> {
@@ -83,10 +83,10 @@ export default class MapLeafValues implements Transform<MapLeafValuesTransformat
   }
 
   public transformRequest(
-    originalRequest: Request,
+    originalRequest: ExecutionRequest,
     _delegationContext: DelegationContext,
     transformationContext: MapLeafValuesTransformationContext
-  ): Request {
+  ): ExecutionRequest {
     const document = originalRequest.document;
     const variableValues = (originalRequest.variables = {});
 

--- a/packages/wrap/src/transforms/RenameInputObjectFields.ts
+++ b/packages/wrap/src/transforms/RenameInputObjectFields.ts
@@ -1,6 +1,6 @@
 import { GraphQLSchema, GraphQLInputFieldConfig, ObjectFieldNode } from 'graphql';
 
-import { Request, mapSchema, MapperKind } from '@graphql-tools/utils';
+import { ExecutionRequest, mapSchema, MapperKind } from '@graphql-tools/utils';
 
 import { Transform, DelegationContext, SubschemaConfig } from '@graphql-tools/delegate';
 
@@ -81,10 +81,10 @@ export default class RenameInputObjectFields implements Transform {
   }
 
   public transformRequest(
-    originalRequest: Request,
+    originalRequest: ExecutionRequest,
     delegationContext: DelegationContext,
     transformationContext: Record<string, any>
-  ): Request {
+  ): ExecutionRequest {
     return this.transformer.transformRequest(originalRequest, delegationContext, transformationContext);
   }
 }

--- a/packages/wrap/src/transforms/RenameInterfaceFields.ts
+++ b/packages/wrap/src/transforms/RenameInterfaceFields.ts
@@ -1,6 +1,6 @@
 import { GraphQLSchema, GraphQLFieldConfig } from 'graphql';
 
-import { Request } from '@graphql-tools/utils';
+import { ExecutionRequest } from '@graphql-tools/utils';
 
 import { Transform, DelegationContext, SubschemaConfig } from '@graphql-tools/delegate';
 
@@ -27,10 +27,10 @@ export default class RenameInterfaceFields implements Transform {
   }
 
   public transformRequest(
-    originalRequest: Request,
+    originalRequest: ExecutionRequest,
     delegationContext: DelegationContext,
     transformationContext: Record<string, any>
-  ): Request {
+  ): ExecutionRequest {
     return this.transformer.transformRequest(originalRequest, delegationContext, transformationContext);
   }
 }

--- a/packages/wrap/src/transforms/RenameObjectFields.ts
+++ b/packages/wrap/src/transforms/RenameObjectFields.ts
@@ -1,6 +1,6 @@
 import { GraphQLSchema, GraphQLFieldConfig } from 'graphql';
 
-import { Request } from '@graphql-tools/utils';
+import { ExecutionRequest } from '@graphql-tools/utils';
 
 import { Transform, DelegationContext, SubschemaConfig } from '@graphql-tools/delegate';
 
@@ -27,10 +27,10 @@ export default class RenameObjectFields implements Transform {
   }
 
   public transformRequest(
-    originalRequest: Request,
+    originalRequest: ExecutionRequest,
     delegationContext: DelegationContext,
     transformationContext: Record<string, any>
-  ): Request {
+  ): ExecutionRequest {
     return this.transformer.transformRequest(originalRequest, delegationContext, transformationContext);
   }
 }

--- a/packages/wrap/src/transforms/RenameRootFields.ts
+++ b/packages/wrap/src/transforms/RenameRootFields.ts
@@ -1,6 +1,6 @@
 import { GraphQLSchema, GraphQLFieldConfig } from 'graphql';
 
-import { Request } from '@graphql-tools/utils';
+import { ExecutionRequest } from '@graphql-tools/utils';
 
 import { Transform, DelegationContext, SubschemaConfig } from '@graphql-tools/delegate';
 
@@ -34,10 +34,10 @@ export default class RenameRootFields implements Transform {
   }
 
   public transformRequest(
-    originalRequest: Request,
+    originalRequest: ExecutionRequest,
     delegationContext: DelegationContext,
     transformationContext: Record<string, any>
-  ): Request {
+  ): ExecutionRequest {
     return this.transformer.transformRequest(originalRequest, delegationContext, transformationContext);
   }
 }

--- a/packages/wrap/src/transforms/RenameRootTypes.ts
+++ b/packages/wrap/src/transforms/RenameRootTypes.ts
@@ -1,6 +1,6 @@
 import { visit, GraphQLSchema, NamedTypeNode, Kind } from 'graphql';
 
-import { Request, ExecutionResult, MapperKind, mapSchema, renameType, visitData } from '@graphql-tools/utils';
+import { ExecutionRequest, ExecutionResult, MapperKind, mapSchema, renameType, visitData } from '@graphql-tools/utils';
 
 import { Transform, DelegationContext, SubschemaConfig } from '@graphql-tools/delegate';
 
@@ -35,10 +35,10 @@ export default class RenameRootTypes implements Transform {
   }
 
   public transformRequest(
-    originalRequest: Request,
+    originalRequest: ExecutionRequest,
     _delegationContext: DelegationContext,
     _transformationContext: Record<string, any>
-  ): Request {
+  ): ExecutionRequest {
     const document = visit(originalRequest.document, {
       [Kind.NAMED_TYPE]: (node: NamedTypeNode) => {
         const name = node.name.value;

--- a/packages/wrap/src/transforms/RenameTypes.ts
+++ b/packages/wrap/src/transforms/RenameTypes.ts
@@ -9,7 +9,7 @@ import {
 } from 'graphql';
 
 import {
-  Request,
+  ExecutionRequest,
   ExecutionResult,
   MapperKind,
   RenameTypesOptions,
@@ -66,10 +66,10 @@ export default class RenameTypes implements Transform {
   }
 
   public transformRequest(
-    originalRequest: Request,
+    originalRequest: ExecutionRequest,
     _delegationContext: DelegationContext,
     _transformationContext: Record<string, any>
-  ): Request {
+  ): ExecutionRequest {
     const document = visit(originalRequest.document, {
       [Kind.NAMED_TYPE]: (node: NamedTypeNode) => {
         const name = node.name.value;

--- a/packages/wrap/src/transforms/TransformCompositeFields.ts
+++ b/packages/wrap/src/transforms/TransformCompositeFields.ts
@@ -11,7 +11,7 @@ import {
   FragmentDefinitionNode,
 } from 'graphql';
 
-import { Request, MapperKind, mapSchema, visitData, ExecutionResult, Maybe } from '@graphql-tools/utils';
+import { ExecutionRequest, MapperKind, mapSchema, visitData, ExecutionResult, Maybe } from '@graphql-tools/utils';
 
 import { Transform, DelegationContext, SubschemaConfig } from '@graphql-tools/delegate';
 
@@ -78,10 +78,10 @@ export default class TransformCompositeFields<TContext = Record<string, any>> im
   }
 
   public transformRequest(
-    originalRequest: Request,
+    originalRequest: ExecutionRequest,
     _delegationContext: DelegationContext,
     transformationContext: Record<string, any>
-  ): Request {
+  ): ExecutionRequest {
     const document = originalRequest.document;
     const fragments = Object.create(null);
     for (const def of document.definitions) {

--- a/packages/wrap/src/transforms/TransformEnumValues.ts
+++ b/packages/wrap/src/transforms/TransformEnumValues.ts
@@ -1,6 +1,6 @@
 import { GraphQLSchema, GraphQLEnumValueConfig, ExecutionResult } from 'graphql';
 
-import { Request, MapperKind, mapSchema, Maybe } from '@graphql-tools/utils';
+import { ExecutionRequest, MapperKind, mapSchema, Maybe } from '@graphql-tools/utils';
 
 import { Transform, DelegationContext, SubschemaConfig } from '@graphql-tools/delegate';
 
@@ -43,10 +43,10 @@ export default class TransformEnumValues implements Transform<MapLeafValuesTrans
   }
 
   public transformRequest(
-    originalRequest: Request,
+    originalRequest: ExecutionRequest,
     delegationContext: DelegationContext,
     transformationContext: MapLeafValuesTransformationContext
-  ): Request {
+  ): ExecutionRequest {
     return this.transformer.transformRequest(originalRequest, delegationContext, transformationContext);
   }
 

--- a/packages/wrap/src/transforms/TransformInputObjectFields.ts
+++ b/packages/wrap/src/transforms/TransformInputObjectFields.ts
@@ -14,7 +14,7 @@ import {
   isInputType,
 } from 'graphql';
 
-import { Maybe, Request, MapperKind, mapSchema, transformInputValue } from '@graphql-tools/utils';
+import { Maybe, ExecutionRequest, MapperKind, mapSchema, transformInputValue } from '@graphql-tools/utils';
 
 import { Transform, DelegationContext, SubschemaConfig } from '@graphql-tools/delegate';
 
@@ -74,10 +74,10 @@ export default class TransformInputObjectFields implements Transform {
   }
 
   public transformRequest(
-    originalRequest: Request,
+    originalRequest: ExecutionRequest,
     delegationContext: DelegationContext,
     _transformationContext: Record<string, any>
-  ): Request {
+  ): ExecutionRequest {
     const variableValues = originalRequest.variables ?? {};
     const fragments = Object.create(null);
 
@@ -152,7 +152,7 @@ export default class TransformInputObjectFields implements Transform {
     mapping: Record<string, Record<string, string>>,
     inputFieldNodeTransformer: InputFieldNodeTransformer | undefined,
     inputObjectNodeTransformer: InputObjectNodeTransformer | undefined,
-    request: Request,
+    request: ExecutionRequest,
     delegationContext?: DelegationContext
   ): DocumentNode {
     const typeInfo = new TypeInfo(this._getTransformedSchema());

--- a/packages/wrap/src/transforms/TransformInterfaceFields.ts
+++ b/packages/wrap/src/transforms/TransformInterfaceFields.ts
@@ -1,6 +1,6 @@
 import { GraphQLSchema, isInterfaceType, GraphQLFieldConfig } from 'graphql';
 
-import { Request, ExecutionResult } from '@graphql-tools/utils';
+import { ExecutionRequest, ExecutionResult } from '@graphql-tools/utils';
 
 import { Transform, DelegationContext, SubschemaConfig } from '@graphql-tools/delegate';
 
@@ -51,10 +51,10 @@ export default class TransformInterfaceFields implements Transform {
   }
 
   public transformRequest(
-    originalRequest: Request,
+    originalRequest: ExecutionRequest,
     delegationContext: DelegationContext,
     transformationContext: Record<string, any>
-  ): Request {
+  ): ExecutionRequest {
     return this._getTransformer().transformRequest(originalRequest, delegationContext, transformationContext);
   }
 

--- a/packages/wrap/src/transforms/TransformObjectFields.ts
+++ b/packages/wrap/src/transforms/TransformObjectFields.ts
@@ -1,6 +1,6 @@
 import { GraphQLSchema, isObjectType, GraphQLFieldConfig } from 'graphql';
 
-import { Request, ExecutionResult } from '@graphql-tools/utils';
+import { ExecutionRequest, ExecutionResult } from '@graphql-tools/utils';
 
 import { Transform, DelegationContext, SubschemaConfig } from '@graphql-tools/delegate';
 
@@ -51,10 +51,10 @@ export default class TransformObjectFields implements Transform {
   }
 
   public transformRequest(
-    originalRequest: Request,
+    originalRequest: ExecutionRequest,
     delegationContext: DelegationContext,
     transformationContext: Record<string, any>
-  ): Request {
+  ): ExecutionRequest {
     return this._getTransformer().transformRequest(originalRequest, delegationContext, transformationContext);
   }
 

--- a/packages/wrap/src/transforms/TransformQuery.ts
+++ b/packages/wrap/src/transforms/TransformQuery.ts
@@ -1,6 +1,6 @@
 import { visit, Kind, SelectionSetNode, FragmentDefinitionNode, GraphQLError } from 'graphql';
 
-import { Request, ExecutionResult, relocatedError } from '@graphql-tools/utils';
+import { ExecutionRequest, ExecutionResult, relocatedError } from '@graphql-tools/utils';
 
 import { Transform, DelegationContext } from '@graphql-tools/delegate';
 
@@ -47,10 +47,10 @@ export default class TransformQuery implements Transform {
   }
 
   public transformRequest(
-    originalRequest: Request,
+    originalRequest: ExecutionRequest,
     delegationContext: DelegationContext,
     transformationContext: Record<string, any>
-  ): Request {
+  ): ExecutionRequest {
     const pathLength = this.path.length;
     let index = 0;
     const document = visit(originalRequest.document, {

--- a/packages/wrap/src/transforms/TransformRootFields.ts
+++ b/packages/wrap/src/transforms/TransformRootFields.ts
@@ -1,6 +1,6 @@
 import { GraphQLSchema, GraphQLFieldConfig } from 'graphql';
 
-import { Request, ExecutionResult } from '@graphql-tools/utils';
+import { ExecutionRequest, ExecutionResult } from '@graphql-tools/utils';
 
 import { Transform, DelegationContext, SubschemaConfig } from '@graphql-tools/delegate';
 
@@ -59,10 +59,10 @@ export default class TransformRootFields implements Transform {
   }
 
   public transformRequest(
-    originalRequest: Request,
+    originalRequest: ExecutionRequest,
     delegationContext: DelegationContext,
     transformationContext: Record<string, any>
-  ): Request {
+  ): ExecutionRequest {
     return this._getTransformer().transformRequest(originalRequest, delegationContext, transformationContext);
   }
 

--- a/packages/wrap/src/transforms/WrapFields.ts
+++ b/packages/wrap/src/transforms/WrapFields.ts
@@ -12,7 +12,7 @@ import {
 } from 'graphql';
 
 import {
-  Request,
+  ExecutionRequest,
   appendObjectFields,
   selectObjectFields,
   modifyObjectFields,
@@ -159,10 +159,10 @@ export default class WrapFields<TContext> implements Transform<WrapFieldsTransfo
   }
 
   public transformRequest(
-    originalRequest: Request,
+    originalRequest: ExecutionRequest,
     delegationContext: DelegationContext,
     transformationContext: WrapFieldsTransformationContext
-  ): Request {
+  ): ExecutionRequest {
     transformationContext.nextIndex = 0;
     transformationContext.paths = Object.create(null);
     return this.transformer.transformRequest(originalRequest, delegationContext, transformationContext);

--- a/packages/wrap/src/transforms/WrapQuery.ts
+++ b/packages/wrap/src/transforms/WrapQuery.ts
@@ -1,6 +1,6 @@
 import { FieldNode, visit, Kind, SelectionNode, SelectionSetNode } from 'graphql';
 
-import { Request, ExecutionResult } from '@graphql-tools/utils';
+import { ExecutionRequest, ExecutionResult } from '@graphql-tools/utils';
 
 import { Transform, DelegationContext } from '@graphql-tools/delegate';
 
@@ -18,10 +18,10 @@ export default class WrapQuery implements Transform {
   }
 
   public transformRequest(
-    originalRequest: Request,
+    originalRequest: ExecutionRequest,
     _delegationContext: DelegationContext,
     _transformationContext: Record<string, any>
-  ): Request {
+  ): ExecutionRequest {
     const fieldPath: Array<string> = [];
     const ourPath = JSON.stringify(this.path);
     const document = visit(originalRequest.document, {

--- a/packages/wrap/src/transforms/WrapType.ts
+++ b/packages/wrap/src/transforms/WrapType.ts
@@ -1,6 +1,6 @@
 import { GraphQLSchema } from 'graphql';
 
-import { Request, ExecutionResult } from '@graphql-tools/utils';
+import { ExecutionRequest, ExecutionResult } from '@graphql-tools/utils';
 
 import { Transform, DelegationContext, SubschemaConfig } from '@graphql-tools/delegate';
 
@@ -22,10 +22,10 @@ export default class WrapType implements Transform {
   }
 
   public transformRequest(
-    originalRequest: Request,
+    originalRequest: ExecutionRequest,
     delegationContext: DelegationContext,
     transformationContext: Record<string, any>
-  ): Request {
+  ): ExecutionRequest {
     return this.transformer.transformRequest(originalRequest, delegationContext, transformationContext as any);
   }
 

--- a/packages/wrap/src/types.ts
+++ b/packages/wrap/src/types.ts
@@ -10,7 +10,7 @@ import {
   GraphQLEnumValueConfig,
 } from 'graphql';
 import { DelegationContext } from '@graphql-tools/delegate';
-import { Request, Maybe } from '@graphql-tools/utils';
+import { ExecutionRequest, Maybe } from '@graphql-tools/utils';
 
 export type InputFieldTransformer = (
   typeName: string,
@@ -22,14 +22,14 @@ export type InputFieldNodeTransformer = (
   typeName: string,
   fieldName: string,
   inputFieldNode: ObjectFieldNode,
-  request: Request,
+  request: ExecutionRequest,
   delegationContext?: DelegationContext
 ) => ObjectFieldNode | Array<ObjectFieldNode>;
 
 export type InputObjectNodeTransformer = (
   typeName: string,
   inputObjectNode: ObjectValueNode,
-  request: Request,
+  request: ExecutionRequest,
   delegationContext?: DelegationContext
 ) => ObjectValueNode | undefined;
 

--- a/packages/wrap/tests/fixtures/schemas.ts
+++ b/packages/wrap/tests/fixtures/schemas.ts
@@ -20,9 +20,10 @@ import {
   ExecutionResult,
   isAsyncIterable,
   AsyncExecutor,
+  ExecutionRequest,
 } from '@graphql-tools/utils';
 import { makeExecutableSchema } from '@graphql-tools/schema';
-import { SubschemaConfig, Request } from '@graphql-tools/delegate';
+import { SubschemaConfig } from '@graphql-tools/delegate';
 
 export class CustomError extends GraphQLError {
   constructor(message: string, extensions: Record<string, any>) {
@@ -678,7 +679,7 @@ export const subscriptionSchema: GraphQLSchema = makeExecutableSchema({
 });
 
 function makeExecutorFromSchema(schema: GraphQLSchema): AsyncExecutor {
-  return async <TReturn, TArgs, TContext>({ document, variables, context, operationType }: Request<TArgs, TContext>) => {
+  return async <TReturn, TArgs, TContext>({ document, variables, context, operationType }: ExecutionRequest<TArgs, TContext>) => {
     if (operationType === 'subscription') {
       const result = await subscribe(
         schema,

--- a/packages/wrap/tests/requests.test.ts
+++ b/packages/wrap/tests/requests.test.ts
@@ -51,7 +51,8 @@ describe('requests', () => {
       rootValue: undefined,
       variables: {},
       operationName: 'test',
-      operationType: 'query'
+      operationType: 'query',
+      context: undefined
     });
 
     expect(expectedRequest).toMatchObject(request);

--- a/packages/wrap/tests/requests.test.ts
+++ b/packages/wrap/tests/requests.test.ts
@@ -50,7 +50,8 @@ describe('requests', () => {
       `),
       rootValue: undefined,
       variables: {},
-      operationName: 'test'
+      operationName: 'test',
+      operationType: 'query'
     });
 
     expect(expectedRequest).toMatchObject(request);

--- a/packages/wrap/tests/requests.test.ts
+++ b/packages/wrap/tests/requests.test.ts
@@ -52,7 +52,8 @@ describe('requests', () => {
       variables: {},
       operationName: 'test',
       operationType: 'query',
-      context: undefined
+      context: undefined,
+      info: undefined,
     });
 
     expect(expectedRequest).toMatchObject(request);

--- a/packages/wrap/tests/transformFilterToSchema.test.ts
+++ b/packages/wrap/tests/transformFilterToSchema.test.ts
@@ -26,7 +26,8 @@ describe('FilterToSchema', () => {
       document: query,
       variables: {
         id: 'c1',
-      }
+      },
+      operationType: 'query' as const
     }, {
       targetSchema: bookingSchema
     } as DelegationContext, {});
@@ -60,6 +61,7 @@ describe('FilterToSchema', () => {
         id: 'c1',
         limit: 10,
       },
+      operationType: 'query' as const,
     }, {
       targetSchema: bookingSchema
     } as DelegationContext, {});
@@ -92,6 +94,7 @@ describe('FilterToSchema', () => {
       variables: {
         id: 'b1',
       },
+      operationType: 'query' as const,
     }, {
       targetSchema: bookingSchema
     } as DelegationContext, {});


### PR DESCRIPTION
BREAKING CHANGES;

- Rename `Request` to `ExecutionRequest` (`Request` is also part of DOM types so this prevents the possible confusion)
- Drop unnecessary `GraphQLResolveInfo` in `ExecutionRequest`
- Add `operationType: OperationTypeNode`  as a required field in `ExecutionRequest`
- Add `context` in `createRequest` and `createRequestInfo` instead of `delegateToSchema`

> It doesn't rely on info.operation.operationType to allow the user to call an operation from different root type.
And it doesn't call getOperationAST again and again to get operation type from the document/operation because we have it in Request and ExecutionParams
https://github.com/ardatan/graphql-tools/pull/3166/files#diff-d4824895ea613dcc1f710c3ac82e952fe0ca12391b671f70d9f2d90d5656fdceR38

Improvements;
- Memoize `defaultExecutor` for a single `GraphQLSchema` so allow `getBatchingExecutor` to memoize `batchingExecutor` correctly.
- And there is no different `defaultExecutor` is created for `subscription` and other operation types. Only one executor is used.

> Batch executor is memoized by `executor` reference but `createDefaultExecutor` didn't memoize the default executor so this memoization wasn't working correctly on `batch-execute` side.
https://github.com/ardatan/graphql-tools/blob/remove-info-executor/packages/batch-execute/src/getBatchingExecutor.ts#L9
