### PR TITLE
Fix typings for stitch schema with custom context

### DIFF
--- a/.changeset/dull-ties-cover.md
+++ b/.changeset/dull-ties-cover.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/delegate': minor
+---
+
+Add better type support for stitchSchemas using subschema transformations

--- a/.changeset/wild-rivers-matter.md
+++ b/.changeset/wild-rivers-matter.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/wrap': minor
+---
+
+Add better type support for stitchSchemas using subschema transformations

--- a/packages/delegate/CHANGELOG.md
+++ b/packages/delegate/CHANGELOG.md
@@ -213,7 +213,7 @@
 
   - Replace `CheckResultAndHandleErrors` with `checkResultAndHandleErrors`
   - Remove `delegationBindings`
-  - Replace `AddArgumentsAsVariables`, `AddSelectionSets`, `AddTypenameToAbstract`, `ExpandAbstractTypes`, `FilterToSchema`, `VisitSelectionSets` and `WrapConcreteTypes` with `prepareGatewayRequest` and `finalizeGatewayRequest`
+  - Replace `AddArgumentsAsVariables`, `AddSelectionSets`, `AddTypenameToAbstract`, `ExpandAbstractTypes`, `FilterToSchema`, `VisitSelectionSets` and `WrapConcreteTypes` with `prepareGatewayDocument` and `finalizeGatewayRequest`
 
 - dae6dc7b: refactor: ExecutionParams type replaced by Request type
 

--- a/packages/delegate/src/Transformer.ts
+++ b/packages/delegate/src/Transformer.ts
@@ -6,14 +6,14 @@ import { prepareGatewayDocument } from './prepareGatewayDocument';
 import { finalizeGatewayRequest } from './finalizeGatewayRequest';
 import { checkResultAndHandleErrors } from './checkResultAndHandleErrors';
 
-interface Transformation {
-  transform: Transform;
+interface Transformation<TContext> {
+  transform: Transform<any, TContext>;
   context: Record<string, any>;
 }
 
 export class Transformer<TContext = Record<string, any>> {
-  private transformations: Array<Transformation> = [];
-  private delegationContext: DelegationContext<any>;
+  private transformations: Array<Transformation<TContext>> = [];
+  private delegationContext: DelegationContext<TContext>;
 
   constructor(context: DelegationContext<TContext>) {
     this.delegationContext = context;
@@ -24,7 +24,7 @@ export class Transformer<TContext = Record<string, any>> {
     }
   }
 
-  private addTransform(transform: Transform, context = {}) {
+  private addTransform(transform: Transform<any, TContext>, context = {}) {
     this.transformations.push({ transform, context });
   }
 

--- a/packages/delegate/src/checkResultAndHandleErrors.ts
+++ b/packages/delegate/src/checkResultAndHandleErrors.ts
@@ -5,7 +5,10 @@ import { AggregateError, getResponseKeyFromInfo, ExecutionResult, relocatedError
 import { DelegationContext } from './types';
 import { resolveExternalValue } from './resolveExternalValue';
 
-export function checkResultAndHandleErrors(result: ExecutionResult, delegationContext: DelegationContext): any {
+export function checkResultAndHandleErrors<TContext>(
+  result: ExecutionResult,
+  delegationContext: DelegationContext<TContext>
+): any {
   const {
     context,
     info,

--- a/packages/delegate/src/finalizeGatewayRequest.ts
+++ b/packages/delegate/src/finalizeGatewayRequest.ts
@@ -105,9 +105,9 @@ function finalizeGatewayDocument(
   };
 }
 
-export function finalizeGatewayRequest(
+export function finalizeGatewayRequest<TContext>(
   originalRequest: ExecutionRequest,
-  delegationContext: DelegationContext
+  delegationContext: DelegationContext<TContext>
 ): ExecutionRequest {
   let { document, variables } = originalRequest;
 

--- a/packages/delegate/src/mergeFields.ts
+++ b/packages/delegate/src/mergeFields.ts
@@ -19,10 +19,10 @@ export function isExternalObject(data: any): data is ExternalObject {
   return data[UNPATHED_ERRORS_SYMBOL] !== undefined;
 }
 
-export function annotateExternalObject(
+export function annotateExternalObject<TContext>(
   object: any,
   errors: Array<GraphQLError>,
-  subschema: GraphQLSchema | SubschemaConfig | undefined,
+  subschema: GraphQLSchema | SubschemaConfig<any, any, any, TContext> | undefined,
   subschemaMap: Record<string, GraphQLSchema | SubschemaConfig<any, any, any, Record<string, any>>>
 ): ExternalObject {
   Object.defineProperties(object, {

--- a/packages/delegate/src/resolveExternalValue.ts
+++ b/packages/delegate/src/resolveExternalValue.ts
@@ -19,10 +19,10 @@ import { StitchingInfo, SubschemaConfig } from './types';
 import { annotateExternalObject, isExternalObject, mergeFields } from './mergeFields';
 import { Subschema } from './Subschema';
 
-export function resolveExternalValue(
+export function resolveExternalValue<TContext>(
   result: any,
   unpathedErrors: Array<GraphQLError>,
-  subschema: GraphQLSchema | SubschemaConfig,
+  subschema: GraphQLSchema | SubschemaConfig<any, any, any, TContext>,
   context?: Record<string, any>,
   info?: GraphQLResolveInfo,
   returnType = getReturnType(info),
@@ -47,11 +47,11 @@ export function resolveExternalValue(
   }
 }
 
-function resolveExternalObject(
+function resolveExternalObject<TContext>(
   type: GraphQLCompositeType,
   object: any,
   unpathedErrors: Array<GraphQLError>,
-  subschema: GraphQLSchema | SubschemaConfig,
+  subschema: GraphQLSchema | SubschemaConfig<any, any, any, TContext>,
   context?: Record<string, any>,
   info?: GraphQLResolveInfo,
   skipTypeMerging?: boolean
@@ -103,11 +103,11 @@ function resolveExternalObject(
   return mergeFields(mergedTypeInfo, object, subschema as Subschema, context, info);
 }
 
-function resolveExternalList(
+function resolveExternalList<TContext>(
   type: GraphQLList<any>,
   list: Array<any>,
   unpathedErrors: Array<GraphQLError>,
-  subschema: GraphQLSchema | SubschemaConfig,
+  subschema: GraphQLSchema | SubschemaConfig<any, any, any, TContext>,
   context?: Record<string, any>,
   info?: GraphQLResolveInfo,
   skipTypeMerging?: boolean
@@ -125,11 +125,11 @@ function resolveExternalList(
   );
 }
 
-function resolveExternalListMember(
+function resolveExternalListMember<TContext>(
   type: GraphQLType,
   listMember: any,
   unpathedErrors: Array<GraphQLError>,
-  subschema: GraphQLSchema | SubschemaConfig,
+  subschema: GraphQLSchema | SubschemaConfig<any, any, any, TContext>,
   context?: Record<string, any>,
   info?: GraphQLResolveInfo,
   skipTypeMerging?: boolean

--- a/packages/delegate/src/types.ts
+++ b/packages/delegate/src/types.ts
@@ -25,21 +25,21 @@ export type SchemaTransform<TContext = Record<any, string>> = (
   subschemaConfig: SubschemaConfig<any, any, any, TContext>,
   transformedSchema?: GraphQLSchema
 ) => GraphQLSchema;
-export type RequestTransform<T = Record<string, any>> = (
+export type RequestTransform<T = Record<string, any>, TContext = Record<any, string>> = (
   originalRequest: ExecutionRequest,
-  delegationContext: DelegationContext,
+  delegationContext: DelegationContext<TContext>,
   transformationContext: T
 ) => ExecutionRequest;
-export type ResultTransform<T = Record<string, any>> = (
+export type ResultTransform<T = Record<string, any>, TContext = Record<any, string>> = (
   originalResult: ExecutionResult,
-  delegationContext: DelegationContext,
+  delegationContext: DelegationContext<TContext>,
   transformationContext: T
 ) => ExecutionResult;
 
 export interface Transform<T = any, TContext = Record<string, any>> {
   transformSchema?: SchemaTransform<TContext>;
-  transformRequest?: RequestTransform<T>;
-  transformResult?: ResultTransform<T>;
+  transformRequest?: RequestTransform<T, TContext>;
+  transformResult?: ResultTransform<T, TContext>;
 }
 
 export interface DelegationContext<TContext = Record<string, any>> {

--- a/packages/wrap/src/transforms/ExtractField.ts
+++ b/packages/wrap/src/transforms/ExtractField.ts
@@ -4,7 +4,11 @@ import { ExecutionRequest } from '@graphql-tools/utils';
 
 import { Transform, DelegationContext } from '@graphql-tools/delegate';
 
-export default class ExtractField implements Transform {
+interface ExtractFieldTransformationContext extends Record<string, any> {}
+
+export default class ExtractField<TContext = Record<string, any>>
+  implements Transform<ExtractFieldTransformationContext, TContext>
+{
   private readonly from: Array<string>;
   private readonly to: Array<string>;
 
@@ -15,8 +19,8 @@ export default class ExtractField implements Transform {
 
   public transformRequest(
     originalRequest: ExecutionRequest,
-    _delegationContext: DelegationContext,
-    _transformationContext: Record<string, any>
+    _delegationContext: DelegationContext<TContext>,
+    _transformationContext: ExtractFieldTransformationContext
   ): ExecutionRequest {
     let fromSelection: SelectionSetNode | undefined;
     const ourPathFrom = JSON.stringify(this.from);

--- a/packages/wrap/src/transforms/FilterInputObjectFields.ts
+++ b/packages/wrap/src/transforms/FilterInputObjectFields.ts
@@ -8,8 +8,12 @@ import { InputObjectNodeTransformer } from '../types';
 
 import TransformInputObjectFields from './TransformInputObjectFields';
 
-export default class FilterInputObjectFields implements Transform {
-  private readonly transformer: TransformInputObjectFields;
+interface FilterInputObjectFieldsTransformationContext extends Record<string, any> {}
+
+export default class FilterInputObjectFields<TContext = Record<string, any>>
+  implements Transform<FilterInputObjectFieldsTransformationContext, TContext>
+{
+  private readonly transformer: TransformInputObjectFields<TContext>;
 
   constructor(filter: InputFieldFilter, inputObjectNodeTransformer?: InputObjectNodeTransformer) {
     this.transformer = new TransformInputObjectFields(
@@ -22,7 +26,7 @@ export default class FilterInputObjectFields implements Transform {
 
   public transformSchema(
     originalWrappingSchema: GraphQLSchema,
-    subschemaConfig: SubschemaConfig,
+    subschemaConfig: SubschemaConfig<any, any, any, TContext>,
     transformedSchema?: GraphQLSchema
   ): GraphQLSchema {
     return this.transformer.transformSchema(originalWrappingSchema, subschemaConfig, transformedSchema);
@@ -30,8 +34,8 @@ export default class FilterInputObjectFields implements Transform {
 
   public transformRequest(
     originalRequest: ExecutionRequest,
-    delegationContext: DelegationContext,
-    transformationContext: Record<string, any>
+    delegationContext: DelegationContext<TContext>,
+    transformationContext: FilterInputObjectFieldsTransformationContext
   ): ExecutionRequest {
     return this.transformer.transformRequest(originalRequest, delegationContext, transformationContext);
   }

--- a/packages/wrap/src/transforms/FilterInterfaceFields.ts
+++ b/packages/wrap/src/transforms/FilterInterfaceFields.ts
@@ -6,8 +6,12 @@ import { SubschemaConfig, Transform } from '@graphql-tools/delegate';
 
 import TransformInterfaceFields from './TransformInterfaceFields';
 
-export default class FilterInterfaceFields implements Transform {
-  private readonly transformer: TransformInterfaceFields;
+interface FilterInterfaceFieldsTransformationContext extends Record<string, any> {}
+
+export default class FilterInterfaceFields<TContext = Record<string, any>>
+  implements Transform<FilterInterfaceFieldsTransformationContext, TContext>
+{
+  private readonly transformer: TransformInterfaceFields<TContext>;
 
   constructor(filter: FieldFilter) {
     this.transformer = new TransformInterfaceFields(
@@ -18,7 +22,7 @@ export default class FilterInterfaceFields implements Transform {
 
   public transformSchema(
     originalWrappingSchema: GraphQLSchema,
-    subschemaConfig: SubschemaConfig,
+    subschemaConfig: SubschemaConfig<any, any, any, TContext>,
     transformedSchema?: GraphQLSchema
   ): GraphQLSchema {
     return this.transformer.transformSchema(originalWrappingSchema, subschemaConfig, transformedSchema);

--- a/packages/wrap/src/transforms/FilterObjectFieldDirectives.ts
+++ b/packages/wrap/src/transforms/FilterObjectFieldDirectives.ts
@@ -6,7 +6,11 @@ import { SubschemaConfig, Transform } from '@graphql-tools/delegate';
 
 import TransformObjectFields from './TransformObjectFields';
 
-export default class FilterObjectFieldDirectives implements Transform {
+interface FilterObjectFieldDirectivesTransformationContext extends Record<string, any> {}
+
+export default class FilterObjectFieldDirectives<TContext = Record<string, any>>
+  implements Transform<FilterObjectFieldDirectivesTransformationContext, TContext>
+{
   private readonly filter: (dirName: string, dirValue: any) => boolean;
 
   constructor(filter: (dirName: string, dirValue: any) => boolean) {
@@ -15,7 +19,7 @@ export default class FilterObjectFieldDirectives implements Transform {
 
   public transformSchema(
     originalWrappingSchema: GraphQLSchema,
-    subschemaConfig: SubschemaConfig,
+    subschemaConfig: SubschemaConfig<any, any, any, TContext>,
     transformedSchema?: GraphQLSchema
   ): GraphQLSchema {
     const transformer = new TransformObjectFields(

--- a/packages/wrap/src/transforms/FilterObjectFields.ts
+++ b/packages/wrap/src/transforms/FilterObjectFields.ts
@@ -6,11 +6,15 @@ import { SubschemaConfig, Transform } from '@graphql-tools/delegate';
 
 import TransformObjectFields from './TransformObjectFields';
 
-export default class FilterObjectFields<T = any, TContext = Record<string, any>> implements Transform<T, TContext> {
-  private readonly transformer: TransformObjectFields<T, TContext>;
+interface FilterObjectFieldsTransformationContext extends Record<string, any> {}
+
+export default class FilterObjectFields<TContext = Record<string, any>>
+  implements Transform<FilterObjectFieldsTransformationContext, TContext>
+{
+  private readonly transformer: TransformObjectFields<TContext>;
 
   constructor(filter: ObjectFieldFilter) {
-    this.transformer = new TransformObjectFields<T, TContext>(
+    this.transformer = new TransformObjectFields(
       (typeName: string, fieldName: string, fieldConfig: GraphQLFieldConfig<any, TContext>) =>
         filter(typeName, fieldName, fieldConfig) ? undefined : null
     );

--- a/packages/wrap/src/transforms/FilterObjectFields.ts
+++ b/packages/wrap/src/transforms/FilterObjectFields.ts
@@ -6,19 +6,19 @@ import { SubschemaConfig, Transform } from '@graphql-tools/delegate';
 
 import TransformObjectFields from './TransformObjectFields';
 
-export default class FilterObjectFields implements Transform {
-  private readonly transformer: TransformObjectFields;
+export default class FilterObjectFields<T = any, TContext = Record<string, any>> implements Transform<T, TContext> {
+  private readonly transformer: TransformObjectFields<T, TContext>;
 
   constructor(filter: ObjectFieldFilter) {
-    this.transformer = new TransformObjectFields(
-      (typeName: string, fieldName: string, fieldConfig: GraphQLFieldConfig<any, any>) =>
+    this.transformer = new TransformObjectFields<T, TContext>(
+      (typeName: string, fieldName: string, fieldConfig: GraphQLFieldConfig<any, TContext>) =>
         filter(typeName, fieldName, fieldConfig) ? undefined : null
     );
   }
 
   public transformSchema(
     originalWrappingSchema: GraphQLSchema,
-    subschemaConfig: SubschemaConfig,
+    subschemaConfig: SubschemaConfig<any, any, any, TContext>,
     transformedSchema?: GraphQLSchema
   ): GraphQLSchema {
     return this.transformer.transformSchema(originalWrappingSchema, subschemaConfig, transformedSchema);

--- a/packages/wrap/src/transforms/FilterRootFields.ts
+++ b/packages/wrap/src/transforms/FilterRootFields.ts
@@ -6,11 +6,11 @@ import { SubschemaConfig, Transform } from '@graphql-tools/delegate';
 
 import TransformRootFields from './TransformRootFields';
 
-export default class FilterRootFields implements Transform {
-  private readonly transformer: TransformRootFields;
+export default class FilterRootFields<T = any, TContext = Record<string, any>> implements Transform<T, TContext> {
+  private readonly transformer: TransformRootFields<T, TContext>;
 
   constructor(filter: RootFieldFilter) {
-    this.transformer = new TransformRootFields(
+    this.transformer = new TransformRootFields<T, TContext>(
       (
         operation: 'Query' | 'Mutation' | 'Subscription',
         fieldName: string,
@@ -27,7 +27,7 @@ export default class FilterRootFields implements Transform {
 
   public transformSchema(
     originalWrappingSchema: GraphQLSchema,
-    subschemaConfig: SubschemaConfig,
+    subschemaConfig: SubschemaConfig<any, any, any, TContext>,
     transformedSchema?: GraphQLSchema
   ): GraphQLSchema {
     return this.transformer.transformSchema(originalWrappingSchema, subschemaConfig, transformedSchema);

--- a/packages/wrap/src/transforms/FilterRootFields.ts
+++ b/packages/wrap/src/transforms/FilterRootFields.ts
@@ -6,11 +6,15 @@ import { SubschemaConfig, Transform } from '@graphql-tools/delegate';
 
 import TransformRootFields from './TransformRootFields';
 
-export default class FilterRootFields<T = any, TContext = Record<string, any>> implements Transform<T, TContext> {
-  private readonly transformer: TransformRootFields<T, TContext>;
+interface FilterRootFieldsTransformationContext extends Record<string, any> {}
+
+export default class FilterRootFields<TContext = Record<string, any>>
+  implements Transform<FilterRootFieldsTransformationContext, TContext>
+{
+  private readonly transformer: TransformRootFields<TContext>;
 
   constructor(filter: RootFieldFilter) {
-    this.transformer = new TransformRootFields<T, TContext>(
+    this.transformer = new TransformRootFields(
       (
         operation: 'Query' | 'Mutation' | 'Subscription',
         fieldName: string,

--- a/packages/wrap/src/transforms/FilterTypes.ts
+++ b/packages/wrap/src/transforms/FilterTypes.ts
@@ -4,7 +4,11 @@ import { mapSchema, MapperKind } from '@graphql-tools/utils';
 
 import { SubschemaConfig, Transform } from '@graphql-tools/delegate';
 
-export default class FilterTypes implements Transform {
+interface FilterTypesTransformationContext extends Record<string, any> {}
+
+export default class FilterTypes<TContext = Record<string, any>>
+  implements Transform<FilterTypesTransformationContext, TContext>
+{
   private readonly filter: (type: GraphQLNamedType) => boolean;
 
   constructor(filter: (type: GraphQLNamedType) => boolean) {
@@ -13,7 +17,7 @@ export default class FilterTypes implements Transform {
 
   public transformSchema(
     originalWrappingSchema: GraphQLSchema,
-    _subschemaConfig: SubschemaConfig,
+    _subschemaConfig: SubschemaConfig<any, any, any, TContext>,
     _transformedSchema?: GraphQLSchema
   ): GraphQLSchema {
     return mapSchema(originalWrappingSchema, {

--- a/packages/wrap/src/transforms/HoistField.ts
+++ b/packages/wrap/src/transforms/HoistField.ts
@@ -24,14 +24,18 @@ import { defaultCreateProxyingResolver } from '../generateProxyingResolvers';
 
 import MapFields from './MapFields';
 
-export default class HoistField implements Transform {
+interface HoistFieldTransformationContext extends Record<string, any> {}
+
+export default class HoistField<TContext = Record<string, any>>
+  implements Transform<HoistFieldTransformationContext, TContext>
+{
   private readonly typeName: string;
   private readonly newFieldName: string;
   private readonly pathToField: Array<string>;
   private readonly oldFieldName: string;
   private readonly argFilters: Array<(arg: GraphQLArgument) => boolean>;
   private readonly argLevels: Record<string, number>;
-  private readonly transformer: MapFields<any>;
+  private readonly transformer: MapFields<TContext>;
 
   constructor(
     typeName: string,
@@ -77,7 +81,7 @@ export default class HoistField implements Transform {
 
   public transformSchema(
     originalWrappingSchema: GraphQLSchema,
-    subschemaConfig: SubschemaConfig,
+    subschemaConfig: SubschemaConfig<any, any, any, TContext>,
     transformedSchema?: GraphQLSchema
   ): GraphQLSchema {
     const argsMap: Record<string, GraphQLArgument> = Object.create(null);
@@ -161,16 +165,16 @@ export default class HoistField implements Transform {
 
   public transformRequest(
     originalRequest: ExecutionRequest,
-    delegationContext: DelegationContext,
-    transformationContext: Record<string, any>
+    delegationContext: DelegationContext<TContext>,
+    transformationContext: HoistFieldTransformationContext
   ): ExecutionRequest {
     return this.transformer.transformRequest(originalRequest, delegationContext, transformationContext);
   }
 
   public transformResult(
     originalResult: ExecutionResult,
-    delegationContext: DelegationContext,
-    transformationContext: Record<string, any>
+    delegationContext: DelegationContext<TContext>,
+    transformationContext: HoistFieldTransformationContext
   ): ExecutionResult {
     return this.transformer.transformResult(originalResult, delegationContext, transformationContext);
   }

--- a/packages/wrap/src/transforms/MapFields.ts
+++ b/packages/wrap/src/transforms/MapFields.ts
@@ -8,7 +8,9 @@ import { ObjectValueTransformerMap, ErrorsTransformer } from '../types';
 
 import TransformCompositeFields from './TransformCompositeFields';
 
-export default class MapFields<TContext> implements Transform<any, TContext> {
+interface MapFieldsTransformationContext extends Record<string, any> {}
+
+export default class MapFields<TContext> implements Transform<MapFieldsTransformationContext, TContext> {
   private fieldNodeTransformerMap: FieldNodeMappers;
   private objectValueTransformerMap?: ObjectValueTransformerMap;
   private errorsTransformer?: ErrorsTransformer;
@@ -86,16 +88,16 @@ export default class MapFields<TContext> implements Transform<any, TContext> {
 
   public transformRequest(
     originalRequest: ExecutionRequest,
-    delegationContext: DelegationContext,
-    transformationContext: Record<string, any>
+    delegationContext: DelegationContext<TContext>,
+    transformationContext: MapFieldsTransformationContext
   ): ExecutionRequest {
     return this._getTransformer().transformRequest(originalRequest, delegationContext, transformationContext);
   }
 
   public transformResult(
     originalResult: ExecutionResult,
-    delegationContext: DelegationContext,
-    transformationContext: Record<string, any>
+    delegationContext: DelegationContext<TContext>,
+    transformationContext: MapFieldsTransformationContext
   ): ExecutionResult {
     return this._getTransformer().transformResult(originalResult, delegationContext, transformationContext);
   }

--- a/packages/wrap/src/transforms/MapLeafValues.ts
+++ b/packages/wrap/src/transforms/MapLeafValues.ts
@@ -32,7 +32,9 @@ export interface MapLeafValuesTransformationContext {
   transformedRequest: ExecutionRequest;
 }
 
-export default class MapLeafValues implements Transform<MapLeafValuesTransformationContext> {
+export default class MapLeafValues<TContext = Record<string, any>>
+  implements Transform<MapLeafValuesTransformationContext, TContext>
+{
   private readonly inputValueTransformer: LeafValueTransformer;
   private readonly outputValueTransformer: LeafValueTransformer;
   private readonly resultVisitorMap: ResultVisitorMap;
@@ -67,7 +69,7 @@ export default class MapLeafValues implements Transform<MapLeafValuesTransformat
 
   public transformSchema(
     originalWrappingSchema: GraphQLSchema,
-    _subschemaConfig: SubschemaConfig,
+    _subschemaConfig: SubschemaConfig<any, any, any, TContext>,
     _transformedSchema?: GraphQLSchema
   ): GraphQLSchema {
     this.originalWrappingSchema = originalWrappingSchema;
@@ -86,7 +88,7 @@ export default class MapLeafValues implements Transform<MapLeafValuesTransformat
 
   public transformRequest(
     originalRequest: ExecutionRequest,
-    _delegationContext: DelegationContext,
+    _delegationContext: DelegationContext<TContext>,
     transformationContext: MapLeafValuesTransformationContext
   ): ExecutionRequest {
     const document = originalRequest.document;
@@ -117,7 +119,7 @@ export default class MapLeafValues implements Transform<MapLeafValuesTransformat
 
   public transformResult(
     originalResult: ExecutionResult,
-    _delegationContext: DelegationContext,
+    _delegationContext: DelegationContext<TContext>,
     transformationContext: MapLeafValuesTransformationContext
   ): ExecutionResult {
     return visitResult(

--- a/packages/wrap/src/transforms/PruneSchema.ts
+++ b/packages/wrap/src/transforms/PruneSchema.ts
@@ -4,7 +4,11 @@ import { PruneSchemaOptions, pruneSchema } from '@graphql-tools/utils';
 
 import { SubschemaConfig, Transform } from '@graphql-tools/delegate';
 
-export default class PruneTypes<T = any, TContext = Record<string, any>> implements Transform<T, TContext> {
+interface PruneTypesTransformationContext extends Record<string, any> {}
+
+export default class PruneTypes<TContext = Record<string, any>>
+  implements Transform<PruneTypesTransformationContext, TContext>
+{
   private readonly options: PruneSchemaOptions;
 
   constructor(options: PruneSchemaOptions = {}) {

--- a/packages/wrap/src/transforms/PruneSchema.ts
+++ b/packages/wrap/src/transforms/PruneSchema.ts
@@ -4,7 +4,7 @@ import { PruneSchemaOptions, pruneSchema } from '@graphql-tools/utils';
 
 import { SubschemaConfig, Transform } from '@graphql-tools/delegate';
 
-export default class PruneTypes implements Transform {
+export default class PruneTypes<T = any, TContext = Record<string, any>> implements Transform<T, TContext> {
   private readonly options: PruneSchemaOptions;
 
   constructor(options: PruneSchemaOptions = {}) {
@@ -13,7 +13,7 @@ export default class PruneTypes implements Transform {
 
   public transformSchema(
     originalWrappingSchema: GraphQLSchema,
-    _subschemaConfig: SubschemaConfig,
+    _subschemaConfig: SubschemaConfig<any, any, any, TContext>,
     _transformedSchema?: GraphQLSchema
   ): GraphQLSchema {
     return pruneSchema(originalWrappingSchema, this.options);

--- a/packages/wrap/src/transforms/RemoveObjectFieldDeprecations.ts
+++ b/packages/wrap/src/transforms/RemoveObjectFieldDeprecations.ts
@@ -7,9 +7,13 @@ import { SubschemaConfig, Transform } from '@graphql-tools/delegate';
 import FilterObjectFieldDirectives from './FilterObjectFieldDirectives';
 import TransformObjectFields from './TransformObjectFields';
 
-export default class RemoveObjectFieldDeprecations implements Transform {
-  private readonly removeDirectives: FilterObjectFieldDirectives;
-  private readonly removeDeprecations: TransformObjectFields;
+interface RemoveObjectFieldDeprecationsTransformationContext extends Record<string, any> {}
+
+export default class RemoveObjectFieldDeprecations<TContext = Record<string, any>>
+  implements Transform<RemoveObjectFieldDeprecationsTransformationContext, TContext>
+{
+  private readonly removeDirectives: FilterObjectFieldDirectives<TContext>;
+  private readonly removeDeprecations: TransformObjectFields<TContext>;
 
   constructor(reason: string | RegExp) {
     const args = { reason };
@@ -29,7 +33,7 @@ export default class RemoveObjectFieldDeprecations implements Transform {
 
   public transformSchema(
     originalWrappingSchema: GraphQLSchema,
-    subschemaConfig: SubschemaConfig,
+    subschemaConfig: SubschemaConfig<any, any, any, TContext>,
     transformedSchema?: GraphQLSchema
   ): GraphQLSchema {
     return this.removeDeprecations.transformSchema(

--- a/packages/wrap/src/transforms/RemoveObjectFieldDirectives.ts
+++ b/packages/wrap/src/transforms/RemoveObjectFieldDirectives.ts
@@ -6,8 +6,12 @@ import { SubschemaConfig, Transform } from '@graphql-tools/delegate';
 
 import FilterObjectFieldDirectives from './FilterObjectFieldDirectives';
 
-export default class RemoveObjectFieldDirectives implements Transform {
-  private readonly transformer: FilterObjectFieldDirectives;
+interface RemoveObjectFieldDirectivesTransformationContext extends Record<string, any> {}
+
+export default class RemoveObjectFieldDirectives<TContext = Record<string, any>>
+  implements Transform<RemoveObjectFieldDirectivesTransformationContext, TContext>
+{
+  private readonly transformer: FilterObjectFieldDirectives<TContext>;
 
   constructor(directiveName: string | RegExp, args: Record<string, any> = {}) {
     this.transformer = new FilterObjectFieldDirectives((dirName: string, dirValue: any) => {
@@ -17,7 +21,7 @@ export default class RemoveObjectFieldDirectives implements Transform {
 
   public transformSchema(
     originalWrappingSchema: GraphQLSchema,
-    subschemaConfig: SubschemaConfig,
+    subschemaConfig: SubschemaConfig<any, any, any, TContext>,
     transformedSchema?: GraphQLSchema
   ): GraphQLSchema {
     return this.transformer.transformSchema(originalWrappingSchema, subschemaConfig, transformedSchema);

--- a/packages/wrap/src/transforms/RemoveObjectFieldsWithDeprecation.ts
+++ b/packages/wrap/src/transforms/RemoveObjectFieldsWithDeprecation.ts
@@ -6,8 +6,12 @@ import { SubschemaConfig, Transform } from '@graphql-tools/delegate';
 
 import FilterObjectFields from './FilterObjectFields';
 
-export default class RemoveObjectFieldsWithDeprecation implements Transform {
-  private readonly transformer: FilterObjectFields;
+interface RemoveObjectFieldsWithDeprecationTransformationContext extends Record<string, any> {}
+
+export default class RemoveObjectFieldsWithDeprecation<TContext = Record<string, any>>
+  implements Transform<RemoveObjectFieldsWithDeprecationTransformationContext, TContext>
+{
+  private readonly transformer: FilterObjectFields<TContext>;
 
   constructor(reason: string | RegExp) {
     this.transformer = new FilterObjectFields((_typeName, _fieldName, fieldConfig) => {
@@ -20,7 +24,7 @@ export default class RemoveObjectFieldsWithDeprecation implements Transform {
 
   public transformSchema(
     originalWrappingSchema: GraphQLSchema,
-    subschemaConfig: SubschemaConfig,
+    subschemaConfig: SubschemaConfig<any, any, any, TContext>,
     transformedSchema?: GraphQLSchema
   ): GraphQLSchema {
     return this.transformer.transformSchema(originalWrappingSchema, subschemaConfig, transformedSchema);

--- a/packages/wrap/src/transforms/RemoveObjectFieldsWithDirective.ts
+++ b/packages/wrap/src/transforms/RemoveObjectFieldsWithDirective.ts
@@ -6,7 +6,11 @@ import { SubschemaConfig, Transform } from '@graphql-tools/delegate';
 
 import FilterObjectFields from './FilterObjectFields';
 
-export default class RemoveObjectFieldsWithDirective implements Transform {
+interface RemoveObjectFieldsWithDirectiveTransformationContext extends Record<string, any> {}
+
+export default class RemoveObjectFieldsWithDirective<TContext = Record<string, any>>
+  implements Transform<RemoveObjectFieldsWithDirectiveTransformationContext, TContext>
+{
   private readonly directiveName: string | RegExp;
   private readonly args: Record<string, any>;
 
@@ -17,10 +21,10 @@ export default class RemoveObjectFieldsWithDirective implements Transform {
 
   public transformSchema(
     originalWrappingSchema: GraphQLSchema,
-    subschemaConfig: SubschemaConfig,
+    subschemaConfig: SubschemaConfig<any, any, any, TContext>,
     transformedSchema?: GraphQLSchema
   ): GraphQLSchema {
-    const transformer = new FilterObjectFields((_typeName, _fieldName, fieldConfig) => {
+    const transformer = new FilterObjectFields<TContext>((_typeName, _fieldName, fieldConfig) => {
       const directives = getDirectives(originalWrappingSchema, fieldConfig);
       return !directives.some(
         directive =>

--- a/packages/wrap/src/transforms/RenameInputObjectFields.ts
+++ b/packages/wrap/src/transforms/RenameInputObjectFields.ts
@@ -12,9 +12,13 @@ type RenamerFunction = (
   inputFieldConfig: GraphQLInputFieldConfig
 ) => string | undefined;
 
-export default class RenameInputObjectFields implements Transform {
+interface RenameInputObjectFieldsTransformationContext extends Record<string, any> {}
+
+export default class RenameInputObjectFields<TContext = Record<string, any>>
+  implements Transform<RenameInputObjectFieldsTransformationContext, TContext>
+{
   private readonly renamer: RenamerFunction;
-  private readonly transformer: TransformInputObjectFields;
+  private readonly transformer: TransformInputObjectFields<TContext>;
   private reverseMap: Record<string, Record<string, string>>;
 
   constructor(renamer: RenamerFunction) {
@@ -53,7 +57,7 @@ export default class RenameInputObjectFields implements Transform {
 
   public transformSchema(
     originalWrappingSchema: GraphQLSchema,
-    subschemaConfig: SubschemaConfig,
+    subschemaConfig: SubschemaConfig<any, any, any, TContext>,
     transformedSchema?: GraphQLSchema
   ): GraphQLSchema {
     mapSchema(originalWrappingSchema, {
@@ -82,8 +86,8 @@ export default class RenameInputObjectFields implements Transform {
 
   public transformRequest(
     originalRequest: ExecutionRequest,
-    delegationContext: DelegationContext,
-    transformationContext: Record<string, any>
+    delegationContext: DelegationContext<TContext>,
+    transformationContext: RenameInputObjectFieldsTransformationContext
   ): ExecutionRequest {
     return this.transformer.transformRequest(originalRequest, delegationContext, transformationContext);
   }

--- a/packages/wrap/src/transforms/RenameInterfaceFields.ts
+++ b/packages/wrap/src/transforms/RenameInterfaceFields.ts
@@ -6,8 +6,12 @@ import { Transform, DelegationContext, SubschemaConfig } from '@graphql-tools/de
 
 import TransformInterfaceFields from './TransformInterfaceFields';
 
-export default class RenameInterfaceFields implements Transform {
-  private readonly transformer: TransformInterfaceFields;
+interface RenameInterfaceFieldsTransformationContext extends Record<string, any> {}
+
+export default class RenameInterfaceFields<TContext = Record<string, any>>
+  implements Transform<RenameInterfaceFieldsTransformationContext, TContext>
+{
+  private readonly transformer: TransformInterfaceFields<TContext>;
 
   constructor(renamer: (typeName: string, fieldName: string, fieldConfig: GraphQLFieldConfig<any, any>) => string) {
     this.transformer = new TransformInterfaceFields(
@@ -20,7 +24,7 @@ export default class RenameInterfaceFields implements Transform {
 
   public transformSchema(
     originalWrappingSchema: GraphQLSchema,
-    subschemaConfig: SubschemaConfig,
+    subschemaConfig: SubschemaConfig<any, any, any, TContext>,
     transformedSchema?: GraphQLSchema
   ): GraphQLSchema {
     return this.transformer.transformSchema(originalWrappingSchema, subschemaConfig, transformedSchema);
@@ -28,8 +32,8 @@ export default class RenameInterfaceFields implements Transform {
 
   public transformRequest(
     originalRequest: ExecutionRequest,
-    delegationContext: DelegationContext,
-    transformationContext: Record<string, any>
+    delegationContext: DelegationContext<TContext>,
+    transformationContext: RenameInterfaceFieldsTransformationContext
   ): ExecutionRequest {
     return this.transformer.transformRequest(originalRequest, delegationContext, transformationContext);
   }

--- a/packages/wrap/src/transforms/RenameObjectFields.ts
+++ b/packages/wrap/src/transforms/RenameObjectFields.ts
@@ -6,8 +6,12 @@ import { Transform, DelegationContext, SubschemaConfig } from '@graphql-tools/de
 
 import TransformObjectFields from './TransformObjectFields';
 
-export default class RenameObjectFields implements Transform {
-  private readonly transformer: TransformObjectFields;
+interface RenameObjectFieldsTransformationContext extends Record<string, any> {}
+
+export default class RenameObjectFields<TContext = Record<string, any>>
+  implements Transform<RenameObjectFieldsTransformationContext, TContext>
+{
+  private readonly transformer: TransformObjectFields<TContext>;
 
   constructor(renamer: (typeName: string, fieldName: string, fieldConfig: GraphQLFieldConfig<any, any>) => string) {
     this.transformer = new TransformObjectFields(
@@ -20,7 +24,7 @@ export default class RenameObjectFields implements Transform {
 
   public transformSchema(
     originalWrappingSchema: GraphQLSchema,
-    subschemaConfig: SubschemaConfig,
+    subschemaConfig: SubschemaConfig<any, any, any, TContext>,
     transformedSchema?: GraphQLSchema
   ): GraphQLSchema {
     return this.transformer.transformSchema(originalWrappingSchema, subschemaConfig, transformedSchema);
@@ -28,8 +32,8 @@ export default class RenameObjectFields implements Transform {
 
   public transformRequest(
     originalRequest: ExecutionRequest,
-    delegationContext: DelegationContext,
-    transformationContext: Record<string, any>
+    delegationContext: DelegationContext<TContext>,
+    transformationContext: RenameObjectFieldsTransformationContext
   ): ExecutionRequest {
     return this.transformer.transformRequest(originalRequest, delegationContext, transformationContext);
   }

--- a/packages/wrap/src/transforms/RenameRootFields.ts
+++ b/packages/wrap/src/transforms/RenameRootFields.ts
@@ -6,8 +6,12 @@ import { Transform, DelegationContext, SubschemaConfig } from '@graphql-tools/de
 
 import TransformRootFields from './TransformRootFields';
 
-export default class RenameRootFields implements Transform {
-  private readonly transformer: TransformRootFields;
+interface RenameRootFieldsTransformationContext extends Record<string, any> {}
+
+export default class RenameRootFields<TContext = Record<string, any>>
+  implements Transform<RenameRootFieldsTransformationContext, TContext>
+{
+  private readonly transformer: TransformRootFields<TContext>;
 
   constructor(
     renamer: (
@@ -27,7 +31,7 @@ export default class RenameRootFields implements Transform {
 
   public transformSchema(
     originalWrappingSchema: GraphQLSchema,
-    subschemaConfig: SubschemaConfig,
+    subschemaConfig: SubschemaConfig<any, any, any, TContext>,
     transformedSchema?: GraphQLSchema
   ): GraphQLSchema {
     return this.transformer.transformSchema(originalWrappingSchema, subschemaConfig, transformedSchema);
@@ -35,8 +39,8 @@ export default class RenameRootFields implements Transform {
 
   public transformRequest(
     originalRequest: ExecutionRequest,
-    delegationContext: DelegationContext,
-    transformationContext: Record<string, any>
+    delegationContext: DelegationContext<TContext>,
+    transformationContext: RenameRootFieldsTransformationContext
   ): ExecutionRequest {
     return this.transformer.transformRequest(originalRequest, delegationContext, transformationContext);
   }

--- a/packages/wrap/src/transforms/RenameRootTypes.ts
+++ b/packages/wrap/src/transforms/RenameRootTypes.ts
@@ -4,7 +4,11 @@ import { ExecutionRequest, ExecutionResult, MapperKind, mapSchema, renameType, v
 
 import { Transform, DelegationContext, SubschemaConfig } from '@graphql-tools/delegate';
 
-export default class RenameRootTypes implements Transform {
+interface RenameRootTypesTransformationContext extends Record<string, any> {}
+
+export default class RenameRootTypes<TContext = Record<string, any>>
+  implements Transform<RenameRootTypesTransformationContext, TContext>
+{
   private readonly renamer: (name: string) => string | undefined;
   private map: Record<string, string>;
   private reverseMap: Record<string, string>;
@@ -17,7 +21,7 @@ export default class RenameRootTypes implements Transform {
 
   public transformSchema(
     originalWrappingSchema: GraphQLSchema,
-    _subschemaConfig: SubschemaConfig,
+    _subschemaConfig: SubschemaConfig<any, any, any, TContext>,
     _transformedSchema?: GraphQLSchema
   ): GraphQLSchema {
     return mapSchema(originalWrappingSchema, {
@@ -36,8 +40,8 @@ export default class RenameRootTypes implements Transform {
 
   public transformRequest(
     originalRequest: ExecutionRequest,
-    _delegationContext: DelegationContext,
-    _transformationContext: Record<string, any>
+    _delegationContext: DelegationContext<TContext>,
+    _transformationContext: RenameRootTypesTransformationContext
   ): ExecutionRequest {
     const document = visit(originalRequest.document, {
       [Kind.NAMED_TYPE]: (node: NamedTypeNode) => {
@@ -61,8 +65,8 @@ export default class RenameRootTypes implements Transform {
 
   public transformResult(
     originalResult: ExecutionResult,
-    _delegationContext: DelegationContext,
-    _transformationContext?: Record<string, any>
+    _delegationContext: DelegationContext<TContext>,
+    _transformationContext?: RenameRootTypesTransformationContext
   ): ExecutionResult {
     return {
       ...originalResult,

--- a/packages/wrap/src/transforms/RenameTypes.ts
+++ b/packages/wrap/src/transforms/RenameTypes.ts
@@ -20,7 +20,11 @@ import {
 
 import { Transform, DelegationContext, SubschemaConfig } from '@graphql-tools/delegate';
 
-export default class RenameTypes implements Transform {
+interface RenameTypesTransformationContext extends Record<string, any> {}
+
+export default class RenameTypes<TContext = Record<string, any>>
+  implements Transform<RenameTypesTransformationContext, TContext>
+{
   private readonly renamer: (name: string) => string | undefined;
   private map: Record<string, string>;
   private reverseMap: Record<string, string>;
@@ -38,7 +42,7 @@ export default class RenameTypes implements Transform {
 
   public transformSchema(
     originalWrappingSchema: GraphQLSchema,
-    _subschemaConfig: SubschemaConfig,
+    _subschemaConfig: SubschemaConfig<any, any, any, TContext>,
     _transformedSchema?: GraphQLSchema
   ): GraphQLSchema {
     return mapSchema(originalWrappingSchema, {
@@ -67,8 +71,8 @@ export default class RenameTypes implements Transform {
 
   public transformRequest(
     originalRequest: ExecutionRequest,
-    _delegationContext: DelegationContext,
-    _transformationContext: Record<string, any>
+    _delegationContext: DelegationContext<TContext>,
+    _transformationContext: RenameTypesTransformationContext
   ): ExecutionRequest {
     const document = visit(originalRequest.document, {
       [Kind.NAMED_TYPE]: (node: NamedTypeNode) => {
@@ -93,8 +97,8 @@ export default class RenameTypes implements Transform {
 
   public transformResult(
     originalResult: ExecutionResult,
-    _delegationContext: DelegationContext,
-    _transformationContext?: Record<string, any>
+    _delegationContext: DelegationContext<TContext>,
+    _transformationContext?: RenameTypesTransformationContext
   ): ExecutionResult {
     return {
       ...originalResult,

--- a/packages/wrap/src/transforms/TransformCompositeFields.ts
+++ b/packages/wrap/src/transforms/TransformCompositeFields.ts
@@ -18,7 +18,7 @@ import { Transform, DelegationContext, SubschemaConfig } from '@graphql-tools/de
 import { FieldTransformer, FieldNodeTransformer, DataTransformer, ErrorsTransformer } from '../types';
 
 export default class TransformCompositeFields<TContext = Record<string, any>> implements Transform<any, TContext> {
-  private readonly fieldTransformer: FieldTransformer;
+  private readonly fieldTransformer: FieldTransformer<TContext>;
   private readonly fieldNodeTransformer: FieldNodeTransformer | undefined;
   private readonly dataTransformer: DataTransformer | undefined;
   private readonly errorsTransformer: ErrorsTransformer | undefined;
@@ -28,7 +28,7 @@ export default class TransformCompositeFields<TContext = Record<string, any>> im
   private subscriptionTypeName: string | undefined;
 
   constructor(
-    fieldTransformer: FieldTransformer,
+    fieldTransformer: FieldTransformer<TContext>,
     fieldNodeTransformer?: FieldNodeTransformer,
     dataTransformer?: DataTransformer,
     errorsTransformer?: ErrorsTransformer

--- a/packages/wrap/src/transforms/TransformCompositeFields.ts
+++ b/packages/wrap/src/transforms/TransformCompositeFields.ts
@@ -17,7 +17,11 @@ import { Transform, DelegationContext, SubschemaConfig } from '@graphql-tools/de
 
 import { FieldTransformer, FieldNodeTransformer, DataTransformer, ErrorsTransformer } from '../types';
 
-export default class TransformCompositeFields<TContext = Record<string, any>> implements Transform<any, TContext> {
+interface TransformCompositeFieldsTransformationContext extends Record<string, any> {}
+
+export default class TransformCompositeFields<TContext = Record<string, any>>
+  implements Transform<TransformCompositeFieldsTransformationContext, TContext>
+{
   private readonly fieldTransformer: FieldTransformer<TContext>;
   private readonly fieldNodeTransformer: FieldNodeTransformer | undefined;
   private readonly dataTransformer: DataTransformer | undefined;
@@ -79,8 +83,8 @@ export default class TransformCompositeFields<TContext = Record<string, any>> im
 
   public transformRequest(
     originalRequest: ExecutionRequest,
-    _delegationContext: DelegationContext,
-    transformationContext: Record<string, any>
+    _delegationContext: DelegationContext<TContext>,
+    transformationContext: TransformCompositeFieldsTransformationContext
   ): ExecutionRequest {
     const document = originalRequest.document;
     return {
@@ -91,8 +95,8 @@ export default class TransformCompositeFields<TContext = Record<string, any>> im
 
   public transformResult(
     result: ExecutionResult,
-    _delegationContext: DelegationContext,
-    transformationContext: Record<string, any>
+    _delegationContext: DelegationContext<TContext>,
+    transformationContext: TransformCompositeFieldsTransformationContext
   ): ExecutionResult {
     const dataTransformer = this.dataTransformer;
     if (dataTransformer != null) {

--- a/packages/wrap/src/transforms/TransformEnumValues.ts
+++ b/packages/wrap/src/transforms/TransformEnumValues.ts
@@ -8,9 +8,13 @@ import { EnumValueTransformer, LeafValueTransformer } from '../types';
 
 import MapLeafValues, { MapLeafValuesTransformationContext } from './MapLeafValues';
 
-export default class TransformEnumValues implements Transform<MapLeafValuesTransformationContext> {
+interface TransformEnumValuesTransformationContext extends MapLeafValuesTransformationContext {}
+
+export default class TransformEnumValues<TContext = Record<string, any>>
+  implements Transform<TransformEnumValuesTransformationContext, TContext>
+{
   private readonly enumValueTransformer: EnumValueTransformer;
-  private readonly transformer: MapLeafValues;
+  private readonly transformer: MapLeafValues<TContext>;
   private transformedSchema: GraphQLSchema | undefined;
   private mapping: Record<string, Record<string, string>>;
   private reverseMapping: Record<string, Record<string, string>>;
@@ -31,7 +35,7 @@ export default class TransformEnumValues implements Transform<MapLeafValuesTrans
 
   public transformSchema(
     originalWrappingSchema: GraphQLSchema,
-    subschemaConfig: SubschemaConfig,
+    subschemaConfig: SubschemaConfig<any, any, any, TContext>,
     transformedSchema?: GraphQLSchema
   ): GraphQLSchema {
     const mappingSchema = this.transformer.transformSchema(originalWrappingSchema, subschemaConfig, transformedSchema);
@@ -44,16 +48,16 @@ export default class TransformEnumValues implements Transform<MapLeafValuesTrans
 
   public transformRequest(
     originalRequest: ExecutionRequest,
-    delegationContext: DelegationContext,
-    transformationContext: MapLeafValuesTransformationContext
+    delegationContext: DelegationContext<TContext>,
+    transformationContext: TransformEnumValuesTransformationContext
   ): ExecutionRequest {
     return this.transformer.transformRequest(originalRequest, delegationContext, transformationContext);
   }
 
   public transformResult(
     originalResult: ExecutionResult,
-    delegationContext: DelegationContext,
-    transformationContext: MapLeafValuesTransformationContext
+    delegationContext: DelegationContext<TContext>,
+    transformationContext: TransformEnumValuesTransformationContext
   ) {
     return this.transformer.transformResult(originalResult, delegationContext, transformationContext);
   }

--- a/packages/wrap/src/transforms/TransformInputObjectFields.ts
+++ b/packages/wrap/src/transforms/TransformInputObjectFields.ts
@@ -21,7 +21,11 @@ import { Transform, DelegationContext, SubschemaConfig } from '@graphql-tools/de
 
 import { InputFieldTransformer, InputFieldNodeTransformer, InputObjectNodeTransformer } from '../types';
 
-export default class TransformInputObjectFields implements Transform {
+interface TransformInputObjectFieldsTransformationContext extends Record<string, any> {}
+
+export default class TransformInputObjectFields<TContext = Record<string, any>>
+  implements Transform<TransformInputObjectFieldsTransformationContext, TContext>
+{
   private readonly inputFieldTransformer: InputFieldTransformer;
   private readonly inputFieldNodeTransformer: InputFieldNodeTransformer | undefined;
   private readonly inputObjectNodeTransformer: InputObjectNodeTransformer | undefined;
@@ -51,7 +55,7 @@ export default class TransformInputObjectFields implements Transform {
 
   public transformSchema(
     originalWrappingSchema: GraphQLSchema,
-    _subschemaConfig: SubschemaConfig,
+    _subschemaConfig: SubschemaConfig<any, any, any, TContext>,
     _transformedSchema?: GraphQLSchema
   ): GraphQLSchema {
     this.transformedSchema = mapSchema(originalWrappingSchema, {
@@ -76,8 +80,8 @@ export default class TransformInputObjectFields implements Transform {
 
   public transformRequest(
     originalRequest: ExecutionRequest,
-    delegationContext: DelegationContext,
-    _transformationContext: Record<string, any>
+    delegationContext: DelegationContext<TContext>,
+    _transformationContext: TransformInputObjectFieldsTransformationContext
   ): ExecutionRequest {
     const variableValues = originalRequest.variables ?? {};
     const fragments = Object.create(null);
@@ -151,7 +155,7 @@ export default class TransformInputObjectFields implements Transform {
     inputFieldNodeTransformer: InputFieldNodeTransformer | undefined,
     inputObjectNodeTransformer: InputObjectNodeTransformer | undefined,
     request: ExecutionRequest,
-    delegationContext?: DelegationContext
+    delegationContext?: DelegationContext<TContext>
   ): DocumentNode {
     const typeInfo = new TypeInfo(this._getTransformedSchema());
     const newDocument: DocumentNode = visit(

--- a/packages/wrap/src/transforms/TransformObjectFields.ts
+++ b/packages/wrap/src/transforms/TransformObjectFields.ts
@@ -8,7 +8,11 @@ import { FieldTransformer, FieldNodeTransformer } from '../types';
 
 import TransformCompositeFields from './TransformCompositeFields';
 
-export default class TransformObjectFields<T = any, TContext = Record<string, any>> implements Transform<T, TContext> {
+interface TransformObjectFieldsTransformationContext extends Record<string, any> {}
+
+export default class TransformObjectFields<TContext = Record<string, any>>
+  implements Transform<TransformObjectFieldsTransformationContext, TContext>
+{
   private readonly objectFieldTransformer: FieldTransformer<TContext>;
   private readonly fieldNodeTransformer: FieldNodeTransformer | undefined;
   private transformer: TransformCompositeFields<TContext> | undefined;
@@ -55,16 +59,16 @@ export default class TransformObjectFields<T = any, TContext = Record<string, an
 
   public transformRequest(
     originalRequest: ExecutionRequest,
-    delegationContext: DelegationContext,
-    transformationContext: Record<string, any>
+    delegationContext: DelegationContext<TContext>,
+    transformationContext: TransformObjectFieldsTransformationContext
   ): ExecutionRequest {
     return this._getTransformer().transformRequest(originalRequest, delegationContext, transformationContext);
   }
 
   public transformResult(
     originalResult: ExecutionResult,
-    delegationContext: DelegationContext,
-    transformationContext: Record<string, any>
+    delegationContext: DelegationContext<TContext>,
+    transformationContext: TransformObjectFieldsTransformationContext
   ): ExecutionResult {
     return this._getTransformer().transformResult(originalResult, delegationContext, transformationContext);
   }

--- a/packages/wrap/src/transforms/TransformObjectFields.ts
+++ b/packages/wrap/src/transforms/TransformObjectFields.ts
@@ -8,12 +8,12 @@ import { FieldTransformer, FieldNodeTransformer } from '../types';
 
 import TransformCompositeFields from './TransformCompositeFields';
 
-export default class TransformObjectFields implements Transform {
-  private readonly objectFieldTransformer: FieldTransformer;
+export default class TransformObjectFields<T = any, TContext = Record<string, any>> implements Transform<T, TContext> {
+  private readonly objectFieldTransformer: FieldTransformer<TContext>;
   private readonly fieldNodeTransformer: FieldNodeTransformer | undefined;
-  private transformer: TransformCompositeFields | undefined;
+  private transformer: TransformCompositeFields<TContext> | undefined;
 
-  constructor(objectFieldTransformer: FieldTransformer, fieldNodeTransformer?: FieldNodeTransformer) {
+  constructor(objectFieldTransformer: FieldTransformer<TContext>, fieldNodeTransformer?: FieldNodeTransformer) {
     this.objectFieldTransformer = objectFieldTransformer;
     this.fieldNodeTransformer = fieldNodeTransformer;
   }
@@ -30,13 +30,13 @@ export default class TransformObjectFields implements Transform {
 
   public transformSchema(
     originalWrappingSchema: GraphQLSchema,
-    subschemaConfig: SubschemaConfig,
+    subschemaConfig: SubschemaConfig<any, any, any, TContext>,
     transformedSchema?: GraphQLSchema
   ): GraphQLSchema {
     const compositeToObjectFieldTransformer = (
       typeName: string,
       fieldName: string,
-      fieldConfig: GraphQLFieldConfig<any, any>
+      fieldConfig: GraphQLFieldConfig<any, TContext>
     ) => {
       if (isObjectType(originalWrappingSchema.getType(typeName))) {
         return this.objectFieldTransformer(typeName, fieldName, fieldConfig);
@@ -45,7 +45,10 @@ export default class TransformObjectFields implements Transform {
       return undefined;
     };
 
-    this.transformer = new TransformCompositeFields(compositeToObjectFieldTransformer, this.fieldNodeTransformer);
+    this.transformer = new TransformCompositeFields<TContext>(
+      compositeToObjectFieldTransformer,
+      this.fieldNodeTransformer
+    );
 
     return this.transformer.transformSchema(originalWrappingSchema, subschemaConfig, transformedSchema);
   }

--- a/packages/wrap/src/transforms/TransformRootFields.ts
+++ b/packages/wrap/src/transforms/TransformRootFields.ts
@@ -8,10 +8,14 @@ import { RootFieldTransformer, FieldNodeTransformer } from '../types';
 
 import TransformObjectFields from './TransformObjectFields';
 
-export default class TransformRootFields<T = any, TContext = Record<string, any>> implements Transform<T, TContext> {
+interface TransformRootFieldsTransformationContext extends Record<string, any> {}
+
+export default class TransformRootFields<TContext = Record<string, any>>
+  implements Transform<TransformRootFieldsTransformationContext, TContext>
+{
   private readonly rootFieldTransformer: RootFieldTransformer<TContext>;
   private readonly fieldNodeTransformer: FieldNodeTransformer | undefined;
-  private transformer: TransformObjectFields<T, TContext> | undefined;
+  private transformer: TransformObjectFields<TContext> | undefined;
 
   constructor(rootFieldTransformer: RootFieldTransformer<TContext>, fieldNodeTransformer?: FieldNodeTransformer) {
     this.rootFieldTransformer = rootFieldTransformer;
@@ -53,23 +57,23 @@ export default class TransformRootFields<T = any, TContext = Record<string, any>
       return undefined;
     };
 
-    this.transformer = new TransformObjectFields<T, TContext>(rootToObjectFieldTransformer, this.fieldNodeTransformer);
+    this.transformer = new TransformObjectFields(rootToObjectFieldTransformer, this.fieldNodeTransformer);
 
     return this.transformer.transformSchema(originalWrappingSchema, subschemaConfig, transformedSchema);
   }
 
   public transformRequest(
     originalRequest: ExecutionRequest,
-    delegationContext: DelegationContext,
-    transformationContext: Record<string, any>
+    delegationContext: DelegationContext<TContext>,
+    transformationContext: TransformRootFieldsTransformationContext
   ): ExecutionRequest {
     return this._getTransformer().transformRequest(originalRequest, delegationContext, transformationContext);
   }
 
   public transformResult(
     originalResult: ExecutionResult,
-    delegationContext: DelegationContext,
-    transformationContext: Record<string, any>
+    delegationContext: DelegationContext<TContext>,
+    transformationContext: TransformRootFieldsTransformationContext
   ): ExecutionResult {
     return this._getTransformer().transformResult(originalResult, delegationContext, transformationContext);
   }

--- a/packages/wrap/src/transforms/TransformRootFields.ts
+++ b/packages/wrap/src/transforms/TransformRootFields.ts
@@ -8,12 +8,12 @@ import { RootFieldTransformer, FieldNodeTransformer } from '../types';
 
 import TransformObjectFields from './TransformObjectFields';
 
-export default class TransformRootFields implements Transform {
-  private readonly rootFieldTransformer: RootFieldTransformer;
+export default class TransformRootFields<T = any, TContext = Record<string, any>> implements Transform<T, TContext> {
+  private readonly rootFieldTransformer: RootFieldTransformer<TContext>;
   private readonly fieldNodeTransformer: FieldNodeTransformer | undefined;
-  private transformer: TransformObjectFields | undefined;
+  private transformer: TransformObjectFields<T, TContext> | undefined;
 
-  constructor(rootFieldTransformer: RootFieldTransformer, fieldNodeTransformer?: FieldNodeTransformer) {
+  constructor(rootFieldTransformer: RootFieldTransformer<TContext>, fieldNodeTransformer?: FieldNodeTransformer) {
     this.rootFieldTransformer = rootFieldTransformer;
     this.fieldNodeTransformer = fieldNodeTransformer;
   }
@@ -30,7 +30,7 @@ export default class TransformRootFields implements Transform {
 
   public transformSchema(
     originalWrappingSchema: GraphQLSchema,
-    subschemaConfig: SubschemaConfig,
+    subschemaConfig: SubschemaConfig<any, any, any, TContext>,
     transformedSchema?: GraphQLSchema
   ): GraphQLSchema {
     const rootToObjectFieldTransformer = (
@@ -53,7 +53,7 @@ export default class TransformRootFields implements Transform {
       return undefined;
     };
 
-    this.transformer = new TransformObjectFields(rootToObjectFieldTransformer, this.fieldNodeTransformer);
+    this.transformer = new TransformObjectFields<T, TContext>(rootToObjectFieldTransformer, this.fieldNodeTransformer);
 
     return this.transformer.transformSchema(originalWrappingSchema, subschemaConfig, transformedSchema);
   }

--- a/packages/wrap/src/transforms/WrapFields.ts
+++ b/packages/wrap/src/transforms/WrapFields.ts
@@ -155,7 +155,7 @@ export default class WrapFields<TContext> implements Transform<WrapFieldsTransfo
 
   public transformRequest(
     originalRequest: ExecutionRequest,
-    delegationContext: DelegationContext,
+    delegationContext: DelegationContext<TContext>,
     transformationContext: WrapFieldsTransformationContext
   ): ExecutionRequest {
     transformationContext.nextIndex = 0;
@@ -165,7 +165,7 @@ export default class WrapFields<TContext> implements Transform<WrapFieldsTransfo
 
   public transformResult(
     originalResult: ExecutionResult,
-    delegationContext: DelegationContext,
+    delegationContext: DelegationContext<TContext>,
     transformationContext: WrapFieldsTransformationContext
   ): ExecutionResult {
     return this.transformer.transformResult(originalResult, delegationContext, transformationContext);

--- a/packages/wrap/src/transforms/WrapQuery.ts
+++ b/packages/wrap/src/transforms/WrapQuery.ts
@@ -6,7 +6,11 @@ import { Transform, DelegationContext } from '@graphql-tools/delegate';
 
 export type QueryWrapper = (subtree: SelectionSetNode) => SelectionNode | SelectionSetNode;
 
-export default class WrapQuery implements Transform {
+interface WrapQueryTransformationContext extends Record<string, any> {}
+
+export default class WrapQuery<TContext = Record<string, any>>
+  implements Transform<WrapQueryTransformationContext, TContext>
+{
   private readonly wrapper: QueryWrapper;
   private readonly extractor: (result: any) => any;
   private readonly path: Array<string>;
@@ -19,8 +23,8 @@ export default class WrapQuery implements Transform {
 
   public transformRequest(
     originalRequest: ExecutionRequest,
-    _delegationContext: DelegationContext,
-    _transformationContext: Record<string, any>
+    _delegationContext: DelegationContext<TContext>,
+    _transformationContext: WrapQueryTransformationContext
   ): ExecutionRequest {
     const fieldPath: Array<string> = [];
     const ourPath = JSON.stringify(this.path);
@@ -60,8 +64,8 @@ export default class WrapQuery implements Transform {
 
   public transformResult(
     originalResult: ExecutionResult,
-    _delegationContext: DelegationContext,
-    _transformationContext: Record<string, any>
+    _delegationContext: DelegationContext<TContext>,
+    _transformationContext: WrapQueryTransformationContext
   ): ExecutionResult {
     const rootData = originalResult.data;
     if (rootData != null) {

--- a/packages/wrap/src/transforms/WrapType.ts
+++ b/packages/wrap/src/transforms/WrapType.ts
@@ -6,8 +6,12 @@ import { Transform, DelegationContext, SubschemaConfig } from '@graphql-tools/de
 
 import WrapFields from './WrapFields';
 
-export default class WrapType implements Transform {
-  private readonly transformer: WrapFields<any>;
+interface WrapTypeTransformationContext extends Record<string, any> {}
+
+export default class WrapType<TContext = Record<string, any>>
+  implements Transform<WrapTypeTransformationContext, TContext>
+{
+  private readonly transformer: WrapFields<TContext>;
 
   constructor(outerTypeName: string, innerTypeName: string, fieldName: string) {
     this.transformer = new WrapFields(outerTypeName, [fieldName], [innerTypeName]);
@@ -15,7 +19,7 @@ export default class WrapType implements Transform {
 
   public transformSchema(
     originalWrappingSchema: GraphQLSchema,
-    subschemaConfig: SubschemaConfig,
+    subschemaConfig: SubschemaConfig<any, any, any, TContext>,
     transformedSchema?: GraphQLSchema
   ): GraphQLSchema {
     return this.transformer.transformSchema(originalWrappingSchema, subschemaConfig, transformedSchema);
@@ -23,16 +27,16 @@ export default class WrapType implements Transform {
 
   public transformRequest(
     originalRequest: ExecutionRequest,
-    delegationContext: DelegationContext,
-    transformationContext: Record<string, any>
+    delegationContext: DelegationContext<TContext>,
+    transformationContext: WrapTypeTransformationContext
   ): ExecutionRequest {
     return this.transformer.transformRequest(originalRequest, delegationContext, transformationContext as any);
   }
 
   public transformResult(
     originalResult: ExecutionResult,
-    delegationContext: DelegationContext,
-    transformationContext: Record<string, any>
+    delegationContext: DelegationContext<TContext>,
+    transformationContext: WrapTypeTransformationContext
   ): ExecutionResult {
     return this.transformer.transformResult(originalResult, delegationContext, transformationContext as any);
   }

--- a/packages/wrap/src/types.ts
+++ b/packages/wrap/src/types.ts
@@ -18,19 +18,19 @@ export type InputFieldTransformer = (
   inputFieldConfig: GraphQLInputFieldConfig
 ) => GraphQLInputFieldConfig | [string, GraphQLInputFieldConfig] | null | undefined;
 
-export type InputFieldNodeTransformer = (
+export type InputFieldNodeTransformer = <TContext>(
   typeName: string,
   fieldName: string,
   inputFieldNode: ObjectFieldNode,
   request: ExecutionRequest,
-  delegationContext?: DelegationContext
+  delegationContext?: DelegationContext<TContext>
 ) => ObjectFieldNode | Array<ObjectFieldNode>;
 
-export type InputObjectNodeTransformer = (
+export type InputObjectNodeTransformer = <TContext>(
   typeName: string,
   inputObjectNode: ObjectValueNode,
   request: ExecutionRequest,
-  delegationContext?: DelegationContext
+  delegationContext?: DelegationContext<TContext>
 ) => ObjectValueNode | undefined;
 
 export type FieldTransformer<TContext = Record<string, any>> = (


### PR DESCRIPTION

## Description

Changed typings to forward context correctly from stitch down to subschemas and from transformers to delegation context.

Related #4248 
Related #4249

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

![Screenshot 2022-02-16 at 16 39 04](https://user-images.githubusercontent.com/2785359/154306198-2a8c5029-fd57-4eb3-be2c-7e5f2069fc8e.png)

## How Has This Been Tested?

I linked locally to built folder in my project and tested that the types worked.

**Test Environment**:

- OS: Macos
- `@graphql-tools/...`:
- NodeJS: 14.18.2

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

None.