### PR TITLE
consider relaxing error path check

### DIFF
--- a/.changeset/ten-spoons-promise.md
+++ b/.changeset/ten-spoons-promise.md
@@ -1,0 +1,7 @@
+---
+'@graphql-tools/delegate': patch
+---
+
+relax subschema error path check
+
+...as (apparently) some implementations may return path as `null` rather than not returning a path.

--- a/packages/delegate/src/checkResultAndHandleErrors.ts
+++ b/packages/delegate/src/checkResultAndHandleErrors.ts
@@ -43,8 +43,7 @@ export function mergeDataAndErrors(
 
     if (errors.length === 1) {
       const error = onLocatedError ? onLocatedError(errors[0]) : errors[0];
-      const newPath =
-        path === undefined ? error.path : error.path === undefined ? path : path.concat(error.path.slice(1));
+      const newPath = path === undefined ? error.path : !error.path ? path : path.concat(error.path.slice(1));
 
       return { data: relocatedError(errors[0], newPath), unpathedErrors: [] };
     }


### PR DESCRIPTION
as some implementations apparently may return null when no path is provided rather than not returning anything