### PR TITLE
Allow empty selectionSet when calling TransformQuery#queryTransformer

### DIFF
--- a/packages/wrap/src/transforms/TransformQuery.ts
+++ b/packages/wrap/src/transforms/TransformQuery.ts
@@ -5,7 +5,7 @@ import { ExecutionRequest, ExecutionResult, relocatedError } from '@graphql-tool
 import { Transform, DelegationContext } from '@graphql-tools/delegate';
 
 export type QueryTransformer = <TContext>(
-  selectionSet: SelectionSetNode,
+  selectionSet: SelectionSetNode | undefined,
   fragments: Record<string, FragmentDefinitionNode>,
   delegationContext: DelegationContext<TContext>,
   transformationContext: Record<string, any>
@@ -60,7 +60,7 @@ export default class TransformQuery<TContext = Record<string, any>>
     const document = visit(originalRequest.document, {
       [Kind.FIELD]: {
         enter: node => {
-          if (index === pathLength || node.name.value !== this.path[index] || node.selectionSet == null) {
+          if (index === pathLength || node.name.value !== this.path[index]) {
             return false;
           }
 

--- a/packages/wrap/tests/transformTransformQuery.test.ts
+++ b/packages/wrap/tests/transformTransformQuery.test.ts
@@ -1,0 +1,95 @@
+import { execute, GraphQLSchema, Kind, OperationTypeNode, parse } from 'graphql';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { TransformQuery } from '@graphql-tools/wrap';
+import { QueryTransformer } from '@graphql-tools/wrap/src/transforms/TransformQuery';
+import { delegateToSchema } from '@graphql-tools/delegate';
+
+describe('TransformQuery', () => {
+  let data: any;
+  const queryTransformer: QueryTransformer = jest.fn(() => ({
+    kind: Kind.SELECTION_SET,
+    selections: [
+      {
+        kind: Kind.FIELD,
+        name: { kind: Kind.NAME, value: 'addressZip' },
+      },
+    ],
+  }));
+  let subschema: GraphQLSchema;
+  let schema: GraphQLSchema;
+  beforeAll(() => {
+    data = {
+      u1: {
+        id: 'user1',
+        addressStreetAddress: 'Windy Shore 21 A 7',
+        addressZip: '12345',
+      },
+    };
+    subschema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        type User {
+          id: ID!
+          addressStreetAddress: String
+          addressZip: String
+        }
+
+        type Query {
+          userById(id: ID!): User
+        }
+      `,
+      resolvers: {
+        Query: {
+          userById(_parent, { id }) {
+            return data[id];
+          },
+        },
+      },
+    });
+    schema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        type User {
+          id: ID!
+        }
+
+        type Query {
+          zipByUser(id: ID!): String
+        }
+      `,
+      resolvers: {
+        Query: {
+          zipByUser(_parent, { id }, context, info) {
+            return delegateToSchema({
+              schema: subschema,
+              operation: 'query' as OperationTypeNode,
+              fieldName: 'userById',
+              args: { id },
+              context,
+              info,
+              transforms: [
+                new TransformQuery({
+                  path: ['userById'],
+                  queryTransformer,
+                  resultTransformer: result => result.addressZip,
+                }),
+              ],
+            });
+          },
+        },
+      },
+    });
+  });
+
+  test('calls queryTransformer even when there is no subtree', async () => {
+    const result = await execute({
+      schema,
+      document: parse(/* GraphQL */ `
+        query {
+          zipByUser(id: "u1")
+        }
+      `),
+    });
+
+    expect(queryTransformer).toHaveBeenCalledWith(undefined, expect.anything(), expect.anything(), expect.anything());
+    expect(result).toEqual({ data: { zipByUser: '12345' } });
+  });
+});

--- a/packages/wrap/tests/transforms.test.ts
+++ b/packages/wrap/tests/transforms.test.ts
@@ -516,7 +516,7 @@ describe('transforms', () => {
                   new TransformQuery({
                     // path at which to apply wrapping and extracting
                     path: ['userById'],
-                    queryTransformer: (subtree: SelectionSetNode) => ({
+                    queryTransformer: (subtree: SelectionSetNode | undefined) => ({
                       kind: Kind.SELECTION_SET,
                       selections: [
                         {
@@ -552,7 +552,7 @@ describe('transforms', () => {
                   new TransformQuery({
                     // longer path, useful when transforming paginated results
                     path: ['usersByIds', 'nodes'],
-                    queryTransformer: (subtree: SelectionSetNode) => ({
+                    queryTransformer: (subtree: SelectionSetNode | undefined) => ({
                       // same query transformation as above
                       kind: Kind.SELECTION_SET,
                       selections: [
@@ -584,7 +584,7 @@ describe('transforms', () => {
                 transforms: [
                   new TransformQuery({
                     path: ['userById'],
-                    queryTransformer: (subtree: SelectionSetNode) => ({
+                    queryTransformer: (subtree: SelectionSetNode | undefined) => ({
                       kind: Kind.SELECTION_SET,
                       selections: [
                         {


### PR DESCRIPTION
## Description

This PR:
* adds a failing test showing that the prior code would not call queryTransformer when there is no selection set
* re-adds the functionality of `TransformQuery#queryTransformer` being called even when the `selectionSet` is empty

Related https://github.com/ardatan/graphql-tools/issues/4311

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Tough to say on this? It is a bug fix. Whether or not the change is breaking is fuzzy IMO. It's arguably a breaking change given that it makes the types _less_ strict, which may cause users with stricter types on their `queryTransformer` functions to see type errors.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Failing unit test

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules