### PR TITLE
fix(jest-transform) Add default export

### DIFF
--- a/packages/jest-transform/src/index.ts
+++ b/packages/jest-transform/src/index.ts
@@ -36,3 +36,9 @@ function defaultTransformer(): GraphQLTransformer {
 export function process(...args: any[]): any {
   return (defaultTransformer().process as any)(...args);
 }
+
+const transformerFactory = {
+  process,
+};
+
+export default transformerFactory;


### PR DESCRIPTION
I tried to use this module today on a Jest 18 install and was met with this error:

> Invalid transformer module: <snip>/node_modules/@graphql-tools/dist/index.js specified in the "transform" object of Jest configuration must export a `process` or `processAsync` or `createTransformer` function.

Looking at the `babel-jest` module there is a comment [suggesting a default export is required](https://github.com/facebook/jest/blob/main/packages/babel-jest/src/index.ts#L276) and this seems to fix the above issue.