### PR TITLE
Fixing typo as suggested in crisp chat

### DIFF
--- a/website/docs/mocking.mdx
+++ b/website/docs/mocking.mdx
@@ -118,7 +118,7 @@ const mocks = {
   DateTime: () => casual.date(format = 'YYYY-MM-DDTHH:mm:ss.SSSZZ'),
 }
 const preserveResolvers = false
-// Mock the server passing the schema, mocks object and preserverResolvers arguments.
+// Mock the server passing the schema, mocks object and preserveResolvers arguments.
 const server = mockServer(schema, mocks, preserveResolvers)
 // Alternatively, you can call addMocksToSchema with the same arguments.
 const schemaWithMocks = addMocksToSchema({


### PR DESCRIPTION
## Description

User reported a typo here: https://app.crisp.chat/website/af9adec5-ddfa-4db9-a4a3-25769daf2fc2/inbox/session_2247f5d0-4e6d-44d2-8af0-f1de034b3d74/

Related https://app.crisp.chat/website/af9adec5-ddfa-4db9-a4a3-25769daf2fc2/inbox/session_2247f5d0-4e6d-44d2-8af0-f1de034b3d74/

## Type of change

Please delete options that are not relevant.

- [x] Documentation update

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project