### PR TITLE
Documenting duplicate typeDefs with processImport

### DIFF
--- a/.changeset/shy-poems-tell.md
+++ b/.changeset/shy-poems-tell.md
@@ -1,0 +1,6 @@
+---
+'@graphql-tools/import': patch
+'@graphql-tools/load': patch
+---
+
+Changes to the documentation regarding processImport

--- a/packages/import/src/index.ts
+++ b/packages/import/src/index.ts
@@ -64,6 +64,7 @@ export type VisitedFilesMap = Map<string, Map<string, Set<DefinitionNode>>>;
 /**
  * Loads the GraphQL document and recursively resolves all the imports
  * and copies them into the final document.
+ * processImport does not merge the typeDefs as designed ( https://github.com/ardatan/graphql-tools/issues/2980#issuecomment-1003692728 )
  */
 export function processImport(
   filePath: string,

--- a/packages/load/src/load-typedefs.ts
+++ b/packages/load/src/load-typedefs.ts
@@ -21,6 +21,7 @@ export type UnnormalizedTypeDefPointer = { [key: string]: any } | string;
  * Asynchronously loads any GraphQL documents (i.e. executable documents like
  * operations and fragments as well as type system definitions) from the
  * provided pointers.
+ * loadTypedefs does not merge the typeDefs when `#import` is used ( https://github.com/ardatan/graphql-tools/issues/2980#issuecomment-1003692728 )
  * @param pointerOrPointers Pointers to the sources to load the documents from
  * @param options Additional options
  */


### PR DESCRIPTION
## Description

Documenting merging issue with respect to `processImport`

Related https://github.com/ardatan/graphql-tools/issues/2980

## Type of change

Please delete options that are not relevant.

- [x] Fixing documentation

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules