### PR TITLE
Refactor processImport from @graphql-tools/import

### DIFF
--- a/.changeset/healthy-penguins-learn.md
+++ b/.changeset/healthy-penguins-learn.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/import': minor
+---
+
+Refactor processImport and export helper functions for parsing GraphQL imports

--- a/packages/import/src/index.ts
+++ b/packages/import/src/index.ts
@@ -70,14 +70,12 @@ export function processImport(
   const set = visitFile(filePath, join(cwd + '/root.graphql'), visitedFiles, predefinedImports);
   const definitionStrSet = new Set<string>();
   let definitionsStr = '';
-  if (set != null) {
-    for (const defs of set.values()) {
-      for (const def of defs) {
-        const defStr = print(def);
-        if (!definitionStrSet.has(defStr)) {
-          definitionStrSet.add(defStr);
-          definitionsStr += defStr + '\n';
-        }
+  for (const defs of set.values()) {
+    for (const def of defs) {
+      const defStr = print(def);
+      if (!definitionStrSet.has(defStr)) {
+        definitionStrSet.add(defStr);
+        definitionsStr += defStr + '\n';
       }
     }
   }
@@ -95,193 +93,28 @@ function visitFile(
   cwd: string,
   visitedFiles: VisitedFilesMap,
   predefinedImports: Record<string, string>
-) {
+): Map<string, Set<DefinitionNode>> {
   if (!isAbsolute(filePath) && !(filePath in predefinedImports)) {
     filePath = resolveFilePath(cwd, filePath);
   }
   if (!visitedFiles.has(filePath)) {
     const fileContent = filePath in predefinedImports ? predefinedImports[filePath] : readFileSync(filePath, 'utf8');
-    const importLines: string[] = [];
-    let otherLines = '';
-    for (const line of fileContent.split('\n')) {
-      const trimmedLine = line.trim();
-      if (trimmedLine.startsWith('#import ') || trimmedLine.startsWith('# import ')) {
-        importLines.push(trimmedLine);
-      } else if (trimmedLine) {
-        otherLines += line + '\n';
-      }
-    }
-    const definitionsByName = new Map<string, Set<DefinitionNode>>();
-    const dependenciesByDefinitionName = new Map<string, Set<string>>();
-    if (otherLines) {
-      const fileDefinitionMap = new Map<string, Set<DefinitionNode>>();
-      // To prevent circular dependency
-      visitedFiles.set(filePath, fileDefinitionMap);
-      const document = parse(new Source(otherLines, filePath), {
-        noLocation: true,
-      });
-      for (const definition of document.definitions) {
-        if ('name' in definition || definition.kind === Kind.SCHEMA_DEFINITION) {
-          const definitionName = 'name' in definition && definition.name ? definition.name.value : 'schema';
-          if (!definitionsByName.has(definitionName)) {
-            definitionsByName.set(definitionName, new Set());
-          }
-          const definitionsSet = definitionsByName.get(definitionName);
-          definitionsSet?.add(definition);
 
-          let dependencySet = dependenciesByDefinitionName.get(definitionName);
-          if (!dependencySet) {
-            dependencySet = new Set();
-            dependenciesByDefinitionName.set(definitionName, dependencySet);
-          }
-          switch (definition.kind) {
-            case Kind.OPERATION_DEFINITION:
-              visitOperationDefinitionNode(definition, dependencySet);
-              break;
-            case Kind.FRAGMENT_DEFINITION:
-              visitFragmentDefinitionNode(definition, dependencySet);
-              break;
-            case Kind.OBJECT_TYPE_DEFINITION:
-              visitObjectTypeDefinitionNode(definition, dependencySet, dependenciesByDefinitionName);
-              break;
-            case Kind.INTERFACE_TYPE_DEFINITION:
-              visitInterfaceTypeDefinitionNode(definition, dependencySet, dependenciesByDefinitionName);
-              break;
-            case Kind.UNION_TYPE_DEFINITION:
-              visitUnionTypeDefinitionNode(definition, dependencySet);
-              break;
-            case Kind.ENUM_TYPE_DEFINITION:
-              visitEnumTypeDefinitionNode(definition, dependencySet);
-              break;
-            case Kind.INPUT_OBJECT_TYPE_DEFINITION:
-              visitInputObjectTypeDefinitionNode(definition, dependencySet, dependenciesByDefinitionName);
-              break;
-            case Kind.DIRECTIVE_DEFINITION:
-              visitDirectiveDefinitionNode(definition, dependencySet, dependenciesByDefinitionName);
-              break;
-            case Kind.SCALAR_TYPE_DEFINITION:
-              visitScalarDefinitionNode(definition, dependencySet);
-              break;
-            case Kind.SCHEMA_DEFINITION:
-              visitSchemaDefinitionNode(definition, dependencySet);
-              break;
-            case Kind.OBJECT_TYPE_EXTENSION:
-              visitObjectTypeExtensionNode(definition, dependencySet, dependenciesByDefinitionName);
-              break;
-            case Kind.INTERFACE_TYPE_EXTENSION:
-              visitInterfaceTypeExtensionNode(definition, dependencySet, dependenciesByDefinitionName);
-              break;
-            case Kind.UNION_TYPE_EXTENSION:
-              visitUnionTypeExtensionNode(definition, dependencySet);
-              break;
-            case Kind.ENUM_TYPE_EXTENSION:
-              visitEnumTypeExtensionNode(definition, dependencySet);
-              break;
-            case Kind.INPUT_OBJECT_TYPE_EXTENSION:
-              visitInputObjectTypeExtensionNode(definition, dependencySet, dependenciesByDefinitionName);
-              break;
-            case Kind.SCALAR_TYPE_EXTENSION:
-              visitScalarExtensionNode(definition, dependencySet);
-              break;
-          }
-          if ('fields' in definition && definition.fields) {
-            for (const field of definition.fields) {
-              const definitionName = definition.name.value + '.' + field.name.value;
-              if (!definitionsByName.has(definitionName)) {
-                definitionsByName.set(definitionName, new Set());
-              }
-              definitionsByName.get(definitionName)?.add({
-                ...definition,
-                fields: [field as any],
-              });
+    const { importLines, otherLines } = splitFile(fileContent);
 
-              let dependencySet = dependenciesByDefinitionName.get(definitionName);
-              if (!dependencySet) {
-                dependencySet = new Set();
-                dependenciesByDefinitionName.set(definitionName, dependencySet);
-              }
-              switch (field.kind) {
-                case Kind.FIELD_DEFINITION:
-                  visitFieldDefinitionNode(field, dependencySet, dependenciesByDefinitionName);
-                  break;
-                case Kind.INPUT_VALUE_DEFINITION:
-                  visitInputValueDefinitionNode(field, dependencySet, dependenciesByDefinitionName);
-                  break;
-              }
-            }
-          }
-        }
-      }
-      for (const [definitionName, definitions] of definitionsByName) {
-        let definitionsWithDependencies = fileDefinitionMap.get(definitionName);
-        if (definitionsWithDependencies == null) {
-          definitionsWithDependencies = new Set();
-          fileDefinitionMap.set(definitionName, definitionsWithDependencies);
-        }
-        for (const definition of definitions) {
-          definitionsWithDependencies.add(definition);
-        }
-        const dependenciesOfDefinition = dependenciesByDefinitionName.get(definitionName);
-        if (dependenciesOfDefinition) {
-          for (const dependencyName of dependenciesOfDefinition) {
-            const dependencyDefinitions = definitionsByName.get(dependencyName);
-            if (dependencyDefinitions != null) {
-              for (const dependencyDefinition of dependencyDefinitions) {
-                definitionsWithDependencies.add(dependencyDefinition);
-              }
-            }
-          }
-        }
-      }
-    }
-    const potentialTransitiveDefinitionsMap = new Map<string, Set<DefinitionNode>>();
-    const allImportedDefinitionsMap = new Map<string, Set<DefinitionNode>>();
-    for (const line of importLines) {
-      const { imports, from } = parseImportLine(line.replace('#', '').trim());
-      const importFileDefinitionMap = visitFile(from, filePath, visitedFiles, predefinedImports);
-      if (importFileDefinitionMap != null) {
-        const buildFullDefinitionMap = (dependenciesMap: Map<string, Set<DefinitionNode>>) => {
-          for (const [importedDefinitionName, importedDefinitions] of importFileDefinitionMap) {
-            const [importedDefinitionTypeName] = importedDefinitionName.split('.');
-            if (!dependenciesMap.has(importedDefinitionTypeName)) {
-              dependenciesMap.set(importedDefinitionTypeName, new Set());
-            }
-            const allImportedDefinitions = dependenciesMap.get(importedDefinitionTypeName);
-            if (allImportedDefinitions) {
-              for (const importedDefinition of importedDefinitions) {
-                allImportedDefinitions.add(importedDefinition);
-              }
-            }
-          }
-        };
+    const { definitionsByName, dependenciesByDefinitionName } = extractDependencies(filePath, otherLines);
+    const fileDefinitionMap = getFileDefinitionMap(definitionsByName, dependenciesByDefinitionName);
 
-        buildFullDefinitionMap(potentialTransitiveDefinitionsMap);
-        if (imports.includes('*')) {
-          buildFullDefinitionMap(allImportedDefinitionsMap);
-        } else {
-          for (let importedDefinitionName of imports) {
-            if (importedDefinitionName.endsWith('.*')) {
-              // Adding whole type means the same thing with adding every single field
-              importedDefinitionName = importedDefinitionName.replace('.*', '');
-            }
-            const [importedDefinitionTypeName] = importedDefinitionName.split('.');
-            if (!allImportedDefinitionsMap.has(importedDefinitionTypeName)) {
-              allImportedDefinitionsMap.set(importedDefinitionTypeName, new Set());
-            }
-            const allImportedDefinitions = allImportedDefinitionsMap.get(importedDefinitionTypeName);
-            const importedDefinitions = importFileDefinitionMap.get(importedDefinitionName);
-            if (!importedDefinitions) {
-              throw new Error(`${importedDefinitionName} is not exported by ${from} imported by ${filePath}`);
-            }
-            if (allImportedDefinitions != null) {
-              for (const importedDefinition of importedDefinitions) {
-                allImportedDefinitions.add(importedDefinition);
-              }
-            }
-          }
-        }
-      }
-    }
+    // To prevent circular dependency
+    visitedFiles.set(filePath, fileDefinitionMap);
+
+    const { allImportedDefinitionsMap, potentialTransitiveDefinitionsMap } = processImports(
+      importLines,
+      filePath,
+      visitedFiles,
+      predefinedImports
+    );
+
     const addDefinition = (definition: DefinitionNode, definitionName: string, definitionSet: Set<DefinitionNode>) => {
       const fileDefinitionMap = visitedFiles.get(filePath);
       if (fileDefinitionMap && !definitionSet.has(definition)) {
@@ -360,7 +193,228 @@ function visitFile(
       }
     }
   }
-  return visitedFiles.get(filePath);
+  return visitedFiles.get(filePath)!;
+}
+
+export function extractDependencies(
+  filePath: string,
+  otherLines: string
+): {
+  definitionsByName: Map<string, Set<DefinitionNode>>;
+  dependenciesByDefinitionName: Map<string, Set<string>>;
+} {
+  const definitionsByName = new Map<string, Set<DefinitionNode>>();
+  const dependenciesByDefinitionName = new Map<string, Set<string>>();
+
+  if (!otherLines) {
+    return { definitionsByName, dependenciesByDefinitionName };
+  }
+
+  const document = parse(new Source(otherLines, filePath), {
+    noLocation: true,
+  });
+
+  for (const definition of document.definitions) {
+    if ('name' in definition || definition.kind === Kind.SCHEMA_DEFINITION) {
+      const definitionName = 'name' in definition && definition.name ? definition.name.value : 'schema';
+      if (!definitionsByName.has(definitionName)) {
+        definitionsByName.set(definitionName, new Set());
+      }
+      const definitionsSet = definitionsByName.get(definitionName);
+      definitionsSet?.add(definition);
+
+      let dependencySet = dependenciesByDefinitionName.get(definitionName);
+      if (!dependencySet) {
+        dependencySet = new Set();
+        dependenciesByDefinitionName.set(definitionName, dependencySet);
+      }
+      switch (definition.kind) {
+        case Kind.OPERATION_DEFINITION:
+          visitOperationDefinitionNode(definition, dependencySet);
+          break;
+        case Kind.FRAGMENT_DEFINITION:
+          visitFragmentDefinitionNode(definition, dependencySet);
+          break;
+        case Kind.OBJECT_TYPE_DEFINITION:
+          visitObjectTypeDefinitionNode(definition, dependencySet, dependenciesByDefinitionName);
+          break;
+        case Kind.INTERFACE_TYPE_DEFINITION:
+          visitInterfaceTypeDefinitionNode(definition, dependencySet, dependenciesByDefinitionName);
+          break;
+        case Kind.UNION_TYPE_DEFINITION:
+          visitUnionTypeDefinitionNode(definition, dependencySet);
+          break;
+        case Kind.ENUM_TYPE_DEFINITION:
+          visitEnumTypeDefinitionNode(definition, dependencySet);
+          break;
+        case Kind.INPUT_OBJECT_TYPE_DEFINITION:
+          visitInputObjectTypeDefinitionNode(definition, dependencySet, dependenciesByDefinitionName);
+          break;
+        case Kind.DIRECTIVE_DEFINITION:
+          visitDirectiveDefinitionNode(definition, dependencySet, dependenciesByDefinitionName);
+          break;
+        case Kind.SCALAR_TYPE_DEFINITION:
+          visitScalarDefinitionNode(definition, dependencySet);
+          break;
+        case Kind.SCHEMA_DEFINITION:
+          visitSchemaDefinitionNode(definition, dependencySet);
+          break;
+        case Kind.OBJECT_TYPE_EXTENSION:
+          visitObjectTypeExtensionNode(definition, dependencySet, dependenciesByDefinitionName);
+          break;
+        case Kind.INTERFACE_TYPE_EXTENSION:
+          visitInterfaceTypeExtensionNode(definition, dependencySet, dependenciesByDefinitionName);
+          break;
+        case Kind.UNION_TYPE_EXTENSION:
+          visitUnionTypeExtensionNode(definition, dependencySet);
+          break;
+        case Kind.ENUM_TYPE_EXTENSION:
+          visitEnumTypeExtensionNode(definition, dependencySet);
+          break;
+        case Kind.INPUT_OBJECT_TYPE_EXTENSION:
+          visitInputObjectTypeExtensionNode(definition, dependencySet, dependenciesByDefinitionName);
+          break;
+        case Kind.SCALAR_TYPE_EXTENSION:
+          visitScalarExtensionNode(definition, dependencySet);
+          break;
+      }
+      if ('fields' in definition && definition.fields) {
+        for (const field of definition.fields) {
+          const definitionName = definition.name.value + '.' + field.name.value;
+          if (!definitionsByName.has(definitionName)) {
+            definitionsByName.set(definitionName, new Set());
+          }
+          definitionsByName.get(definitionName)?.add({
+            ...definition,
+            fields: [field as any],
+          });
+
+          let dependencySet = dependenciesByDefinitionName.get(definitionName);
+          if (!dependencySet) {
+            dependencySet = new Set();
+            dependenciesByDefinitionName.set(definitionName, dependencySet);
+          }
+          switch (field.kind) {
+            case Kind.FIELD_DEFINITION:
+              visitFieldDefinitionNode(field, dependencySet, dependenciesByDefinitionName);
+              break;
+            case Kind.INPUT_VALUE_DEFINITION:
+              visitInputValueDefinitionNode(field, dependencySet, dependenciesByDefinitionName);
+              break;
+          }
+        }
+      }
+    }
+  }
+  return {
+    definitionsByName,
+    dependenciesByDefinitionName,
+  };
+}
+
+function getFileDefinitionMap(
+  definitionsByName: Map<string, Set<DefinitionNode>>,
+  dependenciesByDefinitionName: Map<string, Set<string>>
+): Map<string, Set<DefinitionNode>> {
+  const fileDefinitionMap = new Map<string, Set<DefinitionNode>>();
+
+  for (const [definitionName, definitions] of definitionsByName) {
+    let definitionsWithDependencies = fileDefinitionMap.get(definitionName);
+    if (definitionsWithDependencies == null) {
+      definitionsWithDependencies = new Set();
+      fileDefinitionMap.set(definitionName, definitionsWithDependencies);
+    }
+    for (const definition of definitions) {
+      definitionsWithDependencies.add(definition);
+    }
+    const dependenciesOfDefinition = dependenciesByDefinitionName.get(definitionName);
+    if (dependenciesOfDefinition) {
+      for (const dependencyName of dependenciesOfDefinition) {
+        const dependencyDefinitions = definitionsByName.get(dependencyName);
+        if (dependencyDefinitions != null) {
+          for (const dependencyDefinition of dependencyDefinitions) {
+            definitionsWithDependencies.add(dependencyDefinition);
+          }
+        }
+      }
+    }
+  }
+
+  return fileDefinitionMap;
+}
+
+export function processImports(
+  importLines: string[],
+  filePath: string,
+  visitedFiles: VisitedFilesMap,
+  predefinedImports: Record<string, string>
+): {
+  allImportedDefinitionsMap: Map<string, Set<DefinitionNode>>;
+  potentialTransitiveDefinitionsMap: Map<string, Set<DefinitionNode>>;
+} {
+  const potentialTransitiveDefinitionsMap = new Map<string, Set<DefinitionNode>>();
+  const allImportedDefinitionsMap = new Map<string, Set<DefinitionNode>>();
+  for (const line of importLines) {
+    const { imports, from } = parseImportLine(line.replace('#', '').trim());
+    const importFileDefinitionMap = visitFile(from, filePath, visitedFiles, predefinedImports);
+
+    const buildFullDefinitionMap = (dependenciesMap: Map<string, Set<DefinitionNode>>) => {
+      for (const [importedDefinitionName, importedDefinitions] of importFileDefinitionMap) {
+        const [importedDefinitionTypeName] = importedDefinitionName.split('.');
+        if (!dependenciesMap.has(importedDefinitionTypeName)) {
+          dependenciesMap.set(importedDefinitionTypeName, new Set());
+        }
+        const allImportedDefinitions = dependenciesMap.get(importedDefinitionTypeName);
+        if (allImportedDefinitions) {
+          for (const importedDefinition of importedDefinitions) {
+            allImportedDefinitions.add(importedDefinition);
+          }
+        }
+      }
+    };
+
+    buildFullDefinitionMap(potentialTransitiveDefinitionsMap);
+
+    if (imports.includes('*')) {
+      buildFullDefinitionMap(allImportedDefinitionsMap);
+    } else {
+      for (let importedDefinitionName of imports) {
+        if (importedDefinitionName.endsWith('.*')) {
+          // Adding whole type means the same thing with adding every single field
+          importedDefinitionName = importedDefinitionName.replace('.*', '');
+        }
+        const [importedDefinitionTypeName] = importedDefinitionName.split('.');
+        if (!allImportedDefinitionsMap.has(importedDefinitionTypeName)) {
+          allImportedDefinitionsMap.set(importedDefinitionTypeName, new Set());
+        }
+        const allImportedDefinitions = allImportedDefinitionsMap.get(importedDefinitionTypeName);
+        const importedDefinitions = importFileDefinitionMap.get(importedDefinitionName);
+        if (!importedDefinitions) {
+          throw new Error(`${importedDefinitionName} is not exported by ${from} imported by ${filePath}`);
+        }
+        if (allImportedDefinitions != null) {
+          for (const importedDefinition of importedDefinitions) {
+            allImportedDefinitions.add(importedDefinition);
+          }
+        }
+      }
+    }
+  }
+  return { allImportedDefinitionsMap, potentialTransitiveDefinitionsMap };
+}
+
+export function splitFile(fileContent: string): { importLines: string[]; otherLines: string } {
+  const importLines: string[] = [];
+  let otherLines = '';
+  for (const line of fileContent.split('\n')) {
+    const trimmedLine = line.trim();
+    if (trimmedLine.startsWith('#import ') || trimmedLine.startsWith('# import ')) {
+      importLines.push(trimmedLine);
+    } else if (trimmedLine) {
+      otherLines += line + '\n';
+    }
+  }
+  return { importLines, otherLines };
 }
 
 export function parseImportLine(importLine: string): { imports: string[]; from: string } {

--- a/packages/import/tests/schema/fixtures/multiple-imports/schema.graphql
+++ b/packages/import/tests/schema/fixtures/multiple-imports/schema.graphql
@@ -2,4 +2,4 @@
 
 # import Query.*, Mutation.* from "b.graphql"
 
-# import Query.*, Mutation.* from "c.graphql"
+# import Query.*, Mutation.* from "c.graphql" 

--- a/packages/import/tests/schema/fixtures/multiple-imports/schema.graphql
+++ b/packages/import/tests/schema/fixtures/multiple-imports/schema.graphql
@@ -2,4 +2,4 @@
 
 # import Query.*, Mutation.* from "b.graphql"
 
-# import Query.*, Mutation.* from "c.graphql" 
+# import Query.*, Mutation.* from "c.graphql"


### PR DESCRIPTION
## Description

This PR breaks down the `processImport` function into more granular functions and exports them from the `@graphql-tools/import` package.

Related https://github.com/ardatan/graphql-tools/issues/3638

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

