### PR TITLE
Add MockStore.has method

### DIFF
--- a/.changeset/three-colts-film.md
+++ b/.changeset/three-colts-film.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/mock': minor
+---
+
+feat(mock): add has method to MockStore

--- a/packages/mock/src/MockStore.ts
+++ b/packages/mock/src/MockStore.ts
@@ -70,6 +70,10 @@ export class MockStore implements IMockStore {
     this.typePolicies = typePolicies || {};
   }
 
+  has<KeyT extends KeyTypeConstraints = string>(typeName: string, key: KeyT): boolean {
+    return !!this.store[typeName] && !!this.store[typeName][key];
+  }
+
   get<KeyT extends KeyTypeConstraints = string, ReturnKeyT extends KeyTypeConstraints = string>(
     _typeName: string | Ref<KeyT> | GetArgs<KeyT>,
     _key?: KeyT | { [fieldName: string]: any } | string | string[],

--- a/packages/mock/src/types.ts
+++ b/packages/mock/src/types.ts
@@ -178,6 +178,11 @@ export interface IMockStore {
   set<KeyT extends KeyTypeConstraints = string>(ref: Ref<KeyT>, values: { [fieldName: string]: any }): void;
 
   /**
+   * Checks if a mock is present in the store for the given typeName and key.
+   */
+  has<KeyT extends KeyTypeConstraints = string>(typeName: string, key: KeyT): boolean;
+
+  /**
    * Resets the mock store
    */
   reset(): void;

--- a/packages/mock/tests/store.spec.ts
+++ b/packages/mock/tests/store.spec.ts
@@ -383,6 +383,62 @@ describe('MockStore', () => {
     expect(typeof user.$ref.key).toBe('number');
   });
 
+  describe('has method', () => {
+    it('should return true if a mocked value has been generated via get', () => {
+      const store = createMockStore({ schema });
+
+      expect(store.has('User', 'user-1')).toBe(false);
+
+      store.get('User', 'user-1', {
+        name: 'User 1',
+      });
+
+      expect(store.has('User', 'user-1')).toBe(true);
+    })
+
+    it('should return true if a mocked value was generated using nested get', () => {
+      const store = createMockStore({ schema });
+
+      expect(store.has('UserImageURL', 'user-image-1')).toBe(false);
+
+      store.get('User', 'user-1', {
+        image: {
+          __typename: 'UserImageURL',
+          id: 'user-image-1',
+        },
+      });
+
+      expect(store.has('UserImageURL', 'user-image-1')).toBe(true);
+    })
+
+    it('should return true if a mocked value has been set', () => {
+      const store = createMockStore({ schema });
+
+      expect(store.has('User', 'user-1')).toBe(false);
+
+      store.set('User', 'user-1', {
+        name: 'User 1',
+      });
+
+      expect(store.has('User', 'user-1')).toBe(true);
+    })
+
+    it('should return true if a mocked value was generated using nested set', () => {
+      const store = createMockStore({ schema });
+
+      expect(store.has('UserImageURL', 'user-image-1')).toBe(false);
+
+      store.set('User', 'user-1', {
+        image: {
+          __typename: 'UserImageURL',
+          id: 'user-image-1',
+        },
+      });
+
+      expect(store.has('UserImageURL', 'user-image-1')).toBe(true);
+    })
+  });
+
   describe('default values', () => {
     it('should be inserted when called with no key', () => {
       const store = createMockStore({ schema });


### PR DESCRIPTION
## Description

This change adds `has(typename: string, key: KeyT) => boolean` to MockStore to allow checking if data for a given key has previously been generated in the store.

Addresses #3479 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

## How Has This Been Tested?

Tests have been provided in packages/mock/tests/store.spec.ts

**Test Environment**:
- OS: MacOS 10.14.6
- NodeJS: 14.17.5

## Checklist:

- [X] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests and linter rules pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules is