### PR TITLE
loadSchema no longer accept options.schemas

### DIFF
--- a/.changeset/great-owls-prove.md
+++ b/.changeset/great-owls-prove.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/load': patch
+---
+
+Fix loadSchema no longer accepting options.schemas

--- a/packages/load/src/schema.ts
+++ b/packages/load/src/schema.ts
@@ -39,7 +39,7 @@ export async function loadSchema(
   const { schemas, typeDefs } = collectSchemasAndTypeDefs(sources);
   const mergeSchemasOptions: MergeSchemasConfig = {
     ...options,
-    schemas,
+    schemas: schemas.concat(options.schemas ?? []),
     typeDefs,
   };
 

--- a/packages/load/tests/loaders/schema/integration.spec.ts
+++ b/packages/load/tests/loaders/schema/integration.spec.ts
@@ -1,7 +1,7 @@
 import { loadSchema, loadSchemaSync } from '@graphql-tools/load';
 import { CodeFileLoader } from '@graphql-tools/code-file-loader';
 import { GraphQLFileLoader } from '@graphql-tools/graphql-file-loader';
-import { printSchema } from 'graphql';
+import { printSchema, buildSchema } from 'graphql';
 import { runTests, useMonorepo } from '../../../../testing/utils';
 import '../../../../testing/to-be-similar-gql-doc';
 
@@ -96,6 +96,34 @@ describe('loadSchema', () => {
           aa: String
         }
       `);
-    })
+    });
+
+    test('should add schemas from options.schemas to generated schema', async () => {
+      const schemaPath = './tests/loaders/schema/test-files/schema-dir/non-sorted.graphql';
+      const schema = await load(schemaPath, {
+        loaders: [new GraphQLFileLoader()],
+        sort: true,
+        schemas: [buildSchema(`scalar DateTime`)]
+      });
+      expect(printSchema(schema)).toBeSimilarGqlDoc(/* GraphQL */`
+        scalar DateTime
+
+        type A {
+          b: String
+          s: String
+        }
+
+        type Query {
+          a: String
+          d: String
+          z: String
+        }
+
+        type User {
+          a: String
+          aa: String
+        }
+      `);
+    });
 })
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "incremental": true,
+    "incremental": false,
 
     "outDir": "dist",
     "baseUrl": ".",
@@ -30,9 +30,7 @@
     "paths": {
       "@graphql-tools/*-loader": ["packages/loaders/*/src/index.ts", "packages/*-loader/src/index.ts"],
       "@graphql-tools/*": ["packages/*/src/index.ts"]
-    },
-
-    "tsBuildInfoFile": "./node_modules/tsconfig.tsbuildinfo"
+    }
   },
   "include": ["packages"],
   "exclude": ["**/node_modules", "**/dist", "**/test-files"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "incremental": false,
+    "incremental": true,
 
     "outDir": "dist",
     "baseUrl": ".",


### PR DESCRIPTION
It breaks GraphQL Inspector 

```typescript
const schema = await load('...', {
  loaders: [...],
  schemas: [
    buildSchema(`scalar DateTime`)
  ]
});
```

https://github.com/kamilkisiela/graphql-inspector/blob/03c49eaef0d6634e5222ee255990293a6ce355a5/packages/loaders/loaders/src/index.ts#L47-L55