### PR TITLE
test: check if key field _id is resolved correctly

### DIFF
--- a/.changeset/six-radios-talk.md
+++ b/.changeset/six-radios-talk.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/mock': patch
+---
+
+fix(mock): fix handling \_id field name

--- a/packages/mock/src/MockStore.ts
+++ b/packages/mock/src/MockStore.ts
@@ -39,6 +39,8 @@ export const defaultMocks = {
   ID: () => uuidv4(),
 };
 
+const defaultKeyFieldNames = ['id', '_id'];
+
 type Entity = {
   [key: string]: unknown;
 };
@@ -555,11 +557,14 @@ export class MockStore implements IMockStore {
       return typePolicyKeyField;
     }
 
-    const gqlType = this.getType(typeName);
-    const fieldNames = Object.keys(gqlType.getFields());
+    // How about common key field names?
 
-    if (fieldNames.includes('id')) return 'id';
-    if (fieldNames.includes('_id')) return '+id';
+    const gqlType = this.getType(typeName);
+    for (const fieldName in gqlType.getFields()) {
+      if (defaultKeyFieldNames.includes(fieldName)) {
+        return fieldName;
+      }
+    }
 
     return null;
   }

--- a/packages/mock/tests/addMocksToSchema.spec.ts
+++ b/packages/mock/tests/addMocksToSchema.spec.ts
@@ -10,6 +10,12 @@ type User {
   book: Book!
 }
 
+type Author {
+  _id: ID!
+  name: String!
+  book: Book!
+}
+
 union UserImage = UserImageSolidColor | UserImageURL
 
 type UserImageSolidColor {
@@ -45,6 +51,7 @@ type ColoringBook implements Book {
 type Query {
   viewer: User!
   userById(id: ID!): User!
+  author: Author!
 }
 
 type Mutation {
@@ -87,6 +94,38 @@ describe('addMocksToSchema', () => {
     const viewerData2 = data2?.['viewer'] as any;
 
     expect(viewerData2['id']).toEqual(viewerData['id']);
+  });
+
+  it('handle _id key field', async () => {
+    const query = /* GraphQL */`
+      query {
+        author {
+          _id
+          name
+        }
+      }
+      `;
+    const mockedSchema = addMocksToSchema({ schema });
+    const { data, errors } = await graphql({
+      schema: mockedSchema,
+      source: query,
+    });
+
+
+    expect(errors).not.toBeDefined();
+    expect(data).toBeDefined();
+    const viewerData = data?.['author'] as any;
+    expect(typeof viewerData['_id']).toBe('string')
+    expect(typeof viewerData['name']).toBe('string')
+
+    const { data: data2 } = await graphql({
+      schema: mockedSchema,
+      source: query,
+    });
+
+    const viewerData2 = data2?.['author'] as any;
+
+    expect(viewerData2['_id']).toEqual(viewerData['_id']);
   });
 
   it('mutations resolver', async () => {


### PR DESCRIPTION

## Description

This pull request adds tests the demonstrates the problem using _id fields in schema which is being mocked.

Related #3464

## Type of change

A test demonstrating an issue with _id fields in schema being mocked.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
