### PR TITLE
[mock] Feature: add Relay style pagination mock helper

### DIFF
--- a/.changeset/seven-fireants-carry.md
+++ b/.changeset/seven-fireants-carry.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/mock': minor
+---
+
+Added relayStylePaginationMock helper

--- a/packages/mock/src/addMocksToSchema.ts
+++ b/packages/mock/src/addMocksToSchema.ts
@@ -2,17 +2,16 @@ import {
   GraphQLSchema,
   GraphQLFieldResolver,
   defaultFieldResolver,
-  GraphQLObjectType,
   GraphQLTypeResolver,
   isUnionType,
   GraphQLUnionType,
   GraphQLInterfaceType,
   isSchema,
 } from 'graphql';
-import { mapSchema, MapperKind, IResolvers, getRootTypeNames } from '@graphql-tools/utils';
+import { mapSchema, MapperKind, IResolvers } from '@graphql-tools/utils';
 import { addResolversToSchema } from '@graphql-tools/schema';
 import { isRef, IMockStore, IMocks, TypePolicy } from './types';
-import { copyOwnProps, isObject } from './utils';
+import { copyOwnProps, isObject, isRootType } from './utils';
 import { createMockStore } from './MockStore';
 
 type IMockOptions = {
@@ -246,9 +245,3 @@ export function addMocksToSchema({
 
   return resolvers ? addResolversToSchema(schemaWithMocks, resolvers) : schemaWithMocks;
 }
-
-const isRootType = (type: GraphQLObjectType, schema: GraphQLSchema) => {
-  const rootTypeNames = getRootTypeNames(schema);
-
-  return rootTypeNames.has(type.name);
-};

--- a/packages/mock/src/index.ts
+++ b/packages/mock/src/index.ts
@@ -3,3 +3,4 @@ export * from './addMocksToSchema';
 export * from './mockServer';
 export * from './types';
 export * from './MockList';
+export * from './pagination';

--- a/packages/mock/src/pagination.ts
+++ b/packages/mock/src/pagination.ts
@@ -140,12 +140,12 @@ export const relayStylePaginationMock = <TContext, TArgs extends RelayPagination
       const beforeIndex = foundBeforeIndex !== -1 ? foundBeforeIndex : allNodes.length;
       start = allEdges.length - (allEdges.length - beforeIndex) - last;
 
-      // negative index on Array.slice indicate offsert from end of sequence => we don't want
+      // negative index on Array.slice indicate offset from end of sequence => we don't want
       if (start < 0) start = 0;
 
       end = beforeIndex;
     } else {
-      throw new Error('if `first` or  `last` should be provided');
+      throw new Error('A `first` or a `last` arguments should be provided');
     }
 
     const edges = allEdges.slice(start, end);

--- a/packages/mock/src/pagination.ts
+++ b/packages/mock/src/pagination.ts
@@ -1,0 +1,171 @@
+import { IFieldResolver } from '@graphql-tools/utils';
+import { GraphQLResolveInfo } from 'graphql';
+import { IMockStore, Ref } from './types';
+import { isRootType, makeRef } from './utils';
+
+export type AllNodesFn<TContext, TArgs extends RelayPaginationParams> = (
+  parent: Ref,
+  args: TArgs,
+  context: TContext,
+  info: GraphQLResolveInfo
+) => Ref[];
+
+export type RelayStylePaginationMockOptions<TContext, TArgs extends RelayPaginationParams> = {
+  /**
+   * Use this option to apply filtering or sorting on the nodes given the
+   * arguments the paginated field receives.
+   *
+   * ```ts
+   * {
+   *    User: {
+   *      friends: mockedRelayStylePagination<
+   *        unknown,
+   *        RelayPaginationParams & { sortByBirthdateDesc?: boolean}
+   *      >(
+   *        store, {
+   *          applyOnEdges: (edges, { sortByBirthdateDesc }) => {
+   *            if (!sortByBirthdateDesc) return edges
+   *            return _.sortBy(edges, (e) => store.get(e, ['node', 'birthdate']))
+   *          }
+   *       }),
+   *    }
+   * }
+   * ```
+   */
+  applyOnNodes?: (nodeRefs: Ref[], args: TArgs) => Ref[];
+
+  /**
+   * A function that'll be used to get all the nodes used for pagination.
+   *
+   * By default, it will use the nodes of the field this pagination is attached to.
+   *
+   * This option is handy when several paginable fields should share
+   * the same base nodes:
+   * ```ts
+   * {
+   *    User: {
+   *      friends: mockedRelayStylePagination(store),
+   *      maleFriends: mockedRelayStylePagination(store, {
+   *        allNodesFn: (userRef) =>
+   *          store
+   *           .get(userRef, ['friends', 'edges'])
+   *           .map((e) => store.get(e, 'node'))
+   *           .filter((userRef) => store.get(userRef, 'sex') === 'male')
+   *      })
+   *    }
+   * }
+   * ```
+   */
+  allNodesFn?: AllNodesFn<TContext, TArgs>;
+
+  /**
+   * The function that'll be used to compute the cursor of a node.
+   *
+   * By default, it'll use `MockStore` internal reference `Ref`'s `key`
+   * as cursor.
+   */
+  cursorFn?: (nodeRef: Ref) => string;
+};
+
+export type RelayPaginationParams = {
+  first?: number;
+  after?: string;
+  last?: number;
+  before?: string;
+};
+
+export type RelayPageInfo = {
+  hasPreviousPage: boolean;
+  hasNextPage: boolean;
+  startCursor: string;
+  endCursor: string;
+};
+
+/**
+ * Produces a resolver that'll mock a [Relay-style cursor pagination](https://relay.dev/graphql/connections.htm).
+ *
+ * ```ts
+ * const schemaWithMocks = addMocksToSchema({
+ *   schema,
+ *   resolvers: (store) => ({
+ *     User: {
+ *       friends: relayStylePaginationMock(store),
+ *     }
+ *   }),
+ * })
+ * ```
+ * @param store the MockStore
+ */
+export const relayStylePaginationMock = <TContext, TArgs extends RelayPaginationParams = RelayPaginationParams>(
+  store: IMockStore,
+  {
+    cursorFn = node => `${node.$ref.key}`,
+    applyOnNodes,
+    allNodesFn,
+  }: RelayStylePaginationMockOptions<TContext, TArgs> = {}
+): IFieldResolver<Ref, TContext, TArgs, any> => {
+  return (parent, args, context, info) => {
+    const source = isRootType(info.parentType, info.schema) ? makeRef(info.parentType.name, 'ROOT') : parent;
+
+    const allNodesFn_ = allNodesFn ?? defaultAllNodesFn(store);
+    let allNodes = allNodesFn_(source, args, context, info);
+
+    if (applyOnNodes) {
+      allNodes = applyOnNodes(allNodes, args);
+    }
+
+    const allEdges = allNodes.map(node => ({
+      node,
+      cursor: cursorFn(node),
+    }));
+
+    let start: number, end: number;
+    const { first, after, last, before } = args;
+
+    if (typeof first === 'number') {
+      // forward pagination
+      if (last || before) {
+        throw new Error("if `first` is provided, `last` or `before` can't be provided");
+      }
+      const afterIndex = after ? allEdges.findIndex(e => e.cursor === after) : -1;
+      start = afterIndex + 1;
+      end = afterIndex + 1 + first;
+    } else if (typeof last === 'number') {
+      // backward pagination
+      if (first || after) {
+        throw new Error("if `last` is provided, `first` or `after` can't be provided");
+      }
+      const foundBeforeIndex = before ? allEdges.findIndex(e => e.cursor === before) : -1;
+
+      const beforeIndex = foundBeforeIndex !== -1 ? foundBeforeIndex : allNodes.length;
+      start = allEdges.length - (allEdges.length - beforeIndex) - last;
+
+      // negative index on Array.slice indicate offsert from end of sequence => we don't want
+      if (start < 0) start = 0;
+
+      end = beforeIndex;
+    } else {
+      throw new Error('if `first` or  `last` should be provided');
+    }
+
+    const edges = allEdges.slice(start, end);
+
+    const pageInfo: RelayPageInfo = {
+      startCursor: edges.length > 0 ? edges[0].cursor : '',
+      endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : '',
+      hasNextPage: end < allEdges.length - 1,
+      hasPreviousPage: start > 0,
+    };
+
+    return {
+      edges,
+      pageInfo,
+      totalCount: allEdges.length,
+    };
+  };
+};
+
+const defaultAllNodesFn =
+  <TContext, TArgs extends RelayPaginationParams>(store: IMockStore): AllNodesFn<TContext, TArgs> =>
+  (parent, _, __, info) =>
+    (store.get(parent, [info.fieldName, 'edges']) as Ref[]).map(e => store.get(e, 'node') as Ref);

--- a/packages/mock/src/utils.ts
+++ b/packages/mock/src/utils.ts
@@ -1,3 +1,5 @@
+import { getRootTypeNames } from '@graphql-tools/utils';
+import { GraphQLObjectType, GraphQLSchema } from 'graphql';
 import { Ref, KeyTypeConstraints } from './types';
 
 export function uuidv4() {
@@ -44,3 +46,9 @@ export function copyOwnProps(target: Record<string, any>, ...sources: Array<Reco
   }
   return target;
 }
+
+export const isRootType = (type: GraphQLObjectType, schema: GraphQLSchema) => {
+  const rootTypeNames = getRootTypeNames(schema);
+
+  return rootTypeNames.has(type.name);
+};

--- a/packages/mock/tests/pagination.spec.ts
+++ b/packages/mock/tests/pagination.spec.ts
@@ -1,12 +1,5 @@
 import { buildSchema, graphql, GraphQLSchema } from 'graphql';
-import {
-  addMocksToSchema,
-  assertIsRef,
-  createMockStore,
-  isRef,
-  RelayPaginationParams,
-  relayStylePaginationMock,
-} from '../src';
+import { addMocksToSchema, RelayPaginationParams, relayStylePaginationMock } from '../src';
 
 const typeDefs = /* GraphQL */ `
   type Item {

--- a/packages/mock/tests/pagination.spec.ts
+++ b/packages/mock/tests/pagination.spec.ts
@@ -1,0 +1,232 @@
+import { buildSchema, graphql, GraphQLSchema } from 'graphql';
+import {
+  addMocksToSchema,
+  assertIsRef,
+  createMockStore,
+  isRef,
+  RelayPaginationParams,
+  relayStylePaginationMock,
+} from '../src';
+
+const typeDefs = /* GraphQL */ `
+  type Item {
+    id: ID!
+    index: Int!
+  }
+
+  type ItemEdge {
+    node: Item!
+    cursor: String!
+  }
+
+  type PageInfo {
+    hasPreviousPage: Boolean!
+    hasNextPage: Boolean!
+    startCursor: String!
+    endCursor: String!
+  }
+
+  type ItemConnection {
+    edges: [ItemEdge!]!
+    pageInfo: PageInfo!
+    totalCount: Int!
+  }
+
+  type Query {
+    items(first: Int, after: String, last: Int, before: String, oddIndexOnly: Boolean): ItemConnection!
+  }
+`;
+
+const schema = buildSchema(typeDefs);
+
+describe('relayStylePaginationMock', () => {
+  describe('basic usage', () => {
+    let mockedSchema: GraphQLSchema;
+    beforeEach(() => {
+      mockedSchema = addMocksToSchema({
+        schema,
+        mocks: {
+          Query: {
+            items: () => ({
+              edges: [...new Array(5)].map((_, index) => ({ node: { index } })),
+            }),
+          },
+        },
+        resolvers: store => ({
+          Query: {
+            items: relayStylePaginationMock(store),
+          },
+        }),
+      });
+    });
+
+    describe('forward pagination', () => {
+      it('should work', async () => {
+        const query = /* GraphQL */ `
+          query PaginateItems($after: String) {
+            items(first: 2, after: $after) {
+              edges {
+                node {
+                  index
+                }
+              }
+              pageInfo {
+                endCursor
+                hasNextPage
+              }
+              totalCount
+            }
+          }
+        `;
+
+        const page1 = await graphql({
+          schema: mockedSchema,
+          source: query,
+        });
+
+        expect(page1.errors).not.toBeDefined();
+        expect(page1.data).toBeDefined();
+        const page1Items = page1.data?.['items'] as any;
+        expect(page1Items.totalCount).toEqual(5);
+        expect(page1Items.pageInfo.hasNextPage).toBeTruthy();
+        expect(page1Items.edges).toHaveLength(2);
+        expect(page1Items.edges.map((e: any) => e.node.index)).toEqual([0, 1]);
+
+        const page2 = await graphql({
+          schema: mockedSchema,
+          source: query,
+          variableValues: {
+            after: page1Items.pageInfo.endCursor,
+          },
+        });
+
+        const page2Items = page2.data?.['items'] as any;
+        expect(page2Items.edges.map((e: any) => e.node.index)).toEqual([2, 3]);
+
+        const page3 = await graphql({
+          schema: mockedSchema,
+          source: query,
+          variableValues: {
+            after: page2Items.pageInfo.endCursor,
+          },
+        });
+
+        const page3Items = page3.data?.['items'] as any;
+        expect(page3Items.pageInfo.hasNextPage).toBeFalsy();
+        expect(page3Items.edges.map((e: any) => e.node.index)).toEqual([4]);
+      });
+    });
+    describe('backward pagination', () => {
+      it('should work', async () => {
+        const query = /* GraphQL */ `
+          query PaginateItems($before: String) {
+            items(last: 2, before: $before) {
+              edges {
+                cursor
+                node {
+                  index
+                }
+              }
+              pageInfo {
+                startCursor
+                hasPreviousPage
+              }
+              totalCount
+            }
+          }
+        `;
+
+        const page1 = await graphql({
+          schema: mockedSchema,
+          source: query,
+        });
+
+        expect(page1.errors).not.toBeDefined();
+        expect(page1.data).toBeDefined();
+        const page1Items = page1.data?.['items'] as any;
+        expect(page1Items.totalCount).toEqual(5);
+        expect(page1Items.pageInfo.hasPreviousPage).toBeTruthy();
+        expect(page1Items.edges).toHaveLength(2);
+        expect(page1Items.edges.map((e: any) => e.node.index)).toEqual([3, 4]);
+
+        const page2 = await graphql({
+          schema: mockedSchema,
+          source: query,
+          variableValues: {
+            before: page1Items.pageInfo.startCursor,
+          },
+        });
+
+        const page2Items = page2.data?.['items'] as any;
+        expect(page2Items.edges.map((e: any) => e.node.index)).toEqual([1, 2]);
+
+        const page3 = await graphql({
+          schema: mockedSchema,
+          source: query,
+          variableValues: {
+            before: page2Items.pageInfo.startCursor,
+          },
+        });
+
+        const page3Items = page3.data?.['items'] as any;
+        expect(page3Items.pageInfo.hasPreviousPage).toBeFalsy();
+        expect(page3Items.edges.map((e: any) => e.node.index)).toEqual([0]);
+      });
+    });
+  });
+
+  describe('with `applyOnNodes` option', () => {
+    let mockedSchema: GraphQLSchema;
+    beforeEach(() => {
+      mockedSchema = addMocksToSchema({
+        schema,
+        mocks: {
+          Query: {
+            items: () => ({
+              edges: [...new Array(5)].map((_, index) => ({ node: { index } })),
+            }),
+          },
+        },
+        resolvers: store => ({
+          Query: {
+            items: relayStylePaginationMock<unknown, RelayPaginationParams & { oddIndexOnly?: boolean | null }>(store, {
+              applyOnNodes: (nodes, { oddIndexOnly }) => {
+                if (oddIndexOnly) {
+                  return nodes.filter(node => (store.get(node, 'index') as number) % 2 !== 0);
+                }
+                return nodes;
+              },
+            }),
+          },
+        }),
+      });
+    });
+
+    it('should work', async () => {
+      const query = /* GraphQL */ `
+        query PaginateItems($after: String) {
+          items(first: 2, after: $after, oddIndexOnly: true) {
+            edges {
+              cursor
+              node {
+                index
+              }
+            }
+            pageInfo {
+              startCursor
+              hasPreviousPage
+            }
+            totalCount
+          }
+        }
+      `;
+
+      const page = await graphql({
+        schema: mockedSchema,
+        source: query,
+      });
+      expect(page.errors).not.toBeDefined();
+      expect((page.data?.['items'] as any).totalCount).toEqual(2);
+    });
+  });
+});

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -354,7 +354,7 @@
 
   ```js
   {
-    mydir: [{ arg: 'first' }, { arg: 'second' }];
+    mydir: [{ arg: 'first' }, { arg: 'second' }]
   }
   ```
 

--- a/website/docs/mocking.mdx
+++ b/website/docs/mocking.mdx
@@ -299,45 +299,46 @@ const schemaWithMocks = addMocksToSchema({
 ```
 
 #### Relay-style pagination
+
 To mock a pagination that complies to [Relay-style pagination](https://relay.dev/graphql/connections.htm),
 you can use the provided helper [`relayStylePaginationMock`](/docs/api/modules/mock_src#relaystylepaginationmock):
 
 ```ts
-import { buildSchema } from 'graphql';
-import { addMocksToSchema, relayStylePaginationMock } from '@graphql-tools/mock';
+import { buildSchema } from 'graphql'
+import { addMocksToSchema, relayStylePaginationMock } from '@graphql-tools/mock'
 
-const typeDefs = /* GraphQL */`
-type User {
-  id: Id!
-  name: String!
-  friends(first: Int!, after: String): FriendsConnection!
-}
-type PageInfo {
-  hasNextPage: Boolean!
-  endCursor: String!
-}
-type FriendsConnection {
-  totalCount: Int!
-  edges: [FriendConnectionEdge!]!
-  pageInfo: PageInfo!
-}
-type FriendsConnectionEdge {
-  node: User!
-  cursor: String!
-}
-type Query {
-  me: User!
-}
+const typeDefs = /* GraphQL */ `
+  type User {
+    id: Id!
+    name: String!
+    friends(first: Int!, after: String): FriendsConnection!
+  }
+  type PageInfo {
+    hasNextPage: Boolean!
+    endCursor: String!
+  }
+  type FriendsConnection {
+    totalCount: Int!
+    edges: [FriendConnectionEdge!]!
+    pageInfo: PageInfo!
+  }
+  type FriendsConnectionEdge {
+    node: User!
+    cursor: String!
+  }
+  type Query {
+    me: User!
+  }
 `
-const schema = buildSchema(typeDefs);
+const schema = buildSchema(typeDefs)
 const schemaWithMocks = addMocksToSchema({
   schema,
-  resolvers: (store) => ({
+  resolvers: store => ({
     User: {
       friends: relayStylePaginationMock(store)
     }
   })
-});
+})
 ```
 
 ## Mocking a schema using introspection

--- a/website/docs/mocking.mdx
+++ b/website/docs/mocking.mdx
@@ -249,7 +249,6 @@ const typeDefs = /* GraphQL */ `
 const schema = buildSchema(typeDefs)
 const schemaWithMocks = addMocksToSchema({
   schema,
-  store,
   resolvers: store => ({
     Query: {
       userById: (_, { id }) => store.get('User', id)
@@ -281,7 +280,6 @@ const typeDefs = /* GraphQL */ `
 const schema = buildSchema(typeDefs)
 const schemaWithMocks = addMocksToSchema({
   schema,
-  store,
   resolvers: store => ({
     User: {
       // `addMocksToSchema` resolver will pass a `Ref` as `parent`
@@ -301,25 +299,31 @@ const schemaWithMocks = addMocksToSchema({
 ```
 
 #### Relay-style pagination
-
-The principles stay the same than for basic pagination:
+To mock a pagination that complies to [Relay-style pagination](https://relay.dev/graphql/connections.htm),
+you can use the provided helper [`relayStylePaginationMock`](/docs/api/modules/mock_src#relaystylepaginationmock):
 
 ```ts
 import { buildSchema } from 'graphql';
-import { addMocksToSchema, Ref } from '@graphql-tools/mock';
+import { addMocksToSchema, relayStylePaginationMock } from '@graphql-tools/mock';
 
 const typeDefs = /* GraphQL */`
 type User {
   id: Id!
   name: String!
-  friends(offset: Int!, limit: Int!): FriendsConnection;
+  friends(first: Int!, after: String): FriendsConnection!
+}
+type PageInfo {
+  hasNextPage: Boolean!
+  endCursor: String!
 }
 type FriendsConnection {
   totalCount: Int!
   edges: [FriendConnectionEdge!]!
+  pageInfo: PageInfo!
 }
 type FriendsConnectionEdge {
   node: User!
+  cursor: String!
 }
 type Query {
   me: User!
@@ -328,16 +332,9 @@ type Query {
 const schema = buildSchema(typeDefs);
 const schemaWithMocks = addMocksToSchema({
   schema,
-  store,
   resolvers: (store) => ({
     User: {
-      friends: (userRef, { offset, limit }) => {
-        const edgesFullList = store.get(userRef, 'friends', 'edges') as Ref[];
-
-        return {
-          totalCount: edgesFullList.length,
-          edges: edgesFullList.slice(offset, offset + limit)
-      }
+      friends: relayStylePaginationMock(store)
     }
   })
 });


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

This PR adds a helper to `@graphql-tools/mock` that makes mocking Relay-style pagination easier:

```ts
import { buildSchema } from 'graphql';
import { addMocksToSchema, relayStylePaginationMock } from '@graphql-tools/mock';

const typeDefs = /* GraphQL */`
type User {
  id: Id!
  name: String!
  friends(first: Int!, after: String): FriendsConnection!
}
type PageInfo {
  hasNextPage: Boolean!
  endCursor: String!
}
type FriendConnection {
  totalCount: Int!
  edges: [FriendEdge!]!
  pageInfo: PageInfo!
}
type FriendEdge {
  node: User!
  cursor: String!
}
type Query {
  me: User!
}
`
const schema = buildSchema(typeDefs);
const schemaWithMocks = addMocksToSchema({
  schema,
  resolvers: (store) => ({
    User: {
      friends: relayStylePaginationMock(store)
    }
  })
});
```

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Was tested against unit-tests placed in `packages/mock/tests/pagination.spec.ts`

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] ~Any dependent changes have been merged and published in downstream modules~
