### PR TITLE
Fix graphql-tag-pluck returning results when it shouldn't

### DIFF
--- a/.changeset/poor-olives-report.md
+++ b/.changeset/poor-olives-report.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/graphql-tag-pluck': patch
+---
+
+Fix returning whitespace only results if skipIndent is set to true

--- a/packages/graphql-tag-pluck/src/utils.ts
+++ b/packages/graphql-tag-pluck/src/utils.ts
@@ -14,6 +14,9 @@ export const freeText = (text: string | string[], skipIndentation = false) => {
   });
 
   if (skipIndentation) {
+    if (text.trim() === '') {
+      return '';
+    }
     return text;
   }
 

--- a/packages/graphql-tag-pluck/tests/graphql-tag-pluck.test.ts
+++ b/packages/graphql-tag-pluck/tests/graphql-tag-pluck.test.ts
@@ -37,6 +37,20 @@ describe('graphql-tag-pluck', () => {
       expect(sources.map(source => source.body).join('\n\n')).toMatchSnapshot();
     });
 
+    it('should treat empty results the same', async () => {
+      const content = freeText(`
+      import gql from 'graphql-tag'
+
+      const doc = gql\`
+
+      \`
+    `);
+      let sources = await pluck('tmp-XXXXXX.js', content);
+      expect(sources.length).toEqual(0);
+      sources = await pluck('tmp-XXXXXX.js', content, { skipIndent: true });
+      expect(sources.length).toEqual(0);
+    });
+
     it('should pluck graphql-tag template literals from .js file', async () => {
       const sources = await pluck(
         'tmp-XXXXXX.js',


### PR DESCRIPTION
## Description

Fixes graphql-tag-pluck returning results consisting of only whitespace. When it should just return an empty string

Related #3911

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

I've added two commits. The first one only adds a test which fails. The second fixes the tests. No existing tests fail
