### PR TITLE
fix(load): fix type for NON_OPERATION_KINDS

### DIFF
--- a/.changeset/famous-owls-sit.md
+++ b/.changeset/famous-owls-sit.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/load': patch
+---
+
+Fix type error on NON_OPERATION_KINDS when using with graphql@15

--- a/packages/load/src/documents.ts
+++ b/packages/load/src/documents.ts
@@ -12,7 +12,7 @@ export const OPERATION_KINDS: KindList = [Kind.OPERATION_DEFINITION, Kind.FRAGME
 /**
  * Kinds of AST nodes that are included in type system definition documents
  */
-export const NON_OPERATION_KINDS = Object.keys(Kind)
+export const NON_OPERATION_KINDS: KindList = Object.keys(Kind)
   .reduce((prev, v) => [...prev, Kind[v]], [] as KindList)
   .filter(v => !OPERATION_KINDS.includes(v));
 


### PR DESCRIPTION
## Description

Fixes the following error that shows up when using `graphql@15`:

```
dist/load/src/documents.d.ts:12:43 - error TS2749: 'Kind' refers to a value, but is being used as a type here. Did you mean 'typeof Kind'?

12 export declare const NON_OPERATION_KINDS: Kind[];
```

Related https://github.com/ardatan/graphql-tools/issues/4050

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. In a local graphql-tools repository (without this change!), run `yarn build`
2. Run `yarn add graphql@15 -W` to override what's currently in the package.json devDependencies
3. Run `./node_modules/.bin/tsc --noEmit dist/load/src/documents.d.ts`
4. See the TypeScript error above
5. Apply the change from this PR
6. Run `yarn build` again
7. Run `./node_modules/.bin/tsc --noEmit dist/load/src/documents.d.ts` again
8. See that there are no TypeScript errors

**Test Environment**:

- OS: macOS 12.1
- `@graphql-tools/...`: `@graphql-tools/load@7.5.0`
- NodeJS: 16.13.1

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
  - Not quite done yet? I think I need to ~create a changeset and~ maybe make some config file changes yet?
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
  - I'm not really sure how to test this in an automated way 😅 
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
