### PR TITLE
feat: support Gatsby-style directives in extensions

### DIFF
--- a/.changeset/quick-hotels-beam.md
+++ b/.changeset/quick-hotels-beam.md
@@ -1,0 +1,16 @@
+---
+'@graphql-tools/stitch': major
+'@graphql-tools/stitching-directives': major
+'@graphql-tools/utils': major
+'@graphql-tools/wrap': major
+---
+
+fix(getDirectives): preserve order around repeatable directives
+
+BREAKING CHANGE: getDirectives now always return an array of individual DirectiveAnnotation objects consisting of `name` and `args` properties.
+
+New useful function `getDirective` returns an array of objects representing any args for each use of a single directive (returning the empty object `{}` when a directive is used without arguments).
+
+Note: The `getDirective` function returns an array even when the specified directive is non-repeatable. This is because one use of this function is to throw an error if more than one directive annotation is used for a non repeatable directive!
+
+When specifying directives in extensions, one can use either the old or new format.

--- a/packages/stitch/src/subschemaConfigTransforms/computedDirectiveTransformer.ts
+++ b/packages/stitch/src/subschemaConfigTransforms/computedDirectiveTransformer.ts
@@ -1,4 +1,4 @@
-import { getDirectives, MapperKind, mapSchema } from '@graphql-tools/utils';
+import { getDirective, MapperKind, mapSchema } from '@graphql-tools/utils';
 import { cloneSubschemaConfig, SubschemaConfig } from '@graphql-tools/delegate';
 
 import { SubschemaConfigTransform } from '../types';
@@ -15,13 +15,13 @@ export function computedDirectiveTransformer(computedDirectiveName: string): Sub
           return undefined;
         }
 
-        const computed = getDirectives(schema, fieldConfig)[computedDirectiveName];
+        const computed = getDirective(schema, fieldConfig, computedDirectiveName)?.[0];
 
         if (computed == null) {
           return undefined;
         }
 
-        const selectionSet = computed.fields != null ? `{ ${computed.fields} }` : computed.selectionSet;
+        const selectionSet = computed['fields'] != null ? `{ ${computed['fields']} }` : computed['selectionSet'];
 
         if (selectionSet == null) {
           return undefined;

--- a/packages/stitch/tests/mergeDefinitions.test.ts
+++ b/packages/stitch/tests/mergeDefinitions.test.ts
@@ -1,6 +1,6 @@
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { stitchSchemas } from '@graphql-tools/stitch';
-import { getDirectives } from '@graphql-tools/utils';
+import { getDirective } from '@graphql-tools/utils';
 import { stitchingDirectives } from '@graphql-tools/stitching-directives';
 import {
   GraphQLObjectType,
@@ -282,22 +282,22 @@ describe('merge canonical types', () => {
     const scalarType = gatewaySchema.getType('ProductScalar');
     assertGraphQLScalerType(scalarType)
 
-    expect(getDirectives(firstSchema, queryType.toConfig())['mydir'].value).toEqual('first');
-    expect(getDirectives(firstSchema, objectType.toConfig())['mydir'].value).toEqual('first');
-    expect(getDirectives(firstSchema, interfaceType.toConfig())['mydir'].value).toEqual('first');
-    expect(getDirectives(firstSchema, inputType.toConfig())['mydir'].value).toEqual('first');
-    expect(getDirectives(firstSchema, enumType.toConfig())['mydir'].value).toEqual('first');
-    expect(getDirectives(firstSchema, unionType.toConfig())['mydir'].value).toEqual('first');
-    expect(getDirectives(firstSchema, scalarType.toConfig())['mydir'].value).toEqual('first');
+    expect(getDirective(firstSchema, queryType.toConfig(), 'mydir')?.[0]['value']).toEqual('first');
+    expect(getDirective(firstSchema, objectType.toConfig(), 'mydir')?.[0]['value']).toEqual('first');
+    expect(getDirective(firstSchema, interfaceType.toConfig(), 'mydir')?.[0]['value']).toEqual('first');
+    expect(getDirective(firstSchema, inputType.toConfig(), 'mydir')?.[0]['value']).toEqual('first');
+    expect(getDirective(firstSchema, enumType.toConfig(), 'mydir')?.[0]['value']).toEqual('first');
+    expect(getDirective(firstSchema, unionType.toConfig(), 'mydir')?.[0]['value']).toEqual('first');
+    expect(getDirective(firstSchema, scalarType.toConfig(), 'mydir')?.[0]['value']).toEqual('first');
 
-    expect(getDirectives(firstSchema, queryType.getFields()['field1'])['mydir'].value).toEqual('first');
-    expect(getDirectives(firstSchema, queryType.getFields()['field2'])['mydir'].value).toEqual('second');
-    expect(getDirectives(firstSchema, objectType.getFields()['id'])['mydir'].value).toEqual('first');
-    expect(getDirectives(firstSchema, objectType.getFields()['url'])['mydir'].value).toEqual('second');
-    expect(getDirectives(firstSchema, interfaceType.getFields()['id'])['mydir'].value).toEqual('first');
-    expect(getDirectives(firstSchema, interfaceType.getFields()['url'])['mydir'].value).toEqual('second');
-    expect(getDirectives(firstSchema, inputType.getFields()['id'])['mydir'].value).toEqual('first');
-    expect(getDirectives(firstSchema, inputType.getFields()['url'])['mydir'].value).toEqual('second');
+    expect(getDirective(firstSchema, queryType.getFields()['field1'], 'mydir')?.[0]['value']).toEqual('first');
+    expect(getDirective(firstSchema, queryType.getFields()['field2'], 'mydir')?.[0]['value']).toEqual('second');
+    expect(getDirective(firstSchema, objectType.getFields()['id'], 'mydir')?.[0]['value']).toEqual('first');
+    expect(getDirective(firstSchema, objectType.getFields()['url'], 'mydir')?.[0]['value']).toEqual('second');
+    expect(getDirective(firstSchema, interfaceType.getFields()['id'], 'mydir')?.[0]['value']).toEqual('first');
+    expect(getDirective(firstSchema, interfaceType.getFields()['url'], 'mydir')?.[0]['value']).toEqual('second');
+    expect(getDirective(firstSchema, inputType.getFields()['id'], 'mydir')?.[0]['value']).toEqual('first');
+    expect(getDirective(firstSchema, inputType.getFields()['url'], 'mydir')?.[0]['value']).toEqual('second');
 
     expect(enumType.toConfig().astNode?.values?.map(v => v.description?.value)).toEqual(['first', 'first', 'second']);
     expect(enumType.toConfig().values['YES'].astNode?.description?.value).toEqual('first');
@@ -309,8 +309,8 @@ describe('merge canonical types', () => {
     const objectType = gatewaySchema.getType('Product') as GraphQLObjectType;
     expect(objectType.getFields()['id'].deprecationReason).toEqual('first');
     expect(objectType.getFields()['url'].deprecationReason).toEqual('second');
-    expect(getDirectives(firstSchema, objectType.getFields()['id'])['deprecated'].reason).toEqual('first');
-    expect(getDirectives(firstSchema, objectType.getFields()['url'])['deprecated'].reason).toEqual('second');
+    expect(getDirective(firstSchema, objectType.getFields()['id'], 'deprecated')?.[0]['reason']).toEqual('first');
+    expect(getDirective(firstSchema, objectType.getFields()['url'], 'deprecated')?.[0]['reason']).toEqual('second');
   });
 
   it('promotes canonical root field definitions', async () => {

--- a/packages/stitch/tests/typeMergingWithExtensions.test.ts
+++ b/packages/stitch/tests/typeMergingWithExtensions.test.ts
@@ -52,9 +52,9 @@ describe('merging using type merging', () => {
         },
         resolve: (_root, { keys }) => keys.map((key: Record<string, any>) => users.find(u => u.id === key['id'])),
         extensions: {
-          directives: {
-            merge: {},
-          },
+          directives: [{
+            name: 'merge',
+          }],
         },
       }
     }),
@@ -68,12 +68,13 @@ describe('merging using type merging', () => {
       username: { type: GraphQLString }
     }),
     extensions: {
-      directives: {
-        key: {
+      directives: [{
+        name: 'key',
+        args: {
           selectionSet: '{ id }',
-        }
-      }
-    }
+        },
+      }],
+    },
   });
 
   const accountsSchema = stitchingDirectivesValidator(new GraphQLSchema({

--- a/packages/utils/tests/get-directives.spec.ts
+++ b/packages/utils/tests/get-directives.spec.ts
@@ -4,19 +4,19 @@ import { assertGraphQLObjectType } from '../../testing/assertion';
 import { GraphQLSchema } from 'graphql';
 
 describe('getDirectives', () => {
-  it('should return the correct directives map when no directives specified', () => {
+  it('should return the correct directives when no directives specified', () => {
     const typeDefs = `
       type Query {
         test: String
       }
     `;
     const schema = makeExecutableSchema({ typeDefs, resolvers: {} }) as GraphQLSchema;
-    const directivesMap = getDirectives(schema, schema.getQueryType()!);
+    const directives = getDirectives(schema, schema.getQueryType()!);
 
-    expect(directivesMap).toEqual({});
+    expect(directives).toEqual([]);
   });
 
-  it('should return the correct directives map when built-in directive specified over FIELD_DEFINITION', () => {
+  it('should return the correct directives built-in directive specified over FIELD_DEFINITION', () => {
     const typeDefs = `
       type Query {
         test: String @deprecated
@@ -24,15 +24,16 @@ describe('getDirectives', () => {
     `;
 
     const schema = makeExecutableSchema({ typeDefs, resolvers: {} }) as GraphQLSchema;
-    const directivesMap = getDirectives(schema, schema.getQueryType()!.getFields()['test']);
-    expect(directivesMap).toEqual({
-      deprecated: {
+    const directives = getDirectives(schema, schema.getQueryType()!.getFields()['test']);
+    expect(directives).toEqual([{
+      name: 'deprecated',
+      args: {
         reason: 'No longer supported',
       },
-    });
+    }]);
   });
 
-  it('should return the correct directives map when using custom directive without arguments', () => {
+  it('should return the correct directives when using custom directive without arguments', () => {
     const typeDefs = `
       type Query {
         test: String @mydir
@@ -42,13 +43,14 @@ describe('getDirectives', () => {
     `;
 
     const schema = makeExecutableSchema({ typeDefs, resolvers: {} }) as GraphQLSchema;
-    const directivesMap = getDirectives(schema, schema.getQueryType()!.getFields()['test']);
-    expect(directivesMap).toEqual({
-      mydir: {},
-    });
+    const directives = getDirectives(schema, schema.getQueryType()!.getFields()['test']);
+    expect(directives).toEqual([{
+      name: 'mydir',
+      args: {},
+    }]);
   });
 
-  it('should return the correct directives map when using custom directive with optional argument', () => {
+  it('should return the correct directives when using custom directive with optional argument', () => {
     const typeDefs = `
       type Query {
         test: String @mydir(f1: "test")
@@ -58,15 +60,16 @@ describe('getDirectives', () => {
     `;
 
     const schema = makeExecutableSchema({ typeDefs, resolvers: {} }) as GraphQLSchema;
-    const directivesMap = getDirectives(schema, schema.getQueryType()!.getFields()['test']);
-    expect(directivesMap).toEqual({
-      mydir: {
+    const directives = getDirectives(schema, schema.getQueryType()!.getFields()['test']);
+    expect(directives).toEqual([{
+      name: 'mydir',
+      args: {
         f1: 'test',
       },
-    });
+    }]);
   });
 
-  it('should return the correct directives map when using custom directive with optional argument an no value', () => {
+  it('should return the correct directives when using custom directive with optional argument an no value', () => {
     const typeDefs = `
       type Query {
         test: String @mydir
@@ -76,10 +79,11 @@ describe('getDirectives', () => {
     `;
 
     const schema = makeExecutableSchema({ typeDefs, resolvers: {} }) as GraphQLSchema;
-    const directivesMap = getDirectives(schema, schema.getQueryType()!.getFields()['test']);
-    expect(directivesMap).toEqual({
-      mydir: {},
-    });
+    const directives = getDirectives(schema, schema.getQueryType()!.getFields()['test']);
+    expect(directives).toEqual([{
+      name: 'mydir',
+      args: {},
+    }]);
   });
 
   it('provides the extension definition', () => {
@@ -96,7 +100,7 @@ describe('getDirectives', () => {
     });
     const QueryType = schema.getQueryType()
     assertGraphQLObjectType(QueryType)
-    expect(getDirectives(schema,QueryType)).toEqual({ mydir: { arg: 'ext1' } });
+    expect(getDirectives(schema,QueryType)).toEqual([{ name: 'mydir', args: { arg: 'ext1' } }]);
   });
 
   it('builds proper repeatable directives listing', () => {
@@ -110,8 +114,12 @@ describe('getDirectives', () => {
     });
     const QueryType = schema.getQueryType()
     assertGraphQLObjectType(QueryType)
-    expect(getDirectives(schema, QueryType)).toEqual({
-      mydir: [{ arg: "first" }, { arg: "second" }]
-    });
+    expect(getDirectives(schema, QueryType)).toEqual([{
+      name: 'mydir',
+      args: { arg: 'first' },
+    }, {
+      name: 'mydir',
+      args: { arg: 'second' },
+    }]);
   });
 });

--- a/packages/wrap/src/transforms/RemoveObjectFieldsWithDirective.ts
+++ b/packages/wrap/src/transforms/RemoveObjectFieldsWithDirective.ts
@@ -21,13 +21,10 @@ export default class RemoveObjectFieldsWithDirective implements Transform {
     transformedSchema?: GraphQLSchema
   ): GraphQLSchema {
     const transformer = new FilterObjectFields((_typeName, _fieldName, fieldConfig) => {
-      const valueMap = getDirectives(originalWrappingSchema, fieldConfig);
-      return !Object.keys(valueMap).some(
-        directiveName =>
-          valueMatchesCriteria(directiveName, this.directiveName) &&
-          ((Array.isArray(valueMap[directiveName]) &&
-            valueMap[directiveName].some((value: any) => valueMatchesCriteria(value, this.args))) ||
-            valueMatchesCriteria(valueMap[directiveName], this.args))
+      const directives = getDirectives(originalWrappingSchema, fieldConfig);
+      return !directives.some(
+        directive =>
+          valueMatchesCriteria(directive.name, this.directiveName) && valueMatchesCriteria(directive.args, this.args)
       );
     });
 


### PR DESCRIPTION
BREAKING CHANGE: getDirectives now always return an array of DirectiveAnnotation objects

New function getDirective returns an array of args records for each use of the directive.

Note: this is true even when the directive is non-repeatable. This is because one use of this function is to throw an error if more than one directive annotation is used for a non repeatable directive!

See https://github.com/ardatan/graphql-tools/issues/2534