### PR TITLE
Reproduce: Operation Name not forwarded to remote via stitchSchemas

### DIFF
--- a/packages/stitch/tests/stitchSchemas.test.ts
+++ b/packages/stitch/tests/stitchSchemas.test.ts
@@ -1510,6 +1510,45 @@ bookingById(id: "b1") {
         };
         expect(stitchedResult).toEqual(expected);
       });
+
+      test('forward operation name to stitched schema', async () => {
+        const operationNameFragment = /* GraphQL */ `
+operationNameTest {
+  testString
+}
+  `;
+
+        const localOperationName = 'MyLocalQuery';
+        const localResult = await graphql({
+          schema: localPropertySchema,
+          source: /* GraphQL */ `query ${localOperationName} { ${operationNameFragment} }`,
+        });
+        expect(localResult).toEqual({
+          data: {
+            operationNameTest: {
+              testString: localOperationName,
+            },
+          },
+        });
+
+        const stitchedOperationName = 'MyStitchedQuery';
+        const stitchedResult = await graphql({
+          schema: stitchedSchema,
+          source: /* GraphQL */ `
+              query ${stitchedOperationName} {
+                ${operationNameFragment}
+              }
+            `,
+        });
+
+        expect(stitchedResult).toEqual({
+          data: {
+            operationNameTest: {
+              testString: stitchedOperationName,
+            },
+          },
+        });
+      });
     });
 
     describe('fragments', () => {

--- a/packages/testing/fixtures/schemas.ts
+++ b/packages/testing/fixtures/schemas.ts
@@ -304,6 +304,7 @@ const propertyRootTypeDefs = /* GraphQL */ `
     errorTestNonNull: String!
     relay: Query!
     defaultInputTest(input: InputWithDefault!): String
+    operationNameTest: TestInterface!
   }
 `;
 
@@ -320,6 +321,14 @@ const propertyResolvers: IResolvers = {
   Query: {
     propertyById(_root, { id }) {
       return sampleData.Property[id];
+    },
+
+    operationNameTest(_root, _args, _context, info) {
+      const operationDefinition = info.operation.name;
+      if (operationDefinition !== undefined) {
+        return { testString: operationDefinition.value };
+      }
+      return { testString: null };
     },
 
     properties(_root, { limit }) {


### PR DESCRIPTION
## Description

Reproduces the issue described in issue _"Operation Name not forwarded to remote via stitchSchemas"_

Related #4293

> ## Type of change
> 
> Please delete options that are not relevant.
> 
> - [ ] Bug fix (non-breaking change which fixes an issue)
> - [ ] New feature (non-breaking change which adds functionality)
> - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
> - [ ] This change requires a documentation update
> 
> ## Screenshots/Sandbox (if appropriate/relevant):
> 
> Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate
> 
> ## How Has This Been Tested?
> 
> Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
> 
> - [ ] Test A
> - [ ] Test B
> 
> **Test Environment**:
> 
> - OS:
> - `@graphql-tools/...`:
> - NodeJS:
> 
> ## Checklist:
> 
> - [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
> - [ ] I have performed a self-review of my own code
> - [ ] I have commented my code, particularly in hard-to-understand areas
> - [ ] I have made corresponding changes to the documentation
> - [ ] My changes generate no new warnings
> - [ ] I have added tests that prove my fix is effective or that my feature works
> - [ ] New and existing unit tests and linter rules pass locally with my changes
> - [ ] Any dependent changes have been merged and published in downstream modules
> 
> ## Further comments
> 
> If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
> 