### PR TITLE
Fix for supporting longer paths in TransformQuery

### DIFF
--- a/.changeset/metal-files-worry.md
+++ b/.changeset/metal-files-worry.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/wrap': patch
+---
+
+Fix TransformQuery for path longer than 1

--- a/packages/wrap/src/transforms/TransformQuery.ts
+++ b/packages/wrap/src/transforms/TransformQuery.ts
@@ -122,7 +122,7 @@ export default class TransformQuery implements Transform {
       }
       newData[next] = this.resultTransformer(newData[next], delegationContext, transformationContext);
     }
-    return newData;
+    return data;
   }
 
   private transformErrors(errors: ReadonlyArray<GraphQLError>): ReadonlyArray<GraphQLError> {


### PR DESCRIPTION
## Description

Fix for TransformQuery where path is longer than 1.
- Returns correctly the entire response while only modifying the relevant `path`
- Preserves other fields that are not part of the `path`

Related #3323
<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tests for this fix are included. If fix isn't present the longer path fails with the error described in the issue. Other tests are left untouched so backwards compatibility is ensured.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
  - N/A
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
  - N/A