### PR TITLE
Support deprecated directive on enum values

### DIFF
--- a/.changeset/grumpy-dragons-cry.md
+++ b/.changeset/grumpy-dragons-cry.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/utils': patch
+---
+
+Support deprecated directive on enum values

--- a/packages/utils/src/print-schema-with-directives.ts
+++ b/packages/utils/src/print-schema-with-directives.ts
@@ -256,7 +256,7 @@ export function getDirectiveNodes(
 }
 
 export function getDeprecatableDirectiveNodes(
-  entity: GraphQLArgument | GraphQLField<any, any> | GraphQLInputField,
+  entity: GraphQLArgument | GraphQLField<any, any> | GraphQLInputField | GraphQLEnumValue,
   schema?: GraphQLSchema,
   pathToDirectivesInExtensions?: Array<string>
 ): Array<DirectiveNode> {
@@ -574,7 +574,7 @@ export function astFromEnumValue(
       value: value.name,
     },
     // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
-    directives: getDirectiveNodes(value, schema, pathToDirectivesInExtensions) as any,
+    directives: getDeprecatableDirectiveNodes(value, schema, pathToDirectivesInExtensions) as any,
   };
 }
 

--- a/packages/utils/tests/print-schema-with-directives.spec.ts
+++ b/packages/utils/tests/print-schema-with-directives.spec.ts
@@ -4,6 +4,7 @@ import { stitchSchemas } from '@graphql-tools/stitch';
 import {
   buildSchema,
   GraphQLDirective,
+  GraphQLEnumType,
   printSchema,
   GraphQLSchema,
   specifiedDirectives,
@@ -247,6 +248,33 @@ describe('printSchemaWithDirectives', () => {
     const output = printSchemaWithDirectives(schema);
 
     expect(output).toContain('directive @dummy on QUERY');
+  });
+
+  it(`Should print enum value deprecations correctly if they don't have astNode`, () => {
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {},
+      }),
+      types: [
+        new GraphQLEnumType({
+          name: 'Color',
+          values: {
+            RED: {
+              value: 'RED',
+              deprecationReason: 'No longer supported',
+            },
+            BLUE: {
+              value: 'BLUE',
+            },
+          },
+        }),
+      ],
+    });
+
+    const output = printSchemaWithDirectives(schema);
+
+    expect(output).toContain('RED @deprecated(reason: "No longer supported")');
   });
 
   it('should print comments', () => {


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

Fix deprecated enum values not being parsed by File/UrlLoader.

Schema:
```gql
enum Color {
  Red @deprecated(reason: "Blue is better")
  Blue
}
```

Related #4350

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I patched it in my own codebase, and it's been working great for months. Just trying to get the fix upstream.

- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS:
- `@graphql-tools/...`:
- NodeJS:

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
