### PR TITLE
consolidate Request and ExecutionParams types

### DIFF
--- a/.changeset/fresh-queens-watch.md
+++ b/.changeset/fresh-queens-watch.md
@@ -1,0 +1,24 @@
+---
+'@graphql-tools/batch-delegate': major
+'@graphql-tools/batch-execute': major
+'@graphql-tools/delegate': major
+'@graphql-tools/links': major
+'@graphql-tools/url-loader': major
+'@graphql-tools/stitch': major
+'@graphql-tools/utils': major
+'@graphql-tools/wrap': major
+---
+
+refactor: ExecutionParams type replaced by Request type
+
+rootValue property is now a part of the Request type.
+
+When delegating with delegateToSchema, rootValue can be set multiple ways:
+
+- when using a custom executor, the custom executor can utilize a rootValue in whichever custom way it specifies.
+- when using the default executor (execute/subscribe from graphql-js):
+  -- rootValue can be passed to delegateToSchema via a named option
+  -- rootValue can be included within a subschemaConfig
+  -- otherwise, rootValue is inferred from the originating schema
+
+When using wrapSchema/stitchSchemas, a subschemaConfig can specify the createProxyingResolver function which can pass whatever rootValue it wants to delegateToSchema as above.

--- a/packages/batch-delegate/tests/withTransforms.test.ts
+++ b/packages/batch-delegate/tests/withTransforms.test.ts
@@ -73,7 +73,7 @@ describe('works with complex transforms', () => {
         ]
       }),
       resultTransformer: (results, delegationContext) => {
-        const userIds = delegationContext.args['userIds'];
+        const userIds = delegationContext.args?.['userIds'];
         const booksByUserIds = results.reduce(
           (acc: any, { userId, books }: { userId: string, books: any[] }) => {
             acc[userId] = books

--- a/packages/batch-execute/src/getBatchingExecutor.ts
+++ b/packages/batch-execute/src/getBatchingExecutor.ts
@@ -1,6 +1,6 @@
 import DataLoader from 'dataloader';
 
-import { ExecutionParams, Executor } from '@graphql-tools/utils';
+import { Request, Executor } from '@graphql-tools/utils';
 import { createBatchingExecutor } from './createBatchingExecutor';
 import { memoize2of4 } from './memoize';
 
@@ -8,9 +8,7 @@ export const getBatchingExecutor = memoize2of4(function (
   _context: Record<string, any>,
   executor: Executor,
   dataLoaderOptions?: DataLoader.Options<any, any, any> | undefined,
-  extensionsReducer?:
-    | undefined
-    | ((mergedExtensions: Record<string, any>, executionParams: ExecutionParams) => Record<string, any>)
+  extensionsReducer?: undefined | ((mergedExtensions: Record<string, any>, request: Request) => Record<string, any>)
 ): Executor {
   return createBatchingExecutor(executor, dataLoaderOptions, extensionsReducer);
 });

--- a/packages/delegate/src/createRequest.ts
+++ b/packages/delegate/src/createRequest.ts
@@ -31,6 +31,7 @@ export function getDelegatingOperation(parentType: GraphQLObjectType, schema: Gr
 
 export function createRequestFromInfo({
   info,
+  rootValue,
   operationName,
   operation = getDelegatingOperation(info.parentType, info.schema),
   fieldName = info.fieldName,
@@ -44,6 +45,7 @@ export function createRequestFromInfo({
     fragments: info.fragments,
     variableDefinitions: info.operation.variableDefinitions,
     variableValues: info.variableValues,
+    targetRootValue: rootValue,
     targetOperationName: operationName,
     targetOperation: operation,
     targetFieldName: fieldName,
@@ -59,6 +61,7 @@ export function createRequest({
   fragments,
   variableDefinitions,
   variableValues,
+  targetRootValue,
   targetOperationName,
   targetOperation,
   targetFieldName,
@@ -171,6 +174,7 @@ export function createRequest({
   return {
     document,
     variables: newVariables,
+    rootValue: targetRootValue,
     operationName: targetOperationName,
   };
 }

--- a/packages/delegate/src/index.ts
+++ b/packages/delegate/src/index.ts
@@ -9,4 +9,4 @@ export * from './resolveExternalValue';
 export * from './subschemaConfig';
 export * from './transforms';
 export * from './types';
-export { Executor, AsyncExecutor, SyncExecutor, ExecutionParams } from '@graphql-tools/utils';
+export { Executor, AsyncExecutor, SyncExecutor, Request } from '@graphql-tools/utils';

--- a/packages/delegate/src/transforms/AddArgumentsAsVariables.ts
+++ b/packages/delegate/src/transforms/AddArgumentsAsVariables.ts
@@ -51,7 +51,7 @@ function addVariablesToRootField(
   variables: Record<string, any>;
 } {
   const document = originalRequest.document;
-  const variableValues = originalRequest.variables;
+  const variableValues = originalRequest.variables ?? {};
 
   const operations: Array<OperationDefinitionNode> = document.definitions.filter(
     def => def.kind === Kind.OPERATION_DEFINITION

--- a/packages/delegate/src/transforms/FilterToSchema.ts
+++ b/packages/delegate/src/transforms/FilterToSchema.ts
@@ -41,7 +41,7 @@ export default class FilterToSchema implements Transform {
 function filterToSchema(
   targetSchema: GraphQLSchema,
   document: DocumentNode,
-  variables: Record<string, any>
+  variables?: Record<string, any>
 ): { document: DocumentNode; variables: Record<string, any> } {
   const operations: Array<OperationDefinitionNode> = document.definitions.filter(
     def => def.kind === Kind.OPERATION_DEFINITION
@@ -105,13 +105,15 @@ function filterToSchema(
     });
   }
 
-  const newVariables = usedVariables.reduce((acc, variableName) => {
-    const variableValue = variables[variableName];
-    if (variableValue !== undefined) {
-      acc[variableName] = variableValue;
-    }
-    return acc;
-  }, {});
+  const newVariables = variables
+    ? usedVariables.reduce((acc, variableName) => {
+        const variableValue = variables[variableName];
+        if (variableValue !== undefined) {
+          acc[variableName] = variableValue;
+        }
+        return acc;
+      }, {})
+    : {};
 
   return {
     document: {

--- a/packages/delegate/src/types.ts
+++ b/packages/delegate/src/types.ts
@@ -14,7 +14,7 @@ import {
 
 import DataLoader from 'dataloader';
 
-import { ExecutionParams, ExecutionResult, Executor, Request, TypeMap } from '@graphql-tools/utils';
+import { Request, ExecutionResult, Executor, TypeMap } from '@graphql-tools/utils';
 
 import { Subschema } from './Subschema';
 import { OBJECT_SUBSCHEMA_SYMBOL, FIELD_SUBSCHEMA_MAP_SYMBOL, UNPATHED_ERRORS_SYMBOL } from './symbols';
@@ -47,12 +47,12 @@ export interface DelegationContext<TContext = Record<string, any>> {
   targetSchema: GraphQLSchema;
   operation: OperationTypeNode;
   fieldName: string;
-  args: Record<string, any>;
+  args?: Record<string, any>;
   context?: TContext;
   info: GraphQLResolveInfo;
-  rootValue?: Record<string, any>;
   returnType: GraphQLOutputType;
   onLocatedError?: (originalError: GraphQLError) => GraphQLError;
+  rootValue?: any;
   transforms: Array<Transform<any, TContext>>;
   transformedSchema: GraphQLSchema;
   skipTypeMerging: boolean;
@@ -75,7 +75,7 @@ export interface IDelegateToSchemaOptions<TContext = Record<string, any>, TArgs 
   fieldNodes?: ReadonlyArray<FieldNode>;
   context?: TContext;
   info: GraphQLResolveInfo;
-  rootValue?: Record<string, any>;
+  rootValue?: any;
   transforms?: Array<Transform<any, TContext>>;
   transformedSchema?: GraphQLSchema;
   validateRequest?: boolean;
@@ -90,9 +90,10 @@ export interface IDelegateRequestOptions<TContext = Record<string, any>, TArgs =
 
 export interface ICreateRequestFromInfo {
   info: GraphQLResolveInfo;
+  rootValue?: any;
   operationName?: string;
-  operation: OperationTypeNode;
-  fieldName: string;
+  operation?: OperationTypeNode;
+  fieldName?: string;
   selectionSet?: SelectionSetNode;
   fieldNodes?: ReadonlyArray<FieldNode>;
 }
@@ -105,6 +106,7 @@ export interface ICreateRequest {
   variableDefinitions?: ReadonlyArray<VariableDefinitionNode>;
   variableValues?: Record<string, any>;
   targetOperation: OperationTypeNode;
+  targetRootValue?: any;
   targetOperationName?: string;
   targetFieldName: string;
   selectionSet?: SelectionSetNode;
@@ -135,13 +137,14 @@ export type CreateProxyingResolverFn<TContext = Record<string, any>> = (
 ) => GraphQLFieldResolver<any, TContext>;
 
 export interface BatchingOptions<K = any, V = any, C = K> {
-  extensionsReducer?: (mergedExtensions: Record<string, any>, executionParams: ExecutionParams) => Record<string, any>;
+  extensionsReducer?: (mergedExtensions: Record<string, any>, request: Request) => Record<string, any>;
   dataLoaderOptions?: DataLoader.Options<K, V, C>;
 }
 
 export interface SubschemaConfig<K = any, V = any, C = K, TContext = Record<string, any>> {
   schema: GraphQLSchema;
   createProxyingResolver?: CreateProxyingResolverFn<TContext>;
+  rootValue?: any;
   transforms?: Array<Transform<any, TContext>>;
   merge?: Record<string, MergedTypeConfig<any, any, TContext>>;
   executor?: Executor<TContext>;

--- a/packages/delegate/tests/batchExecution.test.ts
+++ b/packages/delegate/tests/batchExecution.test.ts
@@ -1,7 +1,7 @@
 import { graphql, execute, ExecutionResult } from 'graphql';
 
 import { makeExecutableSchema } from '@graphql-tools/schema';
-import { delegateToSchema, SubschemaConfig, ExecutionParams, SyncExecutor, Executor } from '../src';
+import { delegateToSchema, SubschemaConfig, Request, SyncExecutor, Executor } from '../src';
 import { stitchSchemas } from '@graphql-tools/stitch';
 import { FilterObjectFields } from '@graphql-tools/wrap';
 
@@ -27,9 +27,9 @@ describe('batch execution', () => {
     const innerSubschemaConfig: SubschemaConfig = {
       schema: innerSchema,
       batch: true,
-      executor: ((params: ExecutionParams): ExecutionResult => {
+      executor: ((request: Request): ExecutionResult => {
         executions++;
-        return execute(innerSchema, params.document, undefined, params.context, params.variables) as ExecutionResult;
+        return execute(innerSchema, request.document, undefined, request.context, request.variables) as ExecutionResult;
       }) as SyncExecutor
     }
 
@@ -104,9 +104,9 @@ describe('batch execution', () => {
 
     let executions = 0;
 
-    const executor = ((params: ExecutionParams): ExecutionResult => {
+    const executor = ((request: Request): ExecutionResult => {
       executions++;
-      return execute(innerSchemaA, params.document, undefined, params.context, params.variables) as ExecutionResult;
+      return execute(innerSchemaA, request.document, undefined, request.context, request.variables) as ExecutionResult;
     }) as Executor;
 
     const innerSubschemaConfigA: Array<SubschemaConfig> = [{

--- a/packages/links/src/linkToExecutor.ts
+++ b/packages/links/src/linkToExecutor.ts
@@ -2,12 +2,12 @@ import { toPromise } from '@apollo/client/core';
 import { ApolloLink, execute } from '@apollo/client/link/core';
 import { Observable } from '@apollo/client/utilities';
 
-import { Executor, ExecutionParams, ExecutionResult, observableToAsyncIterable } from '@graphql-tools/utils';
+import { Executor, Request, ExecutionResult, observableToAsyncIterable } from '@graphql-tools/utils';
 
 export const linkToExecutor =
   (link: ApolloLink): Executor =>
-  async <TReturn, TArgs, TContext>(params: ExecutionParams<TArgs, TContext>) => {
-    const { document, variables, extensions, context, info, operationName } = params;
+  async <TReturn, TArgs, TContext>(request: Request<TArgs, TContext>) => {
+    const { document, variables, extensions, context, info, operationName } = request;
     const observable = execute(link, {
       query: document,
       variables,

--- a/packages/loaders/url/src/index.ts
+++ b/packages/loaders/url/src/index.ts
@@ -11,7 +11,7 @@ import {
   BaseLoaderOptions,
   observableToAsyncIterable,
   isAsyncIterable,
-  ExecutionParams,
+  Request,
   mapAsyncIterator,
   withCancel,
   parseGraphQLSDL,
@@ -288,7 +288,7 @@ export class UrlLoader implements Loader<LoadFromUrlOptions> {
       variables,
       operationName,
       extensions,
-    }: ExecutionParams<any, any, any, ExecutionExtensions>) => {
+    }: Request<any, any, any, ExecutionExtensions>) => {
       const controller = new AbortController();
       let method = defaultMethod;
       if (options?.useGETForQueries) {
@@ -456,7 +456,7 @@ export class UrlLoader implements Loader<LoadFromUrlOptions> {
       webSocketImpl
     );
 
-    return async <TReturn, TArgs>({ document, variables, operationName }: ExecutionParams<TArgs>) => {
+    return async <TReturn, TArgs>({ document, variables, operationName }: Request<TArgs>) => {
       return observableToAsyncIterable(
         subscriptionClient.request({
           query: document,

--- a/packages/stitch/tests/fixtures/schemas.ts
+++ b/packages/stitch/tests/fixtures/schemas.ts
@@ -25,7 +25,7 @@ import {
 } from '@graphql-tools/utils';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 
-import { ExecutionParams, SubschemaConfig } from '@graphql-tools/delegate';
+import { Request, SubschemaConfig } from '@graphql-tools/delegate';
 
 export class CustomError extends GraphQLError {
   constructor(message: string, extensions: Record<string, any>) {
@@ -682,7 +682,7 @@ export const subscriptionSchema: GraphQLSchema = makeExecutableSchema({
 });
 
 function makeExecutorFromSchema(schema: GraphQLSchema) {
-  return async <TReturn, TArgs, TContext>({ document, variables, context, info }: ExecutionParams<TArgs, TContext>) => {
+  return async <TReturn, TArgs, TContext>({ document, variables, context, info }: Request<TArgs, TContext>) => {
     if (info?.operation.operation === 'subscription') {
       const result = subscribe(
         schema,

--- a/packages/utils/src/Interfaces.ts
+++ b/packages/utils/src/Interfaces.ts
@@ -58,6 +58,23 @@ export interface ExecutionResult<TData = Record<string, any>> extends GraphQLExe
   extensions?: Record<string, any>;
 }
 
+export interface Request<
+  TArgs extends Record<string, any> = Record<string, any>,
+  TContext = any,
+  TRootValue = any,
+  TExtensions = Record<string, any>
+> {
+  document: DocumentNode;
+  variables?: TArgs;
+  extensions?: TExtensions;
+  operationName?: string;
+  // If the request will be executed locally, it may contain a rootValue
+  rootValue?: TRootValue;
+  // If the request originates within execution of a parent request, it may contain the parent context and info
+  context?: TContext;
+  info?: GraphQLResolveInfo;
+}
+
 // graphql-js non-exported typings
 
 export type TypeMap = Record<string, GraphQLNamedType>;
@@ -308,13 +325,6 @@ export type IFieldIteratorFn = (fieldDef: GraphQLField<any, any>, typeName: stri
 export type IDefaultValueIteratorFn = (type: GraphQLInputType, value: any) => void;
 
 export type NextResolverFn = () => Promise<any>;
-
-export interface Request {
-  document: DocumentNode;
-  variables: Record<string, any>;
-  operationName?: string;
-  extensions?: Record<string, any>;
-}
 
 export type VisitableSchemaType =
   | GraphQLSchema

--- a/packages/utils/src/executor.ts
+++ b/packages/utils/src/executor.ts
@@ -1,23 +1,7 @@
-import { DocumentNode, GraphQLResolveInfo } from 'graphql';
-import { ExecutionResult } from './Interfaces';
+import { ExecutionResult, Request } from './Interfaces';
 
 type MaybePromise<T> = Promise<T> | T;
 type MaybeAsyncIterableIterator<T> = AsyncIterableIterator<T> | T;
-
-export interface ExecutionParams<
-  TArgs extends Record<string, any> = Record<string, any>,
-  TContext = any,
-  TRootValue = any,
-  TExtensions = Record<string, any>
-> {
-  document: DocumentNode;
-  variables?: TArgs;
-  extensions?: TExtensions;
-  context?: TContext;
-  info?: GraphQLResolveInfo;
-  rootValue?: TRootValue;
-  operationName?: string;
-}
 
 export type AsyncExecutor<TBaseContext = Record<string, any>, TBaseExtensions = Record<string, any>> = <
   TReturn = any,
@@ -26,7 +10,7 @@ export type AsyncExecutor<TBaseContext = Record<string, any>, TBaseExtensions = 
   TRoot = any,
   TExtensions extends TBaseExtensions = TBaseExtensions
 >(
-  params: ExecutionParams<TArgs, TContext, TRoot, TExtensions>
+  request: Request<TArgs, TContext, TRoot, TExtensions>
 ) => Promise<MaybeAsyncIterableIterator<ExecutionResult<TReturn>>>;
 
 export type SyncExecutor<TBaseContext = Record<string, any>, TBaseExtensions = Record<string, any>> = <
@@ -36,7 +20,7 @@ export type SyncExecutor<TBaseContext = Record<string, any>, TBaseExtensions = R
   TRoot = any,
   TExtensions extends TBaseExtensions = TBaseExtensions
 >(
-  params: ExecutionParams<TArgs, TContext, TRoot, TExtensions>
+  request: Request<TArgs, TContext, TRoot, TExtensions>
 ) => ExecutionResult<TReturn>;
 
 export type Executor<TBaseContext = Record<string, any>, TBaseExtensions = Record<string, any>> = <
@@ -46,5 +30,5 @@ export type Executor<TBaseContext = Record<string, any>, TBaseExtensions = Recor
   TRoot = any,
   TExtensions extends TBaseExtensions = TBaseExtensions
 >(
-  params: ExecutionParams<TArgs, TContext, TRoot, TExtensions>
+  request: Request<TArgs, TContext, TRoot, TExtensions>
 ) => MaybePromise<MaybeAsyncIterableIterator<ExecutionResult<TReturn>>>;

--- a/packages/wrap/src/transforms/MapLeafValues.ts
+++ b/packages/wrap/src/transforms/MapLeafValues.ts
@@ -88,7 +88,7 @@ export default class MapLeafValues implements Transform<MapLeafValuesTransformat
     transformationContext: MapLeafValuesTransformationContext
   ): Request {
     const document = originalRequest.document;
-    const variableValues = originalRequest.variables;
+    const variableValues = (originalRequest.variables = {});
 
     const operations: Array<OperationDefinitionNode> = document.definitions.filter(
       def => def.kind === Kind.OPERATION_DEFINITION

--- a/packages/wrap/src/transforms/TransformInputObjectFields.ts
+++ b/packages/wrap/src/transforms/TransformInputObjectFields.ts
@@ -78,7 +78,7 @@ export default class TransformInputObjectFields implements Transform {
     delegationContext: DelegationContext,
     _transformationContext: Record<string, any>
   ): Request {
-    const variableValues = originalRequest.variables;
+    const variableValues = (originalRequest.variables = {});
     const fragments = Object.create(null);
 
     const operations: Array<OperationDefinitionNode> = [];

--- a/packages/wrap/src/transforms/TransformInputObjectFields.ts
+++ b/packages/wrap/src/transforms/TransformInputObjectFields.ts
@@ -78,7 +78,7 @@ export default class TransformInputObjectFields implements Transform {
     delegationContext: DelegationContext,
     _transformationContext: Record<string, any>
   ): Request {
-    const variableValues = (originalRequest.variables = {});
+    const variableValues = originalRequest.variables ?? {};
     const fragments = Object.create(null);
 
     const operations: Array<OperationDefinitionNode> = [];

--- a/packages/wrap/tests/fixtures/schemas.ts
+++ b/packages/wrap/tests/fixtures/schemas.ts
@@ -22,7 +22,7 @@ import {
   isAsyncIterable,
 } from '@graphql-tools/utils';
 import { makeExecutableSchema } from '@graphql-tools/schema';
-import { SubschemaConfig, ExecutionParams } from '@graphql-tools/delegate';
+import { SubschemaConfig, Request } from '@graphql-tools/delegate';
 
 export class CustomError extends GraphQLError {
   constructor(message: string, extensions: Record<string, any>) {
@@ -678,7 +678,7 @@ export const subscriptionSchema: GraphQLSchema = makeExecutableSchema({
 });
 
 function makeExecutorFromSchema(schema: GraphQLSchema) {
-  return async <TReturn, TArgs, TContext>({ document, variables, context, info }: ExecutionParams<TArgs, TContext>) => {
+  return async <TReturn, TArgs, TContext>({ document, variables, context, info }: Request<TArgs, TContext>) => {
     if (info?.operation.operation === 'subscription') {
       const result = await subscribe(
         schema,

--- a/packages/wrap/tests/requests.test.ts
+++ b/packages/wrap/tests/requests.test.ts
@@ -48,6 +48,7 @@ describe('requests', () => {
           }
         }
       `),
+      rootValue: undefined,
       variables: {},
       operationName: 'test'
     });

--- a/website/docs/remote-schemas.md
+++ b/website/docs/remote-schemas.md
@@ -27,9 +27,9 @@ You can use an executor with an HTTP Client implementation (like cross-fetch). A
 We've chosen to split this functionality up to give you the flexibility to choose when to do the introspection step. For example, you might already have the remote schema information, allowing you to skip the `introspectSchema` step entirely. Here's a complete example:
 
 ```js
-type Executor = (operation: ExecutionParams) => Promise<ExecutionResult>;
+type Executor = (request: Request) => Promise<ExecutionResult>;
 
-type ExecutionParams = {
+type Request = {
   document: DocumentNode,
   variables?: Object,
   context?: Object,
@@ -213,7 +213,6 @@ import { delegateToSchema } from '@graphql-tools/delegate';
 export function defaultCreateProxyingResolver({
   subschemaConfig,
   operation,
-  transforms,
   transformedSchema,
 }: ICreateProxyingResolverOptions): GraphQLFieldResolver<any, any> {
   return (_parent, _args, context, info) =>

--- a/website/docs/stitch-combining-schemas.md
+++ b/website/docs/stitch-combining-schemas.md
@@ -86,16 +86,16 @@ In the example above, the extra "subschema" wrapper objects may look verbose at 
 ```js
 export interface SubschemaConfig {
   schema: GraphQLSchema;
-  rootValue?: Record<string, any>;
   executor?: Executor;
   createProxyingResolver?: CreateProxyingResolverFn;
+  rootValue?: Record<string, any>;
   transforms?: Array<Transform>;
   merge?: Record<string, MergedTypeConfig>;
   batch?: boolean;
   batchingOptions?: {
     extensionsReducer?: (
       mergedExtensions: Record<string, any>,
-      executionParams: ExecutionParams
+      request: Request
     ) => Record<string, any>,
     dataLoaderOptions?: DataLoader.Options<K, V, C>,
   };

--- a/website/docs/stitch-type-merging.md
+++ b/website/docs/stitch-type-merging.md
@@ -253,7 +253,7 @@ Query batching will collect all queries made during an execution cycle and combi
 ```ts
 batchingOptions?: {
   dataLoaderOptions?: DataLoader.Options<K, V, C>;
-  extensionsReducer?: (mergedExtensions: Record<string, any>, executionParams: ExecutionParams) => Record<string, any>;
+  extensionsReducer?: (mergedExtensions: Record<string, any>, request: Request) => Record<string, any>;
 }
 ```
 


### PR DESCRIPTION
* also affixes rootValue to Request
* when delegating with delegateToSchema, rootValue can be set multiple ways:
  * when using a custom executor, the custom executor can utilize a
    rootValue in whichever custom way it specifies.
  * when using the default executor (execute/subscribe from graphql-js):
   -- rootValue can be passed to delegateToSchema via a named option
   -- rootValue can be included within a subschemaConfig
   -- otherwise, rootValue is inferred from the originating schema
- when using wrapSchema/stitchSchemas, a subschemaConfig can specify the
  createProxyingResolver function which can pass whatever rootValue it
  wants to delegateToSchema as above.