### PR TITLE
Fix pruneSchema removing used input object types

### DIFF
--- a/.changeset/chilled-apricots-allow.md
+++ b/.changeset/chilled-apricots-allow.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/utils': patch
+---
+
+pruneSchema will no longer removed used input object type.

--- a/packages/utils/src/prune.ts
+++ b/packages/utils/src/prune.ts
@@ -139,7 +139,7 @@ function visitQueue(queue: string[], schema: GraphQLSchema, visited: Set<string>
         }
 
         for (const [, field] of entries) {
-          if (isInputObjectType(type)) {
+          if (isObjectType(type)) {
             for (const arg of field.args) {
               queue.push(getNamedType(arg.type).name); // Visit arg types
             }

--- a/packages/utils/tests/prune.test.ts
+++ b/packages/utils/tests/prune.test.ts
@@ -86,6 +86,20 @@ describe('pruneSchema', () => {
     expect(result.getType('CustomScalar')).toBeDefined();
   });
 
+  test('does not remove used input objects', () => {
+    const schema = buildSchema(/* GraphQL */ `
+      input UsedInput {
+        value: String
+      }
+
+      type Query {
+        foo(input: UsedInput): Boolean
+      }
+    `);
+    const result = pruneSchema(schema);
+    expect(result.getType('UsedInput')).toBeDefined();
+  });
+
   test('removes unused input objects', () => {
     const schema = buildSchema(/* GraphQL */ `
       input Unused {


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

This fixes issue #4405 by correcting a check that improperly resulted in stripping all input types used or unused from the schema.

Related # (issue)

#4405 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Added an additional test to validate that used input types are not removed.

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
