### PR TITLE
Wrap: tests for TransformCompositeFields

### DIFF
--- a/packages/wrap/tests/transformTransformCompositeFields.test.ts
+++ b/packages/wrap/tests/transformTransformCompositeFields.test.ts
@@ -71,13 +71,13 @@ describe('TransformCompositeFields', () => {
   });
 
   test('transforms each data object with mapping', async () => {
-    const dataObjects = [];
+    const dataObjects: Array<String> = [];
     const transformedSchema = wrapSchema({
       schema: baseSchema,
       transforms: [
         new TransformCompositeFields(
           (_typeName, _fieldName, fieldConfig) => fieldConfig,
-          null,
+          undefined,
           (obj) => {
             dataObjects.push(obj.__typename);
             if (obj._id) obj._id = obj._id.toUpperCase();

--- a/packages/wrap/tests/transformTransformCompositeFields.test.ts
+++ b/packages/wrap/tests/transformTransformCompositeFields.test.ts
@@ -71,7 +71,7 @@ describe('TransformCompositeFields', () => {
   });
 
   test('transforms each data object with mapping', async () => {
-    const dataObjects: Array<String> = [];
+    const dataObjects: Array<string> = [];
     const transformedSchema = wrapSchema({
       schema: baseSchema,
       transforms: [

--- a/packages/wrap/tests/transformTransformCompositeFields.test.ts
+++ b/packages/wrap/tests/transformTransformCompositeFields.test.ts
@@ -1,6 +1,6 @@
 import { wrapSchema, TransformCompositeFields } from '@graphql-tools/wrap';
 import { makeExecutableSchema } from '@graphql-tools/schema';
-import { execute, parse, printSchema } from 'graphql';
+import { execute, parse } from 'graphql';
 
 const baseSchema = makeExecutableSchema({
   typeDefs: /* GraphQL */`

--- a/packages/wrap/tests/transformTransformCompositeFields.test.ts
+++ b/packages/wrap/tests/transformTransformCompositeFields.test.ts
@@ -1,0 +1,99 @@
+import { wrapSchema, TransformCompositeFields } from '@graphql-tools/wrap';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { execute, parse, printSchema } from 'graphql';
+
+const baseSchema = makeExecutableSchema({
+  typeDefs: /* GraphQL */`
+    type Product {
+      _id: ID!
+    }
+
+    type Query {
+      product: Product
+    }
+  `,
+  resolvers: {
+    Query: {
+      product: () => ({ _id: 'r2d2c3p0' }),
+    }
+  }
+});
+
+describe('TransformCompositeFields', () => {
+  test('renames and translates field selections', async () => {
+    const transformedSchema = wrapSchema({
+      schema: baseSchema,
+      transforms: [
+        new TransformCompositeFields(
+          (typeName, _fieldName, fieldConfig) => {
+            return typeName === 'Product' ? ['id', fieldConfig] : fieldConfig;
+          }
+        )
+      ],
+    });
+
+    const result = await execute({
+      schema: transformedSchema,
+      document: parse('{ product { id, theId: id } }'),
+    });
+    expect(result.data).toEqual({
+      product: { id: 'r2d2c3p0', theId: 'r2d2c3p0' }
+    });
+  });
+
+  test('translates field values with custom resolver', async () => {
+    const transformedSchema = wrapSchema({
+      schema: baseSchema,
+      transforms: [
+        new TransformCompositeFields(
+          (typeName, _fieldName, fieldConfig) => {
+            if (typeName === 'Product') {
+              return ['id', {
+                ...fieldConfig,
+                resolve: (parent, _args, _context, info) => {
+                  return parent[info.path.key].toUpperCase();
+                }
+              }];
+            }
+            return fieldConfig;
+          }
+        )
+      ],
+    });
+
+    const result = await execute({
+      schema: transformedSchema,
+      document: parse('{ product { theId: id } }'),
+    });
+    expect(result.data).toEqual({
+      product: { theId: 'R2D2C3P0' }
+    });
+  });
+
+  test('transforms each data object with mapping', async () => {
+    const dataObjects = [];
+    const transformedSchema = wrapSchema({
+      schema: baseSchema,
+      transforms: [
+        new TransformCompositeFields(
+          (_typeName, _fieldName, fieldConfig) => fieldConfig,
+          null,
+          (obj) => {
+            dataObjects.push(obj.__typename);
+            if (obj._id) obj._id = obj._id.toUpperCase();
+            return obj;
+          }
+        )
+      ],
+    });
+
+    const result = await execute({
+      schema: transformedSchema,
+      document: parse('{ product { _id } }'),
+    });
+    expect(dataObjects).toEqual(['Query', 'Product']);
+    expect(result.data).toEqual({
+      product: { _id: 'R2D2C3P0' }
+    });
+  });
+});


### PR DESCRIPTION
Adds a preliminary test suite for `TransformCompositeFields`. I'm slowly filling in tests while exploring various transforms. Hopefully tests offer coverage and help document capabilities for others seeking reference within the documentation wasteland of the `wrap` package.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
