### PR TITLE
Use local `TypeMap` instead of graphql-js's one

### DIFF
--- a/packages/delegate/src/finalizeGatewayRequest.ts
+++ b/packages/delegate/src/finalizeGatewayRequest.ts
@@ -22,6 +22,7 @@ import {
 } from 'graphql';
 
 import {
+  TypeMap,
   getDefinedRootType,
   ExecutionRequest,
   serializeInputValue,
@@ -32,7 +33,6 @@ import {
 
 import { DelegationContext } from './types';
 import { getDocumentMetadata } from './getDocumentMetadata';
-import type { TypeMap } from 'graphql/type/schema';
 
 function finalizeGatewayDocument(
   targetSchema: GraphQLSchema,

--- a/packages/delegate/src/types.ts
+++ b/packages/delegate/src/types.ts
@@ -14,11 +14,10 @@ import {
 
 import DataLoader from 'dataloader';
 
-import { ExecutionRequest, ExecutionResult, Executor } from '@graphql-tools/utils';
+import { TypeMap, ExecutionRequest, ExecutionResult, Executor } from '@graphql-tools/utils';
 
 import { Subschema } from './Subschema';
 import { OBJECT_SUBSCHEMA_SYMBOL, FIELD_SUBSCHEMA_MAP_SYMBOL, UNPATHED_ERRORS_SYMBOL } from './symbols';
-import { TypeMap } from 'graphql/type/schema';
 
 export type SchemaTransform<TContext = Record<any, string>> = (
   originalWrappingSchema: GraphQLSchema,

--- a/packages/stitch/src/stitchingInfo.ts
+++ b/packages/stitch/src/stitchingInfo.ts
@@ -14,7 +14,7 @@ import {
   isUnionType,
 } from 'graphql';
 
-import { parseSelectionSet, IResolvers, IFieldResolverOptions, isSome } from '@graphql-tools/utils';
+import { TypeMap, parseSelectionSet, IResolvers, IFieldResolverOptions, isSome } from '@graphql-tools/utils';
 
 import { MergedTypeResolver, Subschema, SubschemaConfig, MergedTypeInfo, StitchingInfo } from '@graphql-tools/delegate';
 
@@ -22,7 +22,6 @@ import { MergeTypeCandidate, MergeTypeFilter } from './types';
 
 import { createMergedTypeResolver } from './createMergedTypeResolver';
 import { collectFields, ExecutionContext } from 'graphql/execution/execute.js';
-import { TypeMap } from 'graphql/type/schema';
 import { createDelegationPlanBuilder } from './createDelegationPlanBuilder';
 
 export function createStitchingInfo<TContext = Record<string, any>>(

--- a/packages/stitch/src/typeCandidates.ts
+++ b/packages/stitch/src/typeCandidates.ts
@@ -15,14 +15,13 @@ import {
 
 import { wrapSchema } from '@graphql-tools/wrap';
 import { Subschema, SubschemaConfig, StitchingInfo } from '@graphql-tools/delegate';
-import { GraphQLParseOptions, TypeSource, rewireTypes, getRootTypeMap } from '@graphql-tools/utils';
+import { TypeMap, GraphQLParseOptions, TypeSource, rewireTypes, getRootTypeMap } from '@graphql-tools/utils';
 
 import typeFromAST from './typeFromAST';
 import { MergeTypeCandidate, MergeTypeFilter, OnTypeConflict, TypeMergingOptions } from './types';
 import { mergeCandidates } from './mergeCandidates';
 import { extractDefinitions } from './definitions';
 import { mergeTypeDefs } from '@graphql-tools/merge';
-import { TypeMap } from 'graphql/type/schema';
 
 type CandidateSelector<TContext = Record<string, any>> = (
   candidates: Array<MergeTypeCandidate<TContext>>

--- a/packages/utils/src/Interfaces.ts
+++ b/packages/utils/src/Interfaces.ts
@@ -48,6 +48,8 @@ import {
   OperationTypeNode,
 } from 'graphql';
 
+export type TypeMap = Record<string, GraphQLNamedType>;
+
 // graphql-js < v15 backwards compatible ExecutionResult
 // See: https://github.com/graphql/graphql-js/pull/2490
 

--- a/packages/utils/src/heal.ts
+++ b/packages/utils/src/heal.ts
@@ -20,7 +20,8 @@ import {
   isListType,
   isNonNullType,
 } from 'graphql';
-import { TypeMap } from 'graphql/type/schema';
+
+import { TypeMap } from './Interfaces';
 
 // Update any references to named schema types that disagree with the named
 // types found in schema.getTypeMap().

--- a/packages/utils/src/mapSchema.ts
+++ b/packages/utils/src/mapSchema.ts
@@ -29,11 +29,11 @@ import {
   Kind,
   EnumValueDefinitionNode,
 } from 'graphql';
-import { TypeMap } from 'graphql/type/schema';
 
 import { getObjectTypeFromTypeMap } from './getObjectTypeFromTypeMap';
 
 import {
+  TypeMap,
   SchemaMapper,
   MapperKind,
   NamedTypeMapper,

--- a/packages/utils/src/rewire.ts
+++ b/packages/utils/src/rewire.ts
@@ -25,8 +25,8 @@ import {
   isSpecifiedScalarType,
   isSpecifiedDirective,
 } from 'graphql';
-import { TypeMap } from 'graphql/type/schema';
 
+import { TypeMap } from './Interfaces';
 import { getBuiltInForStub, isNamedStub } from './stub';
 
 export function rewireTypes(


### PR DESCRIPTION
TypeMap was never exposed by 'graphql-js' and was just leak in `schema.d.ts` file