### PR TITLE
Update to deep mocking with custom mocks when preserveResolvers option is turned on

### DIFF
--- a/.changeset/gentle-poets-compete.md
+++ b/.changeset/gentle-poets-compete.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/mock': patch
+---
+
+Resolve an issue with custom scalar mocks being ignored in deep mocking when preserveResolvers option is turned on.

--- a/packages/mock/src/addMocksToSchema.ts
+++ b/packages/mock/src/addMocksToSchema.ts
@@ -145,8 +145,8 @@ export function addMocksToSchema({
     }
 
     if (defaultResolvedValue === undefined) {
-      // any is used here because generateValueFromType is a private method at time of writing
-      return (mockStore as any).generateValueFromType(info.returnType);
+      // any is used here because generateFieldValue is a private method at time of writing
+      return (mockStore as any).generateFieldValue(info.parentType.name, info.fieldName);
     }
 
     return undefined;

--- a/packages/mock/tests/mocking-compatibility.spec.ts
+++ b/packages/mock/tests/mocking-compatibility.spec.ts
@@ -861,7 +861,7 @@ describe('Mock retro-compatibility', () => {
     const mockMap = {
       String: () => 'a',
       Int: () => 1,
-      Color: () => ({ hex: '#333' }),
+      Color: () => ({ name: 'red', hex: '#333' }),
       CustomScalar: () => 'cs',
     };
     jsSchema = addMocksToSchema({ schema: jsSchema, mocks: mockMap, preserveResolvers: true });
@@ -906,20 +906,20 @@ describe('Mock retro-compatibility', () => {
                 "id": "a",
                 "nullableReturnColors": Array [
                   Object {
-                    "name": "a",
+                    "name": "red",
                   },
                   Object {
-                    "name": "a",
+                    "name": "red",
                   },
                 ],
                 "returnColors": Array [
                   Object {
                     "hex": "#333",
-                    "name": "a",
+                    "name": "red",
                   },
                   Object {
                     "hex": "#333",
-                    "name": "a",
+                    "name": "red",
                   },
                 ],
                 "returnCustomScalarArr": Array [
@@ -949,7 +949,7 @@ describe('Mock retro-compatibility', () => {
                 "returnColors": Array [
                   Object {
                     "hex": "#ccc",
-                    "name": "a",
+                    "name": "red",
                   },
                 ],
                 "returnCustomScalarArr": Array [
@@ -977,20 +977,20 @@ describe('Mock retro-compatibility', () => {
                 "id": "a",
                 "nullableReturnColors": Array [
                   Object {
-                    "name": "a",
+                    "name": "red",
                   },
                   Object {
-                    "name": "a",
+                    "name": "red",
                   },
                 ],
                 "returnColors": Array [
                   Object {
                     "hex": "#333",
-                    "name": "a",
+                    "name": "red",
                   },
                   Object {
                     "hex": "#333",
-                    "name": "a",
+                    "name": "red",
                   },
                 ],
                 "returnCustomScalarArr": Array [
@@ -1016,10 +1016,10 @@ describe('Mock retro-compatibility', () => {
                 "id": "a",
                 "nullableReturnColors": Array [
                   Object {
-                    "name": "a",
+                    "name": "red",
                   },
                   Object {
-                    "name": "a",
+                    "name": "red",
                   },
                 ],
                 "returnColors": Array [],


### PR DESCRIPTION
## Description

Resolves an issue with custom scalar mocks being ignored in deep mocking when the `preserveResolvers` option is turned on. Please check the related issue for more information.

Related #4035 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit tests

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules