### PR TITLE
Including transitive dependencies in multi-level schema definition imports

### DIFF
--- a/packages/import/tests/schema/fixtures/multiple-levels/level1.graphql
+++ b/packages/import/tests/schema/fixtures/multiple-levels/level1.graphql
@@ -1,0 +1,5 @@
+# import User from './level2.graphql'
+
+type Query {
+    user: User
+}

--- a/packages/import/tests/schema/fixtures/multiple-levels/level2.graphql
+++ b/packages/import/tests/schema/fixtures/multiple-levels/level2.graphql
@@ -1,0 +1,5 @@
+# import Account from "./level3.graphql"
+
+type User {
+    account: Account
+}

--- a/packages/import/tests/schema/fixtures/multiple-levels/level3.graphql
+++ b/packages/import/tests/schema/fixtures/multiple-levels/level3.graphql
@@ -1,0 +1,11 @@
+# import * from "./level4.graphql"
+
+type Cart {
+    total: Int
+    products: Products
+}
+
+type Account {
+    id: ID
+    cart: Cart
+}

--- a/packages/import/tests/schema/fixtures/multiple-levels/level4.graphql
+++ b/packages/import/tests/schema/fixtures/multiple-levels/level4.graphql
@@ -1,0 +1,7 @@
+type Product {
+    price: Int
+}
+
+type Products {
+    items: [Product]
+}

--- a/packages/import/tests/schema/import-schema.spec.ts
+++ b/packages/import/tests/schema/import-schema.spec.ts
@@ -918,6 +918,37 @@ describe('importSchema', () => {
     expect(importSchema('fixtures/multiple-imports/schema.graphql')).toBeSimilarGqlDoc(expectedSDL);
   });
 
+  test('imports multiple imports at least 3 levels deep with transitive dependencies', () => {
+    const expectedSDL = /* GraphQL */`
+        type Product {
+            price: Int
+        }
+
+        type Products {
+            items: [Product]
+        }
+
+        type Account {
+            id: ID
+            cart: Cart
+        }
+
+        type Cart {
+            total: Int
+            products: Products
+        }
+
+        type Query {
+            user: User
+        }
+
+        type User {
+            account: Account
+        }
+    `;
+    expect(importSchema('fixtures/multiple-levels/level1.graphql')).toBeSimilarGqlDoc(expectedSDL);
+  });
+
   test('imports multi-level types without direct references', () => {
     const expectedSDL = /* GraphQL */`\
   type Level1 {


### PR DESCRIPTION
## Description

If an imported type has a field referencing a different type in the same schema definition which isn't being imported, then the dependency hierarchy could only partially form. 

Prior to including potential required transitive dependencies, the test case provided would include the following:

`Query`, `User`, `Account`, `Cart`

Since `Cart` wasn't included in the import definitions list, all if it's required dependencies were being dropped (`Products`, `Product`). This change ensures that all dependencies not explicitly included but still required can be included in building out the full dependency structure.

(For confirmation of this problem, if one includes `Cart` in level2.graphql the test case will begin passing.)

Related #3327, #3328

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Tested below in the provided test case `imports multiple imports at least 3 levels deep with transitive dependencies`

**Test Environment**:
- OS: macOS Big Sur 11.6
- NodeJS: v14.17.6

## Checklist:

- [X] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests and linter rules pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

