### PR TITLE
fix(graphql-tag-pluck): fix ESM usage

### DIFF
--- a/.changeset/forty-cooks-learn.md
+++ b/.changeset/forty-cooks-learn.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/graphql-tag-pluck': patch
+---
+
+fix ESM usage

--- a/packages/graphql-tag-pluck/src/index.ts
+++ b/packages/graphql-tag-pluck/src/index.ts
@@ -2,9 +2,15 @@ import generateConfig from './config';
 import { parse } from '@babel/parser';
 import { getExtNameFromFilePath } from './libs/extname';
 import createVisitor, { PluckedContent } from './visitor';
-import traverse from '@babel/traverse';
+import traversePkg from '@babel/traverse';
 import { freeText } from './utils';
 import { Source } from 'graphql';
+
+function getDefault<T>(module: T & { default?: T }): T {
+  return module.default || module;
+}
+
+const traverse = getDefault(traversePkg);
 
 /**
  * Additional options for determining how a file is parsed.


### PR DESCRIPTION
closes #3515 

tested the changes locally and everything works flawlessly with these changes

<img width="435" alt="Screenshot at Sep 12 01-19-23" src="https://user-images.githubusercontent.com/8672915/132972059-5e84e9bb-ddef-4a6a-9a02-9aebf3e60345.png">
