### PR TITLE
Small typo on mocking docs

### DIFF
--- a/website/docs/mocking.mdx
+++ b/website/docs/mocking.mdx
@@ -508,7 +508,7 @@ store.set('User', '1', { name: 'Alexandre', age: 31 })
 Set a field value via graph traversal (nested set):
 
 ```ts
-store.get('Query', 'ROOT', {
+store.set('Query', 'ROOT', {
   viewer: {
     name: 'Alexandre',
     friends: [{ name: 'Emily' }, { name: 'Caroline' }]


### PR DESCRIPTION
## Description

Fixing a small typo on mocking documentation - MockStore

Doc description refers to a `set` operation while the example shows a `get` operation.

Related #3853

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

- [x] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

![image](https://user-images.githubusercontent.com/479683/141032822-e2b6cc9b-6075-4321-a5ba-b4213b1c3508.png)

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

