### PR TITLE
fix(commentDescriptions): handle descriptions and comments correctly during merge

### DIFF
--- a/.changeset/brown-panthers-kneel.md
+++ b/.changeset/brown-panthers-kneel.md
@@ -1,0 +1,7 @@
+---
+'@graphql-tools/merge': patch
+'@graphql-tools/stitch': patch
+'@graphql-tools/utils': patch
+---
+
+fix(commentDescriptions): handle descriptions and comments correctly during merge

--- a/packages/merge/src/typedefs-mergers/merge-typedefs.ts
+++ b/packages/merge/src/typedefs-mergers/merge-typedefs.ts
@@ -103,7 +103,7 @@ export function mergeTypeDefs(typeSource: TypeSource, config?: Partial<Config>):
 
   let result: any;
 
-  if (config && config.commentDescriptions) {
+  if (config?.commentDescriptions) {
     result = printWithComments(doc);
   } else {
     result = doc;

--- a/packages/merge/tests/merge-typedefs.spec.ts
+++ b/packages/merge/tests/merge-typedefs.spec.ts
@@ -1357,5 +1357,49 @@ describe('Merge TypeDefs', () => {
 
       expect(mergeDirectives(directivesOne, directivesTwo, config)).toEqual(directivesTwo);
     });
+
+    it('should handle tripe quote comments in schema documents', () => {
+      const schemaWithTripleQuotes = gql`
+      type A {
+        """
+        This is a block quote that will fail on 6.2.15 and beyond
+        but will succeed on previous versions.
+        """
+        value: String!
+      }
+    `
+      const reformulatedGraphQL = gql`
+        ${mergeTypeDefs([schemaWithTripleQuotes], { commentDescriptions: true })}
+        `
+
+      expect(reformulatedGraphQL).toBeTruthy()
+    })
+
+    it('should handle single quote comments in schema documents', () => {
+      const schemaWithSingleQuote = gql`
+      type B {
+        "Single quote comment"
+        value: String!
+      }
+      `
+
+      const reformulatedGraphQL = gql`
+        ${mergeTypeDefs([schemaWithSingleQuote], { commentDescriptions: true })}
+      `
+      expect(reformulatedGraphQL).toBeTruthy()
+    })
+
+    it('should handle comment descriptions in schema documents', () => {
+    const schemaWithDescription = gql`
+      type C {
+        #This is a quote that will succed
+        value: String!
+      }
+    `
+    const reformulatedGraphQL = gql`
+      ${mergeTypeDefs([schemaWithDescription], { commentDescriptions: true })}
+    `
+    expect(reformulatedGraphQL).toBeTruthy()
+    })
   })
 });

--- a/packages/merge/tests/merge-typedefs.spec.ts
+++ b/packages/merge/tests/merge-typedefs.spec.ts
@@ -1,4 +1,5 @@
 import '../../testing/to-be-similar-gql-doc';
+import '../../testing/to-be-similar-string';
 import { mergeDirectives, mergeTypeDefs, mergeGraphQLTypes } from '../src';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { stitchSchemas } from '@graphql-tools/stitch'
@@ -660,15 +661,15 @@ describe('Merge TypeDefs', () => {
         'type Query { f2: String }',
       ]);
 
-      expect(stripWhitespaces(print(merged))).toBeSimilarGqlDoc(
+      expect(stripWhitespaces(print(merged))).toBeSimilarString(
         stripWhitespaces(/* GraphQL */`
+        schema {
+          query: Query
+        }
+
         type Query {
           f1: String
           f2: String
-        }
-
-        schema {
-          query: Query
         }`)
       );
     });
@@ -709,16 +710,16 @@ describe('Merge TypeDefs', () => {
         `,
       ]);
 
-      expect(stripWhitespaces(print(merged))).toBeSimilarGqlDoc(
+      expect(stripWhitespaces(print(merged))).toBeSimilarString(
         stripWhitespaces(/* GraphQL */`
+        schema {
+          query: Query
+        }
+
         type Query {
           f1: String
           f2: String
           f3: String
-        }
-
-        schema {
-          query: Query
         }`)
       );
     });
@@ -1358,48 +1359,46 @@ describe('Merge TypeDefs', () => {
       expect(mergeDirectives(directivesOne, directivesTwo, config)).toEqual(directivesTwo);
     });
 
-    it('should handle tripe quote comments in schema documents', () => {
-      const schemaWithTripleQuotes = gql`
+  })
+  it('should handle tripe quote comments in schema documents', () => {
+    const schemaWithTripleQuotes = /* GraphQL */`
+      """
+      Multi line description on a type
+      """
       type A {
         """
-        This is a block quote that will fail on 6.2.15 and beyond
-        but will succeed on previous versions.
+        Multi line description on a field
         """
         value: String!
       }
     `
-      const reformulatedGraphQL = gql`
-        ${mergeTypeDefs([schemaWithTripleQuotes], { commentDescriptions: true })}
-        `
+    const reformulatedGraphQL = mergeTypeDefs([schemaWithTripleQuotes], { commentDescriptions: true });
 
-      expect(reformulatedGraphQL).toBeTruthy()
-    })
+    expect(reformulatedGraphQL).toBeSimilarString(schemaWithTripleQuotes);
+  })
 
-    it('should handle single quote comments in schema documents', () => {
-      const schemaWithSingleQuote = gql`
+  it('should handle single quote comments in schema documents', () => {
+    const schemaWithSingleQuote = /* GraphQL */`
+      "Single line description on a type"
       type B {
-        "Single quote comment"
+        "Single line description on a field"
         value: String!
       }
       `
 
-      const reformulatedGraphQL = gql`
-        ${mergeTypeDefs([schemaWithSingleQuote], { commentDescriptions: true })}
-      `
-      expect(reformulatedGraphQL).toBeTruthy()
-    })
+    const reformulatedGraphQL = mergeTypeDefs([schemaWithSingleQuote], { commentDescriptions: true });
+    expect(reformulatedGraphQL).toBeSimilarString(schemaWithSingleQuote);
+  })
 
-    it('should handle comment descriptions in schema documents', () => {
-    const schemaWithDescription = gql`
+  it('should handle comment descriptions in schema documents', () => {
+    const schemaWithDescription = /* GraphQL */`
+      # Comment on a type
       type C {
-        #This is a quote that will succed
+        # Comment on a field
         value: String!
       }
     `
-    const reformulatedGraphQL = gql`
-      ${mergeTypeDefs([schemaWithDescription], { commentDescriptions: true })}
-    `
-    expect(reformulatedGraphQL).toBeTruthy()
-    })
+    const reformulatedGraphQL = mergeTypeDefs([schemaWithDescription], { commentDescriptions: true });
+    expect(reformulatedGraphQL).toBeSimilarString(schemaWithDescription);
   })
 });

--- a/packages/stitch/src/typeCandidates.ts
+++ b/packages/stitch/src/typeCandidates.ts
@@ -15,7 +15,14 @@ import {
 
 import { wrapSchema } from '@graphql-tools/wrap';
 import { Subschema, SubschemaConfig, StitchingInfo } from '@graphql-tools/delegate';
-import { GraphQLParseOptions, TypeSource, rewireTypes, getRootTypeMap, inspect } from '@graphql-tools/utils';
+import {
+  GraphQLParseOptions,
+  TypeSource,
+  rewireTypes,
+  getRootTypeMap,
+  inspect,
+  getRootTypes,
+} from '@graphql-tools/utils';
 
 import typeFromAST from './typeFromAST';
 import { MergeTypeCandidate, MergeTypeFilter, OnTypeConflict, TypeMergingOptions } from './types';
@@ -77,7 +84,7 @@ export function buildTypeCandidates<TContext = Record<string, any>>({
     const schema = wrapSchema(subschema);
 
     const rootTypeMap = getRootTypeMap(schema);
-    const rootTypes = Array.from(rootTypeMap.values());
+    const rootTypes = getRootTypes(schema);
 
     for (const [operation, rootType] of rootTypeMap.entries()) {
       addTypeCandidate(typeCandidates, rootTypeNameMap[operation], {
@@ -99,7 +106,7 @@ export function buildTypeCandidates<TContext = Record<string, any>>({
       if (
         isNamedType(type) &&
         getNamedType(type).name.slice(0, 2) !== '__' &&
-        !rootTypes.includes(type as GraphQLObjectType)
+        !rootTypes.has(type as GraphQLObjectType)
       ) {
         addTypeCandidate(typeCandidates, type.name, {
           type,

--- a/packages/stitch/src/typeFromAST.ts
+++ b/packages/stitch/src/typeFromAST.ts
@@ -1,5 +1,4 @@
 import {
-  DefinitionNode,
   EnumTypeDefinitionNode,
   FieldDefinitionNode,
   GraphQLEnumType,
@@ -27,13 +26,24 @@ import {
   EnumValueDefinitionNode,
   getDirectiveValues,
   GraphQLDeprecatedDirective,
+  TypeDefinitionNode,
 } from 'graphql';
 
 import { createStub, createNamedStub, Maybe, getDescription } from '@graphql-tools/utils';
 
 const backcompatOptions = { commentDescriptions: true };
 
-export default function typeFromAST(node: DefinitionNode): GraphQLNamedType | GraphQLDirective | null {
+export default typeFromAST;
+
+function typeFromAST(node: ObjectTypeDefinitionNode): GraphQLObjectType;
+function typeFromAST(node: InterfaceTypeDefinitionNode): GraphQLInterfaceType;
+function typeFromAST(node: EnumTypeDefinitionNode): GraphQLEnumType;
+function typeFromAST(node: UnionTypeDefinitionNode): GraphQLUnionType;
+function typeFromAST(node: ScalarTypeDefinitionNode): GraphQLScalarType;
+function typeFromAST(node: InputObjectTypeDefinitionNode): GraphQLInputObjectType;
+function typeFromAST(node: DirectiveDefinitionNode): GraphQLDirective;
+function typeFromAST(node: TypeDefinitionNode): GraphQLNamedType;
+function typeFromAST(node: TypeDefinitionNode | DirectiveDefinitionNode): GraphQLNamedType | GraphQLDirective | null {
   switch (node.kind) {
     case Kind.OBJECT_TYPE_DEFINITION:
       return makeObjectType(node);
@@ -69,9 +79,10 @@ function makeInterfaceType(node: InterfaceTypeDefinitionNode): GraphQLInterfaceT
   const config = {
     name: node.name.value,
     description: getDescription(node, backcompatOptions),
-    interfaces: (node as unknown as ObjectTypeDefinitionNode).interfaces?.map(iface =>
-      createNamedStub(iface.name.value, 'interface')
-    ),
+    interfaces: () =>
+      (node as unknown as ObjectTypeDefinitionNode).interfaces?.map(iface =>
+        createNamedStub(iface.name.value, 'interface')
+      ),
     fields: () => (node.fields != null ? makeFields(node.fields) : {}),
     astNode: node,
   };


### PR DESCRIPTION
## Description

This pull request adds tests the demonstrates the problem merging typedefs with comments in them. 

**Note: This does not fix the issue** and should not be merged, this is just a reproduction.

Related #3244

## Type of change
Reproduction only

**Test Environment**:
- OS: Linux
- `@graphql-tools/...`: master branch
- NodeJS: v14.17.5

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules