### PR TITLE
add graphql-executor to benchmarks

### DIFF
--- a/benchmark/federation/index.js
+++ b/benchmark/federation/index.js
@@ -2,14 +2,28 @@ const express = require('express');
 const runStitchingGateway = require('./stitching');
 const runApolloGateway = require('./federation');
 const makeMonolithSchema = require('./monolith');
-const { parse, execute } = require('graphql');
+const { parse } = require('graphql');
+const { execute } = require('graphql-executor');
+
+function memoize1(fn) {
+  const memoize1cache = new Map();
+  return function memoized(a1) {
+    const cachedValue = memoize1cache.get(a1);
+    if (cachedValue === undefined) {
+      const newValue = fn(a1);
+      memoize1cache.set(a1, newValue);
+      return newValue;
+    }
+
+    return cachedValue;
+  };
+}
 
 async function main() {
-  const [stitching, federation, monolith] = await Promise.all([
-    runStitchingGateway(),
-    runApolloGateway(),
-    makeMonolithSchema(),
-  ]);
+  const scenarios = await Promise.all([runStitchingGateway(), runApolloGateway(), makeMonolithSchema()]);
+
+  const [stitching, federation, monolith] = scenarios;
+  const [stitchingParse, federationParse, monolithParse] = scenarios.map(() => memoize1(parse));
 
   const app = express();
 
@@ -18,7 +32,7 @@ async function main() {
   app.post('/federation', (req, res) => {
     federation
       .executor({
-        document: parse(req.body.query),
+        document: federationParse(req.body.query),
         request: {
           query: req.body.query,
         },
@@ -37,7 +51,7 @@ async function main() {
   app.post('/stitching', (req, res) => {
     execute({
       schema: stitching,
-      document: parse(req.body.query),
+      document: stitchingParse(req.body.query),
       contextValue: {},
     })
       .then(result => {
@@ -50,7 +64,7 @@ async function main() {
     try {
       const result = execute({
         schema: monolith,
-        document: parse(req.body.query),
+        document: monolithParse(req.body.query),
         contextValue: {},
       });
       res.json(result);

--- a/benchmark/federation/package.json
+++ b/benchmark/federation/package.json
@@ -15,6 +15,7 @@
     "@graphql-tools/stitching-directives": "2.2.1",
     "express": "4.17.2",
     "graphql": "16.2.0",
+    "graphql-executor": "0.0.14",
     "graphql-tag": "2.12.6",
     "wait-on": "6.0.0",
     "cross-env": "7.0.3"

--- a/benchmark/federation/stitching.js
+++ b/benchmark/federation/stitching.js
@@ -1,7 +1,7 @@
 const { stitchSchemas } = require('@graphql-tools/stitch');
 const { federationToStitchingSDL, stitchingDirectives } = require('@graphql-tools/stitching-directives');
 const { stitchingDirectivesTransformer } = stitchingDirectives();
-const { buildSchema, execute, print } = require('graphql');
+const { buildSchema, print } = require('graphql');
 const { createDefaultExecutor } = require('@graphql-tools/delegate');
 
 const services = [

--- a/benchmark/federation/yarn.lock
+++ b/benchmark/federation/yarn.lock
@@ -952,6 +952,11 @@ glob@^7.1.3, glob@^7.1.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+graphql-executor@0.0.14:
+  version "0.0.14"
+  resolved "https://registry.yarnpkg.com/graphql-executor/-/graphql-executor-0.0.14.tgz#4eaff42eca38794153becdd914029bf0fe00fe9f"
+  integrity sha512-ucgmNIewyZgWibqjCKSfhCsiZEcsYmsBleUklSamdiIC7rE06ABb5OvbIAE5I5zzZcjMF7v79t2cTcrPcN0pvQ==
+
 graphql-tag@2.12.6, graphql-tag@^2.11.0:
   version "2.12.6"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.6.tgz#d441a569c1d2537ef10ca3d1633b48725329b5f1"


### PR DESCRIPTION
compare benefit of executor to benefit of parse cache alone