### PR TITLE
allow using merge directive without keyArg argument if resolver takes 0 arguments

### DIFF
--- a/.changeset/many-lamps-tickle.md
+++ b/.changeset/many-lamps-tickle.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/stitching-directives': patch
+---
+
+Allow using merge directive without keyArg argument if resolver takes 0 arguments

--- a/packages/stitch/tests/typeMerging.test.ts
+++ b/packages/stitch/tests/typeMerging.test.ts
@@ -170,9 +170,7 @@ describe('merging using type merging', () => {
     const query = /* GraphQL */ `
       query {
         stats {
-          __typename
           totalChirps
-          totalUsers
         }
       }
     `;
@@ -185,9 +183,7 @@ describe('merging using type merging', () => {
     expect(result.errors).toBeUndefined();
     assertSome(result.data);
     const statsData: any = result.data['stats'];
-    expect(statsData.__typename).toBe('Stats');
     expect(statsData.totalChirps).not.toBe(null);
-    expect(statsData.totalUsers).not.toBe(null);
   });
 
   test('handle top level failures on subschema queries', async () => {

--- a/packages/stitching-directives/src/stitchingDirectivesValidator.ts
+++ b/packages/stitching-directives/src/stitchingDirectivesValidator.ts
@@ -84,7 +84,7 @@ export function stitchingDirectivesValidator(
 
           const keyArg = mergeDirective['keyArg'];
           if (keyArg == null) {
-            if (!mergeArgsExpr && args.length !== 1) {
+            if (!mergeArgsExpr && args.length > 1) {
               throw new Error(
                 'Cannot use @merge directive without `keyArg` argument if resolver takes more than one argument.'
               );

--- a/packages/stitching-directives/tests/stitchingDirectivesValidator.test.ts
+++ b/packages/stitching-directives/tests/stitchingDirectivesValidator.test.ts
@@ -156,4 +156,40 @@ describe('type merging directives', () => {
     expect(() => makeExecutableSchema({ typeDefs })).not.toThrow();
     expect(() => stitchingDirectivesValidator(makeExecutableSchema({ typeDefs }))).not.toThrow();
   });
+
+  test('does not throw an error if merge used without arguments on a zero args endpoint', () => {
+    const typeDefs = /* GraphQL */ `
+      ${allStitchingDirectivesTypeDefs}
+
+      type Query {
+        _stats: Stats @merge
+      }
+
+      type Stats {
+        firstStat: Int
+        secondStat: Int
+      }
+    `;
+
+    expect(() => makeExecutableSchema({ typeDefs })).not.toThrow();
+    expect(() => stitchingDirectivesValidator(makeExecutableSchema({ typeDefs }))).not.toThrow();
+  });
+
+  test('throws an error if merge used without arguments on a multiple args endpoint', () => {
+    const typeDefs = /* GraphQL */ `
+      ${allStitchingDirectivesTypeDefs}
+
+      type Query {
+        _user(id: ID, name: String): User @merge
+      }
+
+      type User @key(selectionSet: "{ id name }") {
+        id: ID
+        name: String
+      }
+    `;
+
+    expect(() => makeExecutableSchema({ typeDefs })).not.toThrow();
+    expect(() => stitchingDirectivesValidator(makeExecutableSchema({ typeDefs }))).toThrow();
+  });
 });


### PR DESCRIPTION
## Description

Allows using `@merge` directive without `keyArg` argument if resolver takes 0 arguments 
Related #4336 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
