### PR TITLE
`typescript@4.7` readiness (refine generic typings via `extends`)

### DIFF
--- a/.changeset/slow-singers-pull.md
+++ b/.changeset/slow-singers-pull.md
@@ -1,0 +1,21 @@
+---
+'@graphql-tools/delegate': patch
+'@graphql-tools/links': patch
+'@graphql-tools/git-loader': patch
+'@graphql-tools/url-loader': patch
+'@graphql-tools/stitch': patch
+'@graphql-tools/utils': patch
+'@graphql-tools/wrap': patch
+---
+
+Refine generic typings using `extends X` when appropriate
+
+Typescript 4.7 has stricter requirements around generics
+which is explained well in the related PR:
+https://github.com/microsoft/TypeScript/pull/48366
+
+These changes resolve the errors that these packages will
+face when attempting to upgrade to TS 4.7 (still in beta
+at the time of writing this). Landing these changes now
+will allow other TS libraries which depend on these
+packages to experiment with TS 4.7 in the meantime.

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "ts-jest": "27.1.4",
     "typedoc": "0.21.9",
     "typedoc-plugin-markdown": "3.10.4",
-    "typescript": "4.7.0-beta"
+    "typescript": "4.6.3"
   },
   "lint-staged": {
     "packages/**/src/**/*.{ts,tsx}": [

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "ts-jest": "27.1.4",
     "typedoc": "0.21.9",
     "typedoc-plugin-markdown": "3.10.4",
-    "typescript": "4.6.3"
+    "typescript": "4.7.0-beta"
   },
   "lint-staged": {
     "packages/**/src/**/*.{ts,tsx}": [

--- a/packages/delegate/src/Transformer.ts
+++ b/packages/delegate/src/Transformer.ts
@@ -11,7 +11,7 @@ interface Transformation<TContext> {
   context: Record<string, any>;
 }
 
-export class Transformer<TContext = Record<string, any>> {
+export class Transformer<TContext extends Record<string, any> = Record<string, any>> {
   private transformations: Array<Transformation<TContext>> = [];
   private delegationContext: DelegationContext<TContext>;
 
@@ -51,7 +51,7 @@ export class Transformer<TContext = Record<string, any>> {
   public transformResult(originalResult: ExecutionResult) {
     let result = originalResult;
 
-    // from rigth to left
+    // from right to left
     for (let i = this.transformations.length - 1; i >= 0; i--) {
       const transformation = this.transformations[i];
       if (transformation.transform.transformResult) {

--- a/packages/delegate/src/checkResultAndHandleErrors.ts
+++ b/packages/delegate/src/checkResultAndHandleErrors.ts
@@ -5,7 +5,7 @@ import { AggregateError, getResponseKeyFromInfo, ExecutionResult, relocatedError
 import { DelegationContext } from './types';
 import { resolveExternalValue } from './resolveExternalValue';
 
-export function checkResultAndHandleErrors<TContext>(
+export function checkResultAndHandleErrors<TContext extends Record<string, any>>(
   result: ExecutionResult,
   delegationContext: DelegationContext<TContext>
 ): any {

--- a/packages/delegate/src/delegateToSchema.ts
+++ b/packages/delegate/src/delegateToSchema.ts
@@ -38,9 +38,10 @@ import { Subschema } from './Subschema';
 import { createRequest, getDelegatingOperation } from './createRequest';
 import { Transformer } from './Transformer';
 
-export function delegateToSchema<TContext = Record<string, any>, TArgs = any>(
-  options: IDelegateToSchemaOptions<TContext, TArgs>
-): any {
+export function delegateToSchema<
+  TContext extends Record<string, any> = Record<string, any>,
+  TArgs extends Record<string, any> = any
+>(options: IDelegateToSchemaOptions<TContext, TArgs>): any {
   const {
     info,
     schema,
@@ -85,9 +86,10 @@ function getDelegationReturnType(
   return rootType.getFields()[fieldName].type;
 }
 
-export function delegateRequest<TContext = Record<string, any>, TArgs = any>(
-  options: IDelegateRequestOptions<TContext, TArgs>
-) {
+export function delegateRequest<
+  TContext extends Record<string, any> = Record<string, any>,
+  TArgs extends Record<string, any> = any
+>(options: IDelegateRequestOptions<TContext, TArgs>) {
   const delegationContext = getDelegationContext(options);
 
   const transformer = new Transformer<TContext>(delegationContext);
@@ -112,7 +114,7 @@ export function delegateRequest<TContext = Record<string, any>, TArgs = any>(
     .resolve();
 }
 
-function getDelegationContext<TContext>({
+function getDelegationContext<TContext extends Record<string, any>>({
   request,
   schema,
   fieldName,
@@ -193,7 +195,9 @@ function validateRequest(delegationContext: DelegationContext<any>, document: Do
 
 const GLOBAL_CONTEXT = {};
 
-function getExecutor<TContext>(delegationContext: DelegationContext<TContext>): Executor<TContext> {
+function getExecutor<TContext extends Record<string, any>>(
+  delegationContext: DelegationContext<TContext>
+): Executor<TContext> {
   const { subschemaConfig, targetSchema, context } = delegationContext;
 
   let executor: Executor = subschemaConfig?.executor || createDefaultExecutor(targetSchema);

--- a/packages/delegate/src/resolveExternalValue.ts
+++ b/packages/delegate/src/resolveExternalValue.ts
@@ -19,7 +19,7 @@ import { StitchingInfo, SubschemaConfig } from './types';
 import { annotateExternalObject, isExternalObject, mergeFields } from './mergeFields';
 import { Subschema } from './Subschema';
 
-export function resolveExternalValue<TContext>(
+export function resolveExternalValue<TContext extends Record<string, any>>(
   result: any,
   unpathedErrors: Array<GraphQLError>,
   subschema: GraphQLSchema | SubschemaConfig<any, any, any, TContext>,
@@ -47,7 +47,7 @@ export function resolveExternalValue<TContext>(
   }
 }
 
-function resolveExternalObject<TContext>(
+function resolveExternalObject<TContext extends Record<string, any>>(
   type: GraphQLCompositeType,
   object: any,
   unpathedErrors: Array<GraphQLError>,
@@ -91,7 +91,7 @@ function resolveExternalObject<TContext>(
   return mergeFields(mergedTypeInfo, object, subschema as Subschema, context, info);
 }
 
-function resolveExternalList<TContext>(
+function resolveExternalList<TContext extends Record<string, any>>(
   type: GraphQLList<any>,
   list: Array<any>,
   unpathedErrors: Array<GraphQLError>,
@@ -113,7 +113,7 @@ function resolveExternalList<TContext>(
   );
 }
 
-function resolveExternalListMember<TContext>(
+function resolveExternalListMember<TContext extends Record<string, any>>(
   type: GraphQLType,
   listMember: any,
   unpathedErrors: Array<GraphQLError>,

--- a/packages/links/src/linkToExecutor.ts
+++ b/packages/links/src/linkToExecutor.ts
@@ -11,7 +11,9 @@ import {
 } from '@graphql-tools/utils';
 
 export function linkToExecutor(link: ApolloLink): Executor {
-  return function executorFromLink<TReturn, TArgs, TContext>(request: ExecutionRequest<TArgs, TContext>) {
+  return function executorFromLink<TReturn, TArgs extends Record<string, any>, TContext>(
+    request: ExecutionRequest<TArgs, TContext>
+  ) {
     const observable = execute(link, {
       query: request.document,
       operationName: request.operationName,

--- a/packages/loaders/git/src/parse.ts
+++ b/packages/loaders/git/src/parse.ts
@@ -1,9 +1,9 @@
-import { parseGraphQLSDL, parseGraphQLJSON, Source } from '@graphql-tools/utils';
+import { parseGraphQLSDL, parseGraphQLJSON, Source, GraphQLParseOptions } from '@graphql-tools/utils';
 
 /**
  * @internal
  */
-export function parse<T>({
+export function parse<T extends GraphQLParseOptions>({
   path,
   pointer,
   content,

--- a/packages/loaders/url/src/defaultAsyncFetch.ts
+++ b/packages/loaders/url/src/defaultAsyncFetch.ts
@@ -1,6 +1,6 @@
 import { fetch } from 'cross-undici-fetch';
 
 export type AsyncFetchFn = typeof fetch;
-export const defaultAsyncFetch: AsyncFetchFn = async (input: RequestInfo, init?: RequestInit): Promise<Response> => {
+export const defaultAsyncFetch: AsyncFetchFn = async (input, init) => {
   return fetch(input, init);
 };

--- a/packages/loaders/url/src/index.ts
+++ b/packages/loaders/url/src/index.ts
@@ -505,7 +505,11 @@ export class UrlLoader implements Loader<LoadFromUrlOptions> {
       webSocketImpl
     );
 
-    return <TReturn, TArgs>({ document, variables, operationName }: ExecutionRequest<TArgs>) => {
+    return <TReturn, TArgs extends Record<string, any>>({
+      document,
+      variables,
+      operationName,
+    }: ExecutionRequest<TArgs>) => {
       return observableToAsyncIterable(
         subscriptionClient.request({
           query: document,

--- a/packages/stitch/src/createMergedTypeResolver.ts
+++ b/packages/stitch/src/createMergedTypeResolver.ts
@@ -2,7 +2,7 @@ import { getNamedType, GraphQLList, GraphQLOutputType, OperationTypeNode } from 
 import { delegateToSchema, MergedTypeResolver, MergedTypeResolverOptions } from '@graphql-tools/delegate';
 import { batchDelegateToSchema } from '@graphql-tools/batch-delegate';
 
-export function createMergedTypeResolver<TContext = any>(
+export function createMergedTypeResolver<TContext extends Record<string, any> = any>(
   mergedTypeResolverOptions: MergedTypeResolverOptions
 ): MergedTypeResolver<TContext> | undefined {
   const { fieldName, argsFromKeys, valuesFromResults, args } = mergedTypeResolverOptions;

--- a/packages/stitch/src/stitchSchemas.ts
+++ b/packages/stitch/src/stitchSchemas.ts
@@ -24,7 +24,7 @@ import {
 } from './subschemaConfigTransforms';
 import { applyExtensions, mergeExtensions, mergeResolvers } from '@graphql-tools/merge';
 
-export function stitchSchemas<TContext = Record<string, any>>({
+export function stitchSchemas<TContext extends Record<string, any> = Record<string, any>>({
   subschemas = [],
   types = [],
   typeDefs,

--- a/packages/stitch/src/stitchingInfo.ts
+++ b/packages/stitch/src/stitchingInfo.ts
@@ -25,7 +25,7 @@ import { createMergedTypeResolver } from './createMergedTypeResolver';
 import { createDelegationPlanBuilder } from './createDelegationPlanBuilder';
 import { ValueOrPromise } from 'value-or-promise';
 
-export function createStitchingInfo<TContext = Record<string, any>>(
+export function createStitchingInfo<TContext extends Record<string, any> = Record<string, any>>(
   subschemaMap: Map<GraphQLSchema | SubschemaConfig<any, any, any, TContext>, Subschema<any, any, any, TContext>>,
   typeCandidates: Record<string, Array<MergeTypeCandidate<TContext>>>,
   mergeTypes?: boolean | Array<string> | MergeTypeFilter<TContext>
@@ -41,7 +41,7 @@ export function createStitchingInfo<TContext = Record<string, any>>(
   };
 }
 
-function createMergedTypes<TContext = Record<string, any>>(
+function createMergedTypes<TContext extends Record<string, any> = Record<string, any>>(
   typeCandidates: Record<string, Array<MergeTypeCandidate<TContext>>>,
   mergeTypes?: boolean | Array<string> | MergeTypeFilter<TContext>
 ): Record<string, MergedTypeInfo<TContext>> {

--- a/packages/stitch/src/typeCandidates.ts
+++ b/packages/stitch/src/typeCandidates.ts
@@ -34,7 +34,7 @@ type CandidateSelector<TContext = Record<string, any>> = (
   candidates: Array<MergeTypeCandidate<TContext>>
 ) => MergeTypeCandidate<TContext>;
 
-export function buildTypeCandidates<TContext = Record<string, any>>({
+export function buildTypeCandidates<TContext extends Record<string, any> = Record<string, any>>({
   subschemas,
   originalSubschemaMap,
   types,

--- a/packages/stitch/tests/dataloader.test.ts
+++ b/packages/stitch/tests/dataloader.test.ts
@@ -74,7 +74,7 @@ describe('dataloader', () => {
         args: {
           ids: keys.map((k: { id: any }) => k.id),
         },
-        context: null,
+        context: undefined,
         info: keys[0].info,
         returnType: new GraphQLList(keys[0].info.returnType),
       });

--- a/packages/utils/src/executor.ts
+++ b/packages/utils/src/executor.ts
@@ -5,7 +5,7 @@ type MaybeAsyncIterable<T> = AsyncIterable<T> | T;
 
 export type AsyncExecutor<TBaseContext = Record<string, any>, TBaseExtensions = Record<string, any>> = <
   TReturn = any,
-  TArgs = Record<string, any>,
+  TArgs extends Record<string, any> = Record<string, any>,
   TContext extends TBaseContext = TBaseContext,
   TRoot = any,
   TExtensions extends TBaseExtensions = TBaseExtensions
@@ -15,7 +15,7 @@ export type AsyncExecutor<TBaseContext = Record<string, any>, TBaseExtensions = 
 
 export type SyncExecutor<TBaseContext = Record<string, any>, TBaseExtensions = Record<string, any>> = <
   TReturn = any,
-  TArgs = Record<string, any>,
+  TArgs extends Record<string, any> = Record<string, any>,
   TContext extends TBaseContext = TBaseContext,
   TRoot = any,
   TExtensions extends TBaseExtensions = TBaseExtensions
@@ -25,7 +25,7 @@ export type SyncExecutor<TBaseContext = Record<string, any>, TBaseExtensions = R
 
 export type Executor<TBaseContext = Record<string, any>, TBaseExtensions = Record<string, any>> = <
   TReturn = any,
-  TArgs = Record<string, any>,
+  TArgs extends Record<string, any> = Record<string, any>,
   TContext extends TBaseContext = TBaseContext,
   TRoot = any,
   TExtensions extends TBaseExtensions = TBaseExtensions

--- a/packages/wrap/src/generateProxyingResolvers.ts
+++ b/packages/wrap/src/generateProxyingResolvers.ts
@@ -12,7 +12,7 @@ import {
   getUnpathedErrors,
 } from '@graphql-tools/delegate';
 
-export function generateProxyingResolvers<TContext>(
+export function generateProxyingResolvers<TContext extends Record<string, any>>(
   subschemaConfig: SubschemaConfig<any, any, any, TContext>
 ): Record<string, Record<string, GraphQLFieldResolver<any, any>>> {
   const targetSchema = subschemaConfig.schema;
@@ -84,7 +84,7 @@ function createPossiblyNestedProxyingResolver<TContext extends Record<string, an
   };
 }
 
-export function defaultCreateProxyingResolver<TContext>({
+export function defaultCreateProxyingResolver<TContext extends Record<string, any>>({
   subschemaConfig,
   operation,
   transformedSchema,

--- a/packages/wrap/src/generateProxyingResolvers.ts
+++ b/packages/wrap/src/generateProxyingResolvers.ts
@@ -58,7 +58,7 @@ function identical<T>(value: T): T {
   return value;
 }
 
-function createPossiblyNestedProxyingResolver<TContext>(
+function createPossiblyNestedProxyingResolver<TContext extends Record<string, any>>(
   subschemaConfig: SubschemaConfig<any, any, any, TContext>,
   proxyingResolver: GraphQLFieldResolver<any, any>
 ): GraphQLFieldResolver<any, TContext, any> {

--- a/packages/wrap/src/transforms/WrapFields.ts
+++ b/packages/wrap/src/transforms/WrapFields.ts
@@ -31,7 +31,9 @@ interface WrapFieldsTransformationContext {
   paths: Record<string, { pathToField: Array<string>; alias: string }>;
 }
 
-export default class WrapFields<TContext> implements Transform<WrapFieldsTransformationContext, TContext> {
+export default class WrapFields<TContext extends Record<string, any>>
+  implements Transform<WrapFieldsTransformationContext, TContext>
+{
   private readonly outerTypeName: string;
   private readonly wrappingFieldNames: Array<string>;
   private readonly wrappingTypeNames: Array<string>;

--- a/packages/wrap/src/transforms/WrapType.ts
+++ b/packages/wrap/src/transforms/WrapType.ts
@@ -8,7 +8,7 @@ import WrapFields from './WrapFields';
 
 interface WrapTypeTransformationContext extends Record<string, any> {}
 
-export default class WrapType<TContext = Record<string, any>>
+export default class WrapType<TContext extends Record<string, any> = Record<string, any>>
   implements Transform<WrapTypeTransformationContext, TContext>
 {
   private readonly transformer: WrapFields<TContext>;

--- a/packages/wrap/src/wrapSchema.ts
+++ b/packages/wrap/src/wrapSchema.ts
@@ -11,7 +11,7 @@ import { MapperKind, mapSchema } from '@graphql-tools/utils';
 import { SubschemaConfig, defaultMergedResolver, applySchemaTransforms } from '@graphql-tools/delegate';
 import { generateProxyingResolvers } from './generateProxyingResolvers';
 
-export function wrapSchema<TConfig = Record<string, any>>(
+export function wrapSchema<TConfig extends Record<string, any> = Record<string, any>>(
   subschemaConfig: SubschemaConfig<any, any, any, TConfig>
 ): GraphQLSchema {
   const targetSchema = subschemaConfig.schema;

--- a/yarn.lock
+++ b/yarn.lock
@@ -13163,6 +13163,11 @@ typescript@4.6.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
   integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
 
+typescript@4.7.0-beta:
+  version "4.7.0-beta"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.0-beta.tgz#15952f24d4177479ca3d19f09436ad8c69a30563"
+  integrity sha512-m+CNL8lzHyHDxYYDTI+pm5hw5/bufYVGan2bokPyJY/y9C/4W/PCWMtYZ0vV9fLXbEL57elMeoaz9Evxs8UQ+A==
+
 ua-parser-js@^0.7.18:
   version "0.7.28"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13163,11 +13163,6 @@ typescript@4.6.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
   integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
 
-typescript@4.7.0-beta:
-  version "4.7.0-beta"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.0-beta.tgz#15952f24d4177479ca3d19f09436ad8c69a30563"
-  integrity sha512-m+CNL8lzHyHDxYYDTI+pm5hw5/bufYVGan2bokPyJY/y9C/4W/PCWMtYZ0vV9fLXbEL57elMeoaz9Evxs8UQ+A==
-
 ua-parser-js@^0.7.18:
   version "0.7.28"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.28.tgz#8ba04e653f35ce210239c64661685bf9121dec31"


### PR DESCRIPTION
## Description

This PR was initially intended to be a reproduction of build errors caused by upgrading the TS version (to `typescript@4.7.0-beta`). This is now intended to be merged as-is, having resolved the build errors caused by upgrading to `typescript@4.7.0-beta` (followed by reverting the upgrade with no breakage).

The changes introduced in this PR bring this repo to `typescript@4.7` compatible while maintaining the existing typescript version for now. In doing so, a lot of the generic typings have been refined, so this seems like a win-win.

I've gone through and resolved the build errors (seemed to mostly all be of the class of error mentioned in https://github.com/microsoft/TypeScript/pull/48366). This seems ready to go if the maintainers agree with these changes.

Related #4381

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

This is possibly breaking if my changes affect the public API and if users are misusing the generics. To that end I would call this a patch/bug fix, but it's worth noting. Maybe this change is deserving of a changeset?

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Install `typescript@4.7.0-beta` on `main`, note build failures
- Install `typescript@4.7.0-beta` on this branch, build succeeds
- Revert typescript update on this branch, build succeeds

**Test Environment**:

- OS: MacOS 12.12.1
- `@graphql-tools/...`: `latest`
- NodeJS: `v16.5.0`

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
