### PR TITLE
fix: remove it.only from merge-schema tests

### DIFF
--- a/packages/schema/tests/merge-schemas.spec.ts
+++ b/packages/schema/tests/merge-schemas.spec.ts
@@ -372,7 +372,7 @@ describe('Merge Schemas', () => {
     expect(data['a']).toEqual(now.toISOString());
   });
 
-  it.only('should not duplicate directives of scalars', () => {
+  it('should not duplicate directives of scalars', () => {
     const schema = buildSchema(/* GraphQL */ `
       directive @sqlType(type: String!) on SCALAR
       scalar JSON @sqlType(type: "json")


### PR DESCRIPTION
Saw an `it.only` was left in the `merge-schema` tests so some tests were being skipped. Created this small PR to remove it. All the previously skipped tests are passing on my local. 

Thanks for creating and maintaining `graphql-tools`!