### PR TITLE
Wrap: add package tests for WrapFields

### DIFF
--- a/packages/wrap/tests/transformWrapFields.test.ts
+++ b/packages/wrap/tests/transformWrapFields.test.ts
@@ -42,7 +42,7 @@ describe('WrapFields', () => {
     const userType = schema.getType('User') as GraphQLObjectType;
     const addressType = schema.getType('Address') as GraphQLObjectType;
 
-    expect(userType.getFields().address).toBeDefined();
+    expect(userType.getFields()['address']).toBeDefined();
     expect(Object.keys(addressType.getFields()).sort()).toEqual([
       'city',
       'street',

--- a/packages/wrap/tests/transformWrapFields.test.ts
+++ b/packages/wrap/tests/transformWrapFields.test.ts
@@ -1,0 +1,83 @@
+import { graphql } from 'graphql';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { wrapSchema, WrapFields } from '@graphql-tools/wrap';
+
+describe('WrapFields', () => {
+  const subschema = makeExecutableSchema({
+    typeDefs: /* GraphQL */`
+      type User {
+        id: ID!
+        street: String
+        city: String
+        zipcode: String
+      }
+
+      type Query {
+        user: User
+      }
+    `,
+    resolvers: {
+      Query: {
+        user: () => ({
+          id: '1',
+          street: '7 Windy Shore Rd',
+          city: 'Vancouver',
+          zipcode: '12345',
+        }),
+      },
+    },
+  });
+
+  const schema = wrapSchema({
+    schema: subschema,
+    transforms: [new WrapFields(
+      'User',
+      ['address'],
+      ['Address'],
+      ['street', 'city', 'zipcode'],
+    )]
+  });
+
+  test('schema is transformed with new type and field', async () => {
+    const userType = schema.getType('User');
+    const addressType = schema.getType('Address');
+
+    expect(userType.getFields().address).toBeDefined();
+    expect(Object.keys(addressType.getFields()).sort()).toEqual([
+      'city',
+      'street',
+      'zipcode',
+    ]);
+  });
+
+  test('select fields are wrapped and queryable', async () => {
+    const result = await graphql({
+      schema,
+      source: /* GraphQL */ `
+        query {
+          user {
+            id
+            address {
+              street
+              city
+              zipcode
+            }
+          }
+        }
+      `
+    });
+
+    expect(result).toEqual({
+      data: {
+        user: {
+          id: '1',
+          address: {
+            street: '7 Windy Shore Rd',
+            city: 'Vancouver',
+            zipcode: '12345',
+          },
+        },
+      },
+    });
+  });
+});

--- a/packages/wrap/tests/transformWrapFields.test.ts
+++ b/packages/wrap/tests/transformWrapFields.test.ts
@@ -1,4 +1,4 @@
-import { graphql } from 'graphql';
+import { graphql, GraphQLObjectType } from 'graphql';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { wrapSchema, WrapFields } from '@graphql-tools/wrap';
 
@@ -39,8 +39,8 @@ describe('WrapFields', () => {
   });
 
   test('schema is transformed with new type and field', async () => {
-    const userType = schema.getType('User');
-    const addressType = schema.getType('Address');
+    const userType = schema.getType('User') as GraphQLObjectType;
+    const addressType = schema.getType('Address') as GraphQLObjectType;
 
     expect(userType.getFields().address).toBeDefined();
     expect(Object.keys(addressType.getFields()).sort()).toEqual([

--- a/website/docs/schema-wrapping.mdx
+++ b/website/docs/schema-wrapping.mdx
@@ -234,6 +234,7 @@ const schema = wrapSchema({
 
 It may be sometimes useful to add additional transforms to manually change an operation request or result when using `delegateToSchema`. Common use cases may be move selections around or to wrap them. The following built-in transforms may be useful in those cases.
 
+- `WrapFields('ParentType', ['scope'], ['ScopeType'], ['field1', 'field2', ...])` wraps a collection of fields on a parent type in one or more wrapping scopes with given namespaces and object types.
 - `ExtractField({ from: Array<string>, to: Array<string> })` move selection at `from` path to `to` path.
 - `WrapQuery(path: Array<string>, wrapper: QueryWrapper, extractor: (result: any) => any)` wrap a selection at `path` using function `wrapper`. Apply `extractor` at the same path to get the result. This is used to get a result nested inside other result.
 


### PR DESCRIPTION
## Description

Just came across `WrapFields` and was really amazed by how slick it is. This adds `wrap` package tests for it (both for coverage and to demonstrate its use, which I find extremely helpful with wrap transforms). Also adds a mention of it to the Schema Wrapping docs page for discoverability.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) ... test coverage + docs for discoverability.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules