### PR TITLE
FIX: fixed potential bug in info object that is passed to onTypeConfl…

### DIFF
--- a/.changeset/curly-items-glow.md
+++ b/.changeset/curly-items-glow.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/stitch': patch
+---
+
+Fixed issue with stitchSchemas function returning info object with left.subschema and right.subschema referencing the same object

--- a/packages/stitch/src/typeCandidates.ts
+++ b/packages/stitch/src/typeCandidates.ts
@@ -236,8 +236,8 @@ function onTypeConflictToCandidateSelector<TContext = Record<string, any>>(
           transformedSubschema: prev.transformedSubschema,
         },
         right: {
-          subschema: prev.subschema,
-          transformedSubschema: prev.transformedSubschema,
+          subschema: next.subschema,
+          transformedSubschema: next.transformedSubschema,
         },
       });
       if (prev.type === type) {

--- a/packages/stitch/tests/alternateStitchSchemas.test.ts
+++ b/packages/stitch/tests/alternateStitchSchemas.test.ts
@@ -1931,7 +1931,7 @@ describe('onTypeConflict', () => {
     expect(result2.data).toBeUndefined();
   });
 
-  test('returns info.left and info.right properties that are not equal', async () => {
+  test('returns info.left and info.right properties that are not equal', () => {
     stitchSchemas({
       subschemas: [schema1, schema2],
       mergeTypes: false,

--- a/packages/stitch/tests/alternateStitchSchemas.test.ts
+++ b/packages/stitch/tests/alternateStitchSchemas.test.ts
@@ -1930,6 +1930,18 @@ describe('onTypeConflict', () => {
     const result2 = await graphql(stitchedSchema, '{ test1 { fieldC } }');
     expect(result2.data).toBeUndefined();
   });
+
+  test('returns info.left and info.right properties that are not equal', async () => {
+    stitchSchemas({
+      subschemas: [schema1, schema2],
+      mergeTypes: false,
+      onTypeConflict: (left, _right, info) => {
+        expect(info?.right.subschema !== info?.left.subschema).toBe(true);
+        expect(info?.right.transformedSubschema !== info?.left.transformedSubschema).toBe(true);
+        return left;
+      }
+    });
+  });
 });
 
 describe('basic type merging', () => {


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
## Description

Fixed issue with stitchSchemas function returning info object with left.subschema and right.subschema referencing the same object.

Related https://github.com/ardatan/graphql-tools/issues/3205
<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
