### PR TITLE
Fix interface extension `implements` bug

### DIFF
--- a/.changeset/famous-humans-report.md
+++ b/.changeset/famous-humans-report.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/merge': patch
+---
+
+Update `mergeTypeDefs` to merge `implements` definitions defined within interface extensions.

--- a/packages/merge/src/typedefs-mergers/interface.ts
+++ b/packages/merge/src/typedefs-mergers/interface.ts
@@ -23,7 +23,9 @@ export function mergeInterface(
         loc: node.loc,
         fields: mergeFields(node, node.fields, existingNode.fields, config),
         directives: mergeDirectives(node.directives, existingNode.directives, config),
-        interfaces: mergeNamedTypeArray(node.interfaces, existingNode.interfaces, config),
+        interfaces: node['interfaces']
+          ? mergeNamedTypeArray(node['interfaces'], existingNode['interfaces'], config)
+          : undefined,
       } as any;
     } catch (e: any) {
       throw new Error(`Unable to merge GraphQL interface "${node.name.value}": ${e.message}`);

--- a/packages/merge/src/typedefs-mergers/interface.ts
+++ b/packages/merge/src/typedefs-mergers/interface.ts
@@ -2,6 +2,7 @@ import { Config } from './merge-typedefs';
 import { InterfaceTypeDefinitionNode, InterfaceTypeExtensionNode, Kind } from 'graphql';
 import { mergeFields } from './fields';
 import { mergeDirectives } from './directives';
+import { mergeNamedTypeArray } from '.';
 
 export function mergeInterface(
   node: InterfaceTypeDefinitionNode | InterfaceTypeExtensionNode,
@@ -22,6 +23,7 @@ export function mergeInterface(
         loc: node.loc,
         fields: mergeFields(node, node.fields, existingNode.fields, config),
         directives: mergeDirectives(node.directives, existingNode.directives, config),
+        interfaces: mergeNamedTypeArray(node.interfaces, existingNode.interfaces, config),
       } as any;
     } catch (e: any) {
       throw new Error(`Unable to merge GraphQL interface "${node.name.value}": ${e.message}`);

--- a/packages/merge/tests/merge-typedefs.spec.ts
+++ b/packages/merge/tests/merge-typedefs.spec.ts
@@ -3,7 +3,7 @@ import '../../testing/to-be-similar-string';
 import { mergeDirectives, mergeTypeDefs, mergeGraphQLTypes } from '../src';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { stitchSchemas } from '@graphql-tools/stitch';
-import { buildSchema, buildClientSchema, print, parse, Kind, DirectiveNode } from 'graphql';
+import { buildSchema, buildClientSchema, print, parse, Kind, DirectiveNode, version as graphqlVersion } from 'graphql';
 import { stripWhitespaces } from './utils';
 import gql from 'graphql-tag';
 import { readFileSync } from 'fs';
@@ -903,34 +903,36 @@ describe('Merge TypeDefs', () => {
     });
 
     it('should handle extend interfaces', () => {
-      const merged = mergeTypeDefs([
-        `
-        interface Interface {
-          foo: String
-        }
-      `,
-        `
-        extend interface Interface implements AdditionalInterface {
-          bar: String
-        }
-
-        interface AdditionalInterface {
-          bar: String
-        }
-      `,
-      ]);
-      expect(stripWhitespaces(print(merged))).toBe(
-        stripWhitespaces(/* GraphQL */ `
-          interface Interface implements AdditionalInterface {
+      if (!graphqlVersion.startsWith('14.')) {
+        const merged = mergeTypeDefs([
+          `
+          interface Interface {
             foo: String
+          }
+        `,
+          `
+          extend interface Interface implements AdditionalInterface {
             bar: String
           }
 
           interface AdditionalInterface {
             bar: String
           }
-        `)
-      );
+        `,
+        ]);
+        expect(stripWhitespaces(print(merged))).toBe(
+          stripWhitespaces(/* GraphQL */ `
+            interface Interface implements AdditionalInterface {
+              foo: String
+              bar: String
+            }
+
+            interface AdditionalInterface {
+              bar: String
+            }
+          `)
+        );
+      }
     });
 
     it('should handle extend input types', () => {

--- a/packages/merge/tests/merge-typedefs.spec.ts
+++ b/packages/merge/tests/merge-typedefs.spec.ts
@@ -836,15 +836,23 @@ describe('Merge TypeDefs', () => {
         }
       `,
         `
-        extend type Test {
+        extend type Test implements Interface {
+          bar: String
+        }
+
+        interface Interface {
           bar: String
         }
       `,
       ]);
       expect(stripWhitespaces(print(merged))).toBe(
         stripWhitespaces(/* GraphQL */ `
-          type Test {
+          type Test implements Interface {
             foo: String
+            bar: String
+          }
+
+          interface Interface {
             bar: String
           }
         `)
@@ -889,6 +897,37 @@ describe('Merge TypeDefs', () => {
           type User {
             name: String
             id: ID
+          }
+        `)
+      );
+    });
+
+    it('should handle extend interfaces', () => {
+      const merged = mergeTypeDefs([
+        `
+        interface Interface {
+          foo: String
+        }
+      `,
+        `
+        extend interface Interface implements AdditionalInterface {
+          bar: String
+        }
+
+        interface AdditionalInterface {
+          bar: String
+        }
+      `,
+      ]);
+      expect(stripWhitespaces(print(merged))).toBe(
+        stripWhitespaces(/* GraphQL */ `
+          interface Interface implements AdditionalInterface {
+            foo: String
+            bar: String
+          }
+
+          interface AdditionalInterface {
+            bar: String
           }
         `)
       );


### PR DESCRIPTION
## Description

When I merge a schema definition like this:

```gql
interface Interface {
  foo: String
}

extend interface Interface implements AdditionalInterface {
  bar: String
}

interface AdditionalInterface {
  bar: String
}
```

then I expect the `implements` to be preserved in the merged type (as is the case for type extensions), like this:

```gql
interface Interface implements AdditionalInterface {
  foo: String
  bar: String
}

interface AdditionalInterface {
  bar: String
}
```

Related # (issue)

N/A

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

New unit test

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
