### PR TITLE
fix(addResolversToSchema): continue processing all types and fields in edge cases

### DIFF
--- a/.changeset/dull-eyes-work.md
+++ b/.changeset/dull-eyes-work.md
@@ -1,0 +1,9 @@
+---
+'@graphql-tools/schema': patch
+---
+
+Fix `addResolversToSchema` bug where type or field processing would be aborted prematurely.
+
+In previous versions, if `requireResolversToMatchSchema` was set to `ignore`, although no error would be thrown for an unexpected resolver type, type processing would still be aborted early. This fix changes the behavior to correctly continue resolver type processing with the next provided type.
+
+In previous versions, if a resolver field began with double underscores, it would correctly be used for legacy behavior to directly set a type property, but field processing would be aborted early. This fix changes the behavior to correctly continue type processing with the next field.

--- a/packages/schema/src/addResolversToSchema.ts
+++ b/packages/schema/src/addResolversToSchema.ts
@@ -77,7 +77,7 @@ export function addResolversToSchema(
 
     if (type == null) {
       if (requireResolversToMatchSchema === 'ignore') {
-        break;
+        continue;
       }
 
       throw new Error(`"${typeName}" defined in resolvers, but not in schema`);
@@ -235,7 +235,7 @@ function addResolversToExistingSchema(
         if (fieldName.startsWith('__')) {
           // this is for isTypeOf and resolveType and all the other stuff.
           type[fieldName.substring(2)] = resolverValue[fieldName];
-          break;
+          continue;
         }
 
         const fields = type.getFields();


### PR DESCRIPTION

In previous versions, if `requireResolversToMatchSchema` was set to `ignore`, although no error would be thrown for an unexpected resolver type, type processing would still be aborted early. This fix changes the behavior to correctly continue resolver type processing with the next provided type.

In previous versions, if a resolver field began with double underscores, it would correctly be used for legacy behavior to directly set a type property, but field processing would be aborted early. This fix changes the behavior to correctly continue type processing with the next field.

https://github.com/ardatan/graphql-tools/pull/3096/#discussion_r838020747