### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/.changeset/pink-rivers-join.md
+++ b/.changeset/pink-rivers-join.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/graphql-tag-pluck': minor
+---
+
+refactor: replace deprecated String.prototype.substr()

--- a/packages/graphql-tag-pluck/src/utils.ts
+++ b/packages/graphql-tag-pluck/src/utils.ts
@@ -47,7 +47,7 @@ export const splitWords = (str: string) => {
 
 // upper -> Upper
 export const toUpperFirst = (str: string) => {
-  return str.substr(0, 1).toUpperCase() + str.substr(1).toLowerCase();
+  return str.slice(0, 1).toUpperCase() + str.slice(1).toLowerCase();
 };
 
 // foo-bar-baz -> fooBarBaz


### PR DESCRIPTION
## Description

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I have tested the output of the function to make sure it's the same as the current one

**Test Environment**:

- OS:
- `@graphql-tools/...`:
- NodeJS:

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

