### PR TITLE
Proposed fix to bypass issue with schema files and pkg

### DIFF
--- a/packages/loaders/graphql-file/src/index.ts
+++ b/packages/loaders/graphql-file/src/index.ts
@@ -110,7 +110,11 @@ export class GraphQLFileLoader implements Loader<GraphQLFileLoaderOptions> {
   }
 
   async load(pointer: string, options: GraphQLFileLoaderOptions): Promise<Source[]> {
-    const resolvedPaths = await this.resolveGlobs(pointer, options);
+    let resolvedPaths: string[] = [];
+    if (!pointer.includes('*') && await this.canLoad(pointer, options))
+      resolvedPaths = [pointer]
+    else
+      resolvedPaths = this.resolveGlobsSync(pointer, options);
     const finalResult: Source[] = [];
     const errors: Error[] = [];
 
@@ -142,7 +146,11 @@ export class GraphQLFileLoader implements Loader<GraphQLFileLoaderOptions> {
   }
 
   loadSync(pointer: string, options: GraphQLFileLoaderOptions): Source[] {
-    const resolvedPaths = this.resolveGlobsSync(pointer, options);
+    let resolvedPaths: string[] = [];
+    if (!pointer.includes('*') && this.canLoadSync(pointer, options))
+      resolvedPaths = [pointer]
+    else
+      resolvedPaths = this.resolveGlobsSync(pointer, options);
     const finalResult: Source[] = [];
     const errors: Error[] = [];
 


### PR DESCRIPTION
## Description

Node projects with version 7 of graphql-tools cannot use schema files packaged into pkg binaries of https://www.npmjs.com/package/pkg.

This proposed solution is a reasonable workaround for an issue likely to be outside the control of graphql-tools and that cannot be expected to be fixed. This issue is speculated to be caused by a primitive file system on pkg lacking full features.

The solution is to bypass globbing if a string representing a schema file (or files) passes two tests:
1. It does not contain the glob * character
2. It passes a file exists test

This solution can also for part of checks in proposed enhancements mentioned below.

Issue raised and PR requested at https://github.com/ardatan/graphql-tools/issues/3447

The problem and fix cannot be demonstrated in a sandbox.

There is a repository at https://github.com/johnheenan/graphql-tools-demo that can be used to demonstrate the problem with version 7 of graphql-tools, how downgrading to version 6 fixes the problem and how these proposed changes fix the problem in version 7

## Type of change

- [x] Bug fix: if using pkg
- [x] Breaking change: unknown

## How Has This Been Tested?

Please see full details on https://github.com/johnheenan/graphql-tools-demo

**Test Environment**:
- OS: Windows 10, Linux WSL2 Debian
- `@graphql-tools/...`:     @graphql-tools/graphql-file-loader": "^7.1.0",  "@graphql-tools/load": "^7.3.2",
- NodeJS: 14.17.6

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

First why this the problem did not occur on version 6 but does on version 7 of the `@graphql-tools` npm modules used.

The following function in version 6 and 7 always returns empty with schema files from the pkg read-only snapshot but not outside the snapshot:
```
  resolveGlobsSync(glob: string, options: GraphQLFileLoaderOptions) {
    const globs = this._buildGlobs(glob, options);
    const result = globby.sync(globs, createGlobbyOptions(options));
    return result;
  }
```

In version 6 the `resolveGlobsSync` function was never called with my project. In version 7 it is always called,

The problem is caused by the npm package called 'globby' failing to recognise a file string matches one existing in a read only snapshot file system built by another npm package called 'pkg'.

Files accessed from pkg without being joined to `__dirname` do not form part of the readonlyfile snapshot and these files are accessed from the real file system with node by pkg.

It can be argued that 'globby' should not have to cater for file systems that are never intended to be full featured read only file systems. Globby of course itself has its own dependencies.

It can be argued by 'pkg' there is no reasonable use case to make their read only file system is responsive to every emulated POSIX file system call and that if someone wants to glob or search for a file they can use a supplied list, since the internal file system is read only.

It can also be argued that it reasonable for users of @graphq-tools to expect to use file systems that are primitive and so not featured enough for a full range of system calls, such as common on embedded systems.

If the solution is or is not accepted than an additional solution is to explicitly allow globbing not to occur by way of an enhancement and to also allow an array of 'pre globbed' strings to be passed by way of an enhancement. This is reasonable for schema files on a read-only file system.







