### PR TITLE
fix: use correct store in mockResolver

### DIFF
--- a/.changeset/thin-numbers-own.md
+++ b/.changeset/thin-numbers-own.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/mock': patch
+---
+
+Resolve an issue with addMocksToSchema where the provided store is ignored

--- a/packages/mock/src/addMocksToSchema.ts
+++ b/packages/mock/src/addMocksToSchema.ts
@@ -107,13 +107,11 @@ export function addMocksToSchema({
     throw new Error('mocks must be of type Object');
   }
 
-  const mockStore = createMockStore({
+  const store = maybeStore || createMockStore({
     schema,
     mocks,
     typePolicies,
   });
-
-  const store = maybeStore || mockStore;
 
   const resolvers =
     typeof resolversOrFnResolvers === 'function' ? resolversOrFnResolvers(store) : resolversOrFnResolvers;

--- a/packages/mock/src/addMocksToSchema.ts
+++ b/packages/mock/src/addMocksToSchema.ts
@@ -107,11 +107,13 @@ export function addMocksToSchema({
     throw new Error('mocks must be of type Object');
   }
 
-  const store = maybeStore || createMockStore({
-    schema,
-    mocks,
-    typePolicies,
-  });
+  const store =
+    maybeStore ||
+    createMockStore({
+      schema,
+      mocks,
+      typePolicies,
+    });
 
   const resolvers =
     typeof resolversOrFnResolvers === 'function' ? resolversOrFnResolvers(store) : resolversOrFnResolvers;

--- a/packages/mock/src/addMocksToSchema.ts
+++ b/packages/mock/src/addMocksToSchema.ts
@@ -146,7 +146,7 @@ export function addMocksToSchema({
 
     if (defaultResolvedValue === undefined) {
       // any is used here because generateFieldValue is a private method at time of writing
-      return (mockStore as any).generateFieldValue(info.parentType.name, info.fieldName);
+      return (store as any).generateFieldValue(info.parentType.name, info.fieldName);
     }
 
     return undefined;

--- a/packages/mock/tests/addMocksToSchema.spec.ts
+++ b/packages/mock/tests/addMocksToSchema.spec.ts
@@ -363,4 +363,29 @@ describe('addMocksToSchema', () => {
     maybeRef.$ref = {};
     expect(isRef(maybeRef)).toBeTruthy();
   });
+  it('resolves fields without defaultResolvedValue correctly', async () => {
+    const store = createMockStore({
+      schema,
+      mocks: {
+        String: () => 'custom mock for String',
+      },
+    });
+    const mockedSchema = addMocksToSchema({
+      schema,
+      store,
+      resolvers: {
+        Query: {
+          viewer: () => ({}),
+        },
+      },
+    });
+
+    const { data } = await graphql({
+      schema: mockedSchema,
+      source: `query { viewer { name }}`,
+    });
+    const viewer = data?.['viewer'] as any;
+
+    expect(viewer.name).toEqual('custom mock for String');
+  });
 });


### PR DESCRIPTION
_I've opened an [issue](https://github.com/ardatan/graphql-tools/issues/4155) about this more than a month ago._

## Description

`addMocksToSchema` accepts an optional `store`. When a `store` is not provided, a default store will be used. 

In some cases, the `mockResolver` defined in `addMocksToSchema` will still use the default store, even when a `store` option is provided to `addMocksToSchema`.

This PR adds a test for this use case and fixes the bug.

Related #4155

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

This repository reproduces the issue: https://github.com/lipsumar/repro-graphql-tools-mock-store-issue

## How Has This Been Tested?

A unit test is provided and will fail if the proposed change in `addMocksToSchema` is removed.

**Test Environment**:

- OS: Mac OS 11.6.2 (20G314)
- `@graphql-tools/mock`: latest (master / `8.5.2`)
- NodeJS: v16.4.2

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

This bug is a simple mistake, the variable `mockStore` was not meant to be used there, as there is no reason to use 2 different stores.
