### PR TITLE
fix(mergeSchemas): Prevent custom resolvers from being overwritten by default resolvers

### DIFF
--- a/packages/schema/src/merge-schemas.ts
+++ b/packages/schema/src/merge-schemas.ts
@@ -21,7 +21,7 @@ export type MergeSchemasConfig<T = any> = Partial<IExecutableSchemaDefinition<T>
  */
 export function mergeSchemas(config: MergeSchemasConfig) {
   const extractedTypeDefs: TypeSource = asArray(config.typeDefs || []);
-  const extractedResolvers: IResolvers<any, any>[] = asArray(config.resolvers || []);
+  const extractedResolvers: IResolvers<any, any>[] = [];
   const extractedSchemaExtensions: SchemaExtensions[] = asArray(config.schemaExtensions || []);
 
   const schemas = config.schemas || [];
@@ -30,7 +30,8 @@ export function mergeSchemas(config: MergeSchemasConfig) {
     extractedResolvers.push(getResolversFromSchema(schema));
     extractedSchemaExtensions.push(extractExtensionsFromSchema(schema));
   }
-
+  extractedResolvers.push(asArray(config.resolvers || []))
+  
   return makeExecutableSchema({
     parseOptions: config,
     ...config,


### PR DESCRIPTION
## Description

 custom resolvers should overwrite default resolvers

Related #4367

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

1. Do a merge schema, which will give every field a default resolver
2. Do a merge schema again with custom resolvers
3. Notice the custom resolver is being used (below you should see '42' in the console)

```ts
const mySchema = mergeSchemas(...) // this will add a default resolver to every field
const withNestedSchema = mergeSchemas({
  schemas: [mySchema],
  resolvers: {_extQuery: { projects: () => console.log(42); return 42}} // this resolver gets overwritten during merge!
})
```

