### PR TITLE
test

### DIFF
--- a/packages/stitch/src/stitchingInfo.ts
+++ b/packages/stitch/src/stitchingInfo.ts
@@ -15,6 +15,8 @@ import {
   GraphQLNamedType,
 } from 'graphql';
 
+import { ValueOrPromise } from 'value-or-promise';
+
 import { collectFields, parseSelectionSet, IResolvers, IFieldResolverOptions, isSome } from '@graphql-tools/utils';
 
 import { MergedTypeResolver, Subschema, SubschemaConfig, MergedTypeInfo, StitchingInfo } from '@graphql-tools/delegate';
@@ -119,8 +121,9 @@ function createMergedTypes<TContext = Record<string, any>>(
             subschema,
             keyFn
               ? (originalResult, context, info, subschema, selectionSet) => {
-                  const key = keyFn(originalResult);
-                  return resolver(originalResult, context, info, subschema, selectionSet, key);
+                  return new ValueOrPromise(() => keyFn(originalResult))
+                    .then(key => resolver(originalResult, context, info, subschema, selectionSet, key))
+                    .resolve();
                 }
               : resolver
           );

--- a/packages/stitching-directives/tests/properties.test.ts
+++ b/packages/stitching-directives/tests/properties.test.ts
@@ -1,4 +1,4 @@
-import { addProperty, getProperties } from "../src/properties";
+import { addProperty, getProperties, getResolvedPropertiesOrPromise } from "../src/properties";
 
 describe('addProperty', () => {
   test('can add a key to an object', () => {
@@ -29,7 +29,7 @@ describe('addProperty', () => {
 });
 
 describe('getProperties', () => {
-  test('can getProperties', () => {
+  test('can getProperties', async () => {
     const object = {
       field1: 'value1',
       field2: {
@@ -43,7 +43,35 @@ describe('getProperties', () => {
       field2: {
         subfieldA: null,
       }
-    })
+    });
+
+    const expectedExtracted = {
+      field1: 'value1',
+      field2: {
+        subfieldA: 'valueA',
+      }
+    }
+
+    expect(extracted).toEqual(expectedExtracted);
+  });
+});
+
+describe('getResolvedPropertiesOrPromise', () => {
+  test('can getResolvedPropertiesOrPromise', async () => {
+    const object = {
+      field1: 'value1',
+      field2: Promise.resolve({
+        subfieldA: 'valueA',
+        subfieldB: 'valueB',
+      }),
+    }
+
+    const extracted = await getResolvedPropertiesOrPromise(object, {
+      field1: null,
+      field2: {
+        subfieldA: null,
+      }
+    }).resolve();
 
     const expectedExtracted = {
       field1: 'value1',


### PR DESCRIPTION
these changes allow key and args functions to return promises, which may be helpful if ExternalObject access were to be managed by a store -- in which case the store could be updated even after initial result returned from original schema either with additional incremental delivery results or with results from other schemas.