### PR TITLE
Fix example of handling byId fields in the docs

### DIFF
--- a/website/docs/mocking.mdx
+++ b/website/docs/mocking.mdx
@@ -228,25 +228,25 @@ const result = await server.query(query, variables)
 By default, `*byId` (like `userById(id: ID!)`) field will return an entity that does not have the same `id` as the one queried. We can fix that:
 
 ```ts
-const typeDefs = /* GraphQL */`
-type User {
-  id: Id!
-  name: String!
-}
-type Query {
-  userById(id: ID!): User!
-}
+const typeDefs = /* GraphQL */ `
+  type User {
+    id: Id!
+    name: String!
+  }
+  type Query {
+    userById(id: ID!): User!
+  }
 `
-const schema = makeExecutableSchema({ typeDefs: schemaString });
+const schema = makeExecutableSchema({ typeDefs: schemaString })
 const schemaWithMocks = addMocksToSchema({
   schema,
   store,
-  resolvers: (store) => ({
+  resolvers: store => ({
     Query: {
-      userById: (_, { id }) => store.get('User', id),
+      userById: (_, { id }) => store.get('User', id)
     }
   })
-});
+})
 ```
 
 Note that, by default, the `id` or `_id` field will be used as storage key and the store will make sure the storage key and the field value are equal. You can change the key field using the option `typePolicies`.

--- a/website/docs/mocking.mdx
+++ b/website/docs/mocking.mdx
@@ -242,8 +242,8 @@ const schemaWithMocks = addMocksToSchema({
   schema,
   store,
   resolvers: (store) => ({
-    Query {
-      userById(_, { id }) => store.get('User', id),
+    Query: {
+      userById: (_, { id }) => store.get('User', id),
     }
   })
 });


### PR DESCRIPTION
## Description

Fix syntax error of the example provided for a byId fields.

## Type of change

- [x] This change requires a documentation update

## How Has This Been Tested?

Run the example

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- n/a I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- n/a I have added tests that prove my fix is effective or that my feature works
- n/a New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

