### PR TITLE
Fix nested type merges with repeated children ignore all but first occurrence

### DIFF
--- a/.changeset/spicy-lions-shop.md
+++ b/.changeset/spicy-lions-shop.md
@@ -1,0 +1,6 @@
+---
+'@graphql-tools/delegate': patch
+'@graphql-tools/stitch': patch
+---
+
+Fix nested type merges with repeated children ignore all but first occurrence

--- a/packages/delegate/src/resolveExternalValue.ts
+++ b/packages/delegate/src/resolveExternalValue.ts
@@ -60,11 +60,9 @@ function resolveExternalObject(
 ) {
   // if we have already resolved this object, for example, when the identical object appears twice
   // in a list, see https://github.com/ardatan/graphql-tools/issues/2304
-  if (isExternalObject(object)) {
-    return object;
+  if (!isExternalObject(object)) {
+    annotateExternalObject(object, unpathedErrors, subschema);
   }
-
-  annotateExternalObject(object, unpathedErrors, subschema);
 
   if (skipTypeMerging || info == null) {
     return object;


### PR DESCRIPTION
## Description

Fixes nested type merge issue, when children multiple levels deep may be repeated on parents.  Fixes #3372 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested against a fairly complex pre-existing schema which exhibited the behavior prior to change

**Test Environment**:
- OS: Windows 10
- `@graphql-tools/delegate`: 8.0.8
- NodeJS: v12.21.0

