### PR TITLE
Fix Error When Loading Schema URLs Synchronously

### DIFF
--- a/.changeset/eighty-rockets-sniff.md
+++ b/.changeset/eighty-rockets-sniff.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/url-loader': patch
+---
+
+Fix error when loading URLs synchronously

--- a/packages/loaders/url/src/index.ts
+++ b/packages/loaders/url/src/index.ts
@@ -304,6 +304,8 @@ export class UrlLoader implements Loader<LoadFromUrlOptions> {
 
       return new ValueOrPromise(() => {
         const query = print(document);
+        const signal = fetch === syncFetch ? undefined : controller.signal;
+
         switch (method) {
           case 'GET':
             const finalUrl = this.prepareGETUrl({ baseUrl: endpoint, query, variables, operationName, extensions });
@@ -330,7 +332,7 @@ export class UrlLoader implements Loader<LoadFromUrlOptions> {
                         accept: 'application/json',
                         ...headers,
                       },
-                      signal: controller.signal,
+                      signal,
                     }) as any
                 )
                 .resolve();
@@ -349,7 +351,7 @@ export class UrlLoader implements Loader<LoadFromUrlOptions> {
                   'content-type': 'application/json',
                   ...headers,
                 },
-                signal: controller.signal,
+                signal,
               });
             }
         }
@@ -508,7 +510,7 @@ export class UrlLoader implements Loader<LoadFromUrlOptions> {
               }
             },
             fetch,
-            signal: controller.signal,
+            signal: fetch === syncFetch ? undefined : controller.signal,
             ...(options?.eventSourceOptions || {}),
           });
           return {

--- a/packages/loaders/url/tests/url-loader.spec.ts
+++ b/packages/loaders/url/tests/url-loader.spec.ts
@@ -13,7 +13,7 @@ import { useServer } from 'graphql-ws/lib/use/ws';
 import { Server as WSServer } from 'ws';
 import http from 'http';
 import { SubscriptionServer } from 'subscriptions-transport-ws';
-
+import { loadSchemaSync } from 'graphql-tools';
 
 describe('Schema URL Loader', () => {
   const loader = new UrlLoader();
@@ -469,5 +469,11 @@ input TestInput {
       expect(result.data['uploadFile']?.filename).toBe(fileName);
       expect(result.data['uploadFile']?.content).toBe(content);
     });
+
+    it('should load url synchronously', () => {
+      expect(() => {
+        loader.loadSync(testHost)
+      }).not.toThrow('Expected signal to be an instanceof AbortSignal')
+    })
   });
 });


### PR DESCRIPTION
## Description

The `sync-fetch` library does not properly support aborting Fetch requests, so when attempting to call `UrlLoader#loadSync`, you get an error stating that the signal you passed in is not an instance of `AbortSignal` (it actually is, but there's some kind of problem with how sync-fetch is sending this over or how node-fetch is reading it...honestly it's a bit of a rabbit hole).

This change ensures that the only time a `signal:` is sent to fetch is when the fetch implementation can handle it. If `sync-fetch` is used to implement the Fetch API, a signal should not be sent over since it is not capable of aborting requests. Downstream tooling like graphql-config and graphql-eslint will be able read URLs just as they do with schema paths and other schema sources.

Related #3174
Related dotansimha/graphql-eslint#525

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

Example application: https://github.com/tubbo/graphql-tools-example

## How Has This Been Tested?

You'll get the error if you call `new UrlLoader().loadSync()` on any URL.

**Test Environment**:
- OS: macOS 10.14
- `@graphql-tools/url-loader`: 6.10.1
- NodeJS: 12.22.1

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

Shoutout to @B2o5T for digging in and helping to solve this little mystery!