### PR TITLE
Fixing visitData to prevent assingning read only properties

### DIFF
--- a/.changeset/tender-schools-bathe.md
+++ b/.changeset/tender-schools-bathe.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/utils': patch
+---
+
+fix(utils): Avoid processing read-only properties on visitData method

--- a/packages/utils/src/visitResult.ts
+++ b/packages/utils/src/visitResult.ts
@@ -58,8 +58,7 @@ export function visitData(data: any, enter?: ValueVisitor, leave?: ValueVisitor)
     const newData = enter != null ? enter(data) : data;
 
     if (newData != null) {
-      for (const key in newData) {
-        if (!Object.getOwnPropertyDescriptor(newData, key)?.writable) continue;
+      for (const key in Object.getOwnPropertySymbols(newData)) {
         const value = newData[key];
         newData[key] = visitData(value, enter, leave);
       }

--- a/packages/utils/src/visitResult.ts
+++ b/packages/utils/src/visitResult.ts
@@ -59,6 +59,7 @@ export function visitData(data: any, enter?: ValueVisitor, leave?: ValueVisitor)
 
     if (newData != null) {
       for (const key in newData) {
+        if (!Object.getOwnPropertyDescriptor(newData, key)?.set) continue;
         const value = newData[key];
         newData[key] = visitData(value, enter, leave);
       }

--- a/packages/utils/src/visitResult.ts
+++ b/packages/utils/src/visitResult.ts
@@ -58,9 +58,11 @@ export function visitData(data: any, enter?: ValueVisitor, leave?: ValueVisitor)
     const newData = enter != null ? enter(data) : data;
 
     if (newData != null) {
-      for (const key in Object.getOwnPropertySymbols(newData)) {
+      for (const key in newData) {
         const value = newData[key];
-        newData[key] = visitData(value, enter, leave);
+        Object.defineProperty(newData, key, {
+          value: visitData(value, enter, leave),
+        });
       }
     }
 

--- a/packages/utils/src/visitResult.ts
+++ b/packages/utils/src/visitResult.ts
@@ -59,7 +59,7 @@ export function visitData(data: any, enter?: ValueVisitor, leave?: ValueVisitor)
 
     if (newData != null) {
       for (const key in newData) {
-        if (!Object.getOwnPropertyDescriptor(newData, key)?.set) continue;
+        if (!Object.getOwnPropertyDescriptor(newData, key)?.writable) continue;
         const value = newData[key];
         newData[key] = visitData(value, enter, leave);
       }

--- a/packages/utils/tests/visitResult.test.ts
+++ b/packages/utils/tests/visitResult.test.ts
@@ -4,7 +4,7 @@ import { ExecutionResult } from '@graphql-tools/utils';
 
 import { relocatedError } from '../src/errors';
 
-import { visitResult } from '../src/visitResult';
+import { visitData, visitResult } from '../src/visitResult';
 
 describe('visiting results', () => {
   const schema = buildSchema(/* GraphQL */`
@@ -402,5 +402,15 @@ describe('visiting errors', () => {
     });
 
     expect(visitedResult.errors[1].path).toEqual(['test', 'inserted', 'field']);
+  });
+});
+describe('visiting data', () => {
+  it('should work when the parent contains properties with getters only', async () => {
+    const result = {
+      data: Buffer.from("Test"),
+    };
+
+    const visitedResult = visitData(result);
+    expect(visitedResult).toEqual(result);
   });
 });


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

## Description

`visitData` method fails to visit objects containing read-only properties (getters). Updated the for loop to avoid processing the read-only properties.

Related #3554 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

```js
describe('visiting data', () => {
  it('should work when the parent contains properties with getters only', async () => {
    const result = {
      data: Buffer.from("Test"),
    };

    const visitedResult = visitData(result);
    expect(visitedResult).toEqual(result);
  });
});
```

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added a test that visits a Buffer that contains several read-only properties

**Test Environment**:
- OS: MacOS BigSur 11.5.2
- `@graphql-tools/utils`:
- NodeJS: 14.16.1

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

