### PR TITLE
fix(import): allow import nested fragments properly

### DIFF
--- a/.changeset/lovely-guests-join.md
+++ b/.changeset/lovely-guests-join.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/import': minor
+---
+
+fix(import): allow import nested fragments

--- a/packages/import/tests/documents/import-documents.spec.ts
+++ b/packages/import/tests/documents/import-documents.spec.ts
@@ -62,4 +62,41 @@ describe('import in documents', () => {
         "import-test/default/c.graphql"
       ]);
     })
+
+  it('should import fragment with nested fragments', () => {
+    const document = importDocuments('./import-test/default/d.gql');
+
+    expect(document).toBeSimilarGqlDoc(/* GraphQL */ `
+      query User {
+        user {
+          ...UserFields
+        }
+      }
+
+      fragment UserFields on User {
+        ...AnotherUserFields
+        posts {
+          ...PostFields
+        }
+      }
+
+      fragment AnotherUserFields on User {
+        firstName
+      }
+
+      fragment PostFields on Post {
+        title
+        ...AnotherPostFields
+      }
+
+      fragment AnotherPostFields on Post {
+        content
+        ...YetAnotherPostFields
+      }
+
+      fragment YetAnotherPostFields on Post {
+        content
+      }
+    `);
+  });
 });

--- a/packages/import/tests/documents/import-test/default/d.gql
+++ b/packages/import/tests/documents/import-test/default/d.gql
@@ -1,0 +1,7 @@
+#import 'with-nested-fragment.gql'
+
+query User {
+    user {
+        ...UserFields
+    }
+}

--- a/packages/import/tests/documents/import-test/default/with-nested-fragment.gql
+++ b/packages/import/tests/documents/import-test/default/with-nested-fragment.gql
@@ -1,0 +1,30 @@
+fragment UserFields on User {
+    ...AnotherUserFields
+    posts {
+        ...PostFields
+    }
+}
+
+fragment AnotherUserFields on User {
+    firstName
+}
+
+fragment PostFields on Post {
+    title
+    ...AnotherPostFields
+}
+
+fragment AnotherPostFields on Post {
+    content
+    ...YetAnotherPostFields
+}
+
+fragment YetAnotherPostFields on Post {
+    content
+}
+
+# Next fragment should be not imported when default import is used
+fragment IgnoredPostFields on Post {
+    content
+    title
+}


### PR DESCRIPTION
related https://github.com/dotansimha/graphql-eslint/issues/654

It seems like a bug but `AnotherPostFields` is never imported even he is used in `PostFields` fragment that is used in `UserFields` fragment