### PR TITLE
Add option to pluck from custom Vue block

### DIFF
--- a/.changeset/old-lobsters-fold.md
+++ b/.changeset/old-lobsters-fold.md
@@ -1,0 +1,5 @@
+---
+"@graphql-tools/graphql-tag-pluck": patch
+---
+
+Add option to pluck from custom Vue block

--- a/packages/graphql-tag-pluck/src/index.ts
+++ b/packages/graphql-tag-pluck/src/index.ts
@@ -163,7 +163,7 @@ function customBlockFromVue(
   vueTemplateCompiler: typeof import('@vue/compiler-sfc'),
   fileData: string,
   filePath: string,
-  blockType: string
+  blockType: string,
 ): Source | undefined {
   const { descriptor } = vueTemplateCompiler.parse(fileData);
 
@@ -226,7 +226,9 @@ export const gqlPluckFromCodeString = async (
     code = await pluckAstroFileScript(code);
   }
 
-  const sources = parseCode({ code, filePath, options }).map(t => new Source(t.content, filePath, t.loc.start));
+  const sources = parseCode({ code, filePath, options }).map(
+    t => new Source(t.content, filePath, t.loc.start),
+  );
   if (blockSource) {
     sources.push(blockSource);
   }
@@ -263,7 +265,9 @@ export const gqlPluckFromCodeStringSync = (
     code = pluckAstroFileScriptSync(code);
   }
 
-  const sources = parseCode({ code, filePath, options }).map(t => new Source(t.content, filePath, t.loc.start));
+  const sources = parseCode({ code, filePath, options }).map(
+    t => new Source(t.content, filePath, t.loc.start),
+  );
   if (blockSource) {
     sources.push(blockSource);
   }

--- a/packages/graphql-tag-pluck/tests/graphql-tag-pluck.test.ts
+++ b/packages/graphql-tag-pluck/tests/graphql-tag-pluck.test.ts
@@ -268,7 +268,7 @@ describe('graphql-tag-pluck', () => {
       );
     });
 
-    it.only("should pluck graphql-tag template literals from .ts that use 'using' keyword", async () => {
+    it("should pluck graphql-tag template literals from .ts that use 'using' keyword", async () => {
       const sources = await pluck(
         'tmp-XXXXXX.ts',
         freeText(`
@@ -1983,6 +1983,86 @@ describe('graphql-tag-pluck', () => {
           draftjs
         }
       `),
+      );
+    });
+
+    it('should be able to specify a custom Vue block to pluck from', async () => {
+      const sources = await pluck(
+        'tmp-XXXXXX.vue',
+        freeText(`
+        <template lang="pug">
+          <div>test</div>
+        </template>
+
+        <script lang="ts">
+        import { defineComponent } from 'vue'
+        import gql from 'graphql-tag';
+
+        export default defineComponent({
+          name: 'TestComponent',
+          setup(){
+            return {
+              pageQuery: gql\`
+              query IndexQuery {
+                site {
+                  siteMetadata {
+                    title
+                  }
+                }
+              }
+            \`
+            }
+          }
+        })
+
+        // export const pageQuery = gql\`
+        //   query OtherQuery {
+        //     site {
+        //       siteMetadata {
+        //         title
+        //       }
+        //     }
+        //   }
+        // \`;
+        </script>
+
+        <style lang="scss">
+        .test { color: red };
+        </style>
+
+        <graphql lang="gql">
+        query CustomBlockQuery {
+          site {
+            siteMetadata {
+              title
+            }
+          }
+        }
+        </graphql>
+      `),
+        {
+          gqlVueBlock: 'graphql',
+        }
+      );
+
+      expect(sources.map(source => source.body).join('\n\n')).toEqual(
+        freeText(`
+        query IndexQuery {
+          site {
+            siteMetadata {
+              title
+            }
+          }
+        }
+
+        query CustomBlockQuery {
+          site {
+            siteMetadata {
+              title
+            }
+          }
+        }
+      `)
       );
     });
 

--- a/packages/graphql-tag-pluck/tests/graphql-tag-pluck.test.ts
+++ b/packages/graphql-tag-pluck/tests/graphql-tag-pluck.test.ts
@@ -2042,7 +2042,7 @@ describe('graphql-tag-pluck', () => {
       `),
         {
           gqlVueBlock: 'graphql',
-        }
+        },
       );
 
       expect(sources.map(source => source.body).join('\n\n')).toEqual(
@@ -2062,7 +2062,7 @@ describe('graphql-tag-pluck', () => {
             }
           }
         }
-      `)
+      `),
       );
     });
 

--- a/packages/load/tests/loaders/schema/schema-from-export.spec.ts
+++ b/packages/load/tests/loaders/schema/schema-from-export.spec.ts
@@ -21,16 +21,24 @@ describe('Schema From Export', () => {
     sync: loadSchemaSync,
   })((load, mode) => {
     test('should load the schema correctly from module.exports', async () => {
-      const result = await load('./tests/loaders/schema/test-files/loaders/module-exports.js', {
-        loaders: [new CodeFileLoader()],
-      });
+      const result = await load(
+        '../../../../loaders/code-file/tests/test-files/loaders/module-exports.js',
+        {
+          loaders: [new CodeFileLoader()],
+          cwd: __dirname,
+        },
+      );
       expect(isSchema(result)).toBeTruthy();
     });
 
     test('should load the schema (with extend) correctly from module.exports', async () => {
-      const result = await load('./tests/loaders/schema/test-files/schema-dir/with-extend.js', {
-        loaders: [new CodeFileLoader()],
-      });
+      const result = await load(
+        '../../../../loaders/code-file/tests/test-files/loaders/with-extend.js',
+        {
+          loaders: [new CodeFileLoader()],
+          cwd: __dirname,
+        },
+      );
       expect(isSchema(result)).toBeTruthy();
       const QueryType = result.getQueryType();
       assertNonMaybe(QueryType);
@@ -38,36 +46,52 @@ describe('Schema From Export', () => {
     });
 
     test('should load the schema correctly from variable export', async () => {
-      const result = await load('./tests/loaders/schema/test-files/loaders/schema-export.js', {
-        loaders: [new CodeFileLoader()],
-      });
+      const result = await load(
+        '../../../../loaders/code-file/tests/test-files/loaders/schema-export.js',
+        {
+          loaders: [new CodeFileLoader()],
+          cwd: __dirname,
+        },
+      );
       expect(isSchema(result)).toBeTruthy();
     });
 
     test('should load the schema correctly from default export', async () => {
-      const result = await load('./tests/loaders/schema/test-files/loaders/default-export.js', {
-        loaders: [new CodeFileLoader()],
-      });
+      const result = await load(
+        '../../../../loaders/code-file/tests/test-files/loaders/default-export.js',
+        {
+          loaders: [new CodeFileLoader()],
+          cwd: __dirname,
+        },
+      );
       expect(isSchema(result)).toBeTruthy();
     });
 
     if (mode === 'async') {
       test('should load the schema correctly from promise export', async () => {
-        const result = await load('./tests/loaders/schema/test-files/loaders/promise-export.js', {
-          loaders: [new CodeFileLoader()],
-        });
+        const result = await load(
+          '../../../../loaders/code-file/tests/test-files/loaders/promise-export.js',
+          {
+            loaders: [new CodeFileLoader()],
+            cwd: __dirname,
+          },
+        );
         expect(isSchema(result)).toBeTruthy();
       });
 
       test('should load the schema correctly from promise export', async () => {
-        const result = await load('./tests/loaders/schema/test-files/loaders/promise-export.js', {
-          loaders: [new CodeFileLoader()],
-        });
+        const result = await load(
+          '../../../../loaders/code-file/tests/test-files/loaders/promise-export.js',
+          {
+            loaders: [new CodeFileLoader()],
+            cwd: __dirname,
+          },
+        );
         expect(isSchema(result)).toBeTruthy();
       });
     }
 
-    test.only('should work with extensions (without schema definition)', async () => {
+    test('should work with extensions (without schema definition)', async () => {
       const schemaPath = './tests/loaders/schema/test-files/schema-dir/extensions/export-schema.js';
       const schema = await load(schemaPath, {
         loaders: [new CodeFileLoader()],
@@ -80,7 +104,7 @@ describe('Schema From Export', () => {
       expect(queryFields).toContain('bar');
     });
 
-    test.only('should work with extensions (with schema definition)', async () => {
+    test('should work with extensions (with schema definition)', async () => {
       const schemaPath =
         './tests/loaders/schema/test-files/schema-dir/extensions/export-schema-with-def.js';
       const schema = await load(schemaPath, {


### PR DESCRIPTION
## Description

- Adds support for `graphql-tag-pluck` to pluck raw GraphQL from a custom Vue block.
- Adds an option `gqlVueBlock` (defaults to undefined) to specify the name of the custom block. The feature has no impact if this option is not set.
- The parsing of Vue blocks is already being done by the Vue parser, so this requires no additional dependencies or algorithms.
- Includes a new test and small documentation update.
- Very minimal refactoring was done to keep DRY.

Related #4320 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

https://imgur.com/a/383F8uM

## How Has This Been Tested?

- [x] Unit test included in PR
- [x] Fork currently in use in a personal project with `graphql-codegen`, see env info below

**Test Environment**:

- OS: Ubuntu
- NodeJS: v16.15.0
- `@graphql-codegen/cli`: v2.6.2
- `@graphql-codegen/introspection`: v2.1.1
- `@graphql-codegen/typescript`: v2.4.7
- `@graphql-codegen/typescript-operations`: v2.3.4
- `@graphql-codegen/typescript-urql-graphcache`: v2.2.8
- `@graphql-codegen/typescript-vue-urql`: v2.2.8

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
