### PR TITLE
Use caret ranges for tslib

### DIFF
--- a/.changeset/fifty-bobcats-report.md
+++ b/.changeset/fifty-bobcats-report.md
@@ -1,0 +1,35 @@
+---
+'@graphql-tools/batch-delegate': patch
+'@graphql-tools/batch-execute': patch
+'@graphql-tools/delegate': patch
+'@graphql-tools/graphql-tag-pluck': patch
+'graphql-tools': patch
+'@graphql-tools/import': patch
+'@graphql-tools/jest-transform': patch
+'@graphql-tools/links': patch
+'@graphql-tools/load': patch
+'@graphql-tools/load-files': patch
+'@graphql-tools/apollo-engine-loader': patch
+'@graphql-tools/code-file-loader': patch
+'@graphql-tools/git-loader': patch
+'@graphql-tools/github-loader': patch
+'@graphql-tools/graphql-file-loader': patch
+'@graphql-tools/json-file-loader': patch
+'@graphql-tools/module-loader': patch
+'@graphql-tools/prisma-loader': patch
+'@graphql-tools/url-loader': patch
+'@graphql-tools/merge': patch
+'@graphql-tools/mock': patch
+'@graphql-tools/node-require': patch
+'@graphql-tools/optimize': patch
+'@graphql-tools/relay-operation-optimizer': patch
+'@graphql-tools/resolvers-composition': patch
+'@graphql-tools/schema': patch
+'@graphql-tools/stitch': patch
+'@graphql-tools/stitching-directives': patch
+'@graphql-tools/utils': patch
+'@graphql-tools/webpack-loader': patch
+'@graphql-tools/wrap': patch
+---
+
+Use caret range for the tslib dependency

--- a/packages/batch-delegate/package.json
+++ b/packages/batch-delegate/package.json
@@ -35,7 +35,7 @@
     "@graphql-tools/delegate": "8.7.10",
     "@graphql-tools/utils": "8.6.12",
     "dataloader": "2.1.0",
-    "tslib": "~2.4.0"
+    "tslib": "^2.4.0"
   },
   "devDependencies": {
     "@graphql-tools/schema": "8.3.13",

--- a/packages/batch-execute/package.json
+++ b/packages/batch-execute/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@graphql-tools/utils": "8.6.12",
     "dataloader": "2.1.0",
-    "tslib": "~2.4.0",
+    "tslib": "^2.4.0",
     "value-or-promise": "1.0.11"
   },
   "publishConfig": {

--- a/packages/delegate/package.json
+++ b/packages/delegate/package.json
@@ -37,7 +37,7 @@
     "@graphql-tools/utils": "8.6.12",
     "dataloader": "2.1.0",
     "graphql-executor": "0.0.23",
-    "tslib": "~2.4.0",
+    "tslib": "^2.4.0",
     "value-or-promise": "1.0.11"
   },
   "publishConfig": {

--- a/packages/graphql-tag-pluck/package.json
+++ b/packages/graphql-tag-pluck/package.json
@@ -33,7 +33,7 @@
     "@babel/traverse": "^7.16.8",
     "@babel/types": "^7.16.8",
     "@graphql-tools/utils": "8.6.12",
-    "tslib": "~2.4.0"
+    "tslib": "^2.4.0"
   },
   "devDependencies": {
     "@babel/parser": "7.18.3",

--- a/packages/graphql-tools/package.json
+++ b/packages/graphql-tools/package.json
@@ -37,6 +37,6 @@
   },
   "dependencies": {
     "@graphql-tools/schema": "8.3.13",
-    "tslib": "~2.4.0"
+    "tslib": "^2.4.0"
   }
 }

--- a/packages/import/package.json
+++ b/packages/import/package.json
@@ -36,6 +36,6 @@
   "dependencies": {
     "@graphql-tools/utils": "8.6.12",
     "resolve-from": "5.0.0",
-    "tslib": "~2.4.0"
+    "tslib": "^2.4.0"
   }
 }

--- a/packages/jest-transform/package.json
+++ b/packages/jest-transform/package.json
@@ -35,7 +35,7 @@
     "@graphql-tools/webpack-loader": "6.6.2",
     "@jest/transform": "^28.0.0",
     "@jest/types": "^28.0.0",
-    "tslib": "~2.4.0"
+    "tslib": "^2.4.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/links/package.json
+++ b/packages/links/package.json
@@ -50,7 +50,7 @@
     "apollo-upload-client": "17.0.0",
     "node-fetch": "^2.6.5",
     "form-data": "^4.0.0",
-    "tslib": "~2.4.0"
+    "tslib": "^2.4.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/load-files/package.json
+++ b/packages/load-files/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "globby": "11.1.0",
     "unixify": "1.0.0",
-    "tslib": "~2.4.0"
+    "tslib": "^2.4.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/load/package.json
+++ b/packages/load/package.json
@@ -37,7 +37,7 @@
     "@graphql-tools/utils": "8.6.12",
     "@graphql-tools/schema": "8.3.13",
     "p-limit": "3.1.0",
-    "tslib": "~2.4.0"
+    "tslib": "^2.4.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/loaders/apollo-engine/package.json
+++ b/packages/loaders/apollo-engine/package.json
@@ -32,8 +32,8 @@
   "dependencies": {
     "@graphql-tools/utils": "8.6.12",
     "cross-undici-fetch": "^0.4.0",
-    "tslib": "~2.4.0",
-    "sync-fetch": "0.4.1"
+    "sync-fetch": "0.4.1",
+    "tslib": "^2.4.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/loaders/code-file/package.json
+++ b/packages/loaders/code-file/package.json
@@ -33,7 +33,7 @@
     "@graphql-tools/utils": "8.6.12",
     "@graphql-tools/graphql-tag-pluck": "7.2.9",
     "globby": "^11.0.3",
-    "tslib": "~2.4.0",
+    "tslib": "^2.4.0",
     "unixify": "^1.0.0"
   },
   "publishConfig": {

--- a/packages/loaders/git/package.json
+++ b/packages/loaders/git/package.json
@@ -34,7 +34,7 @@
     "@graphql-tools/utils": "8.6.12",
     "is-glob": "4.0.3",
     "micromatch": "^4.0.4",
-    "tslib": "~2.4.0",
+    "tslib": "^2.4.0",
     "unixify": "^1.0.0"
   },
   "devDependencies": {

--- a/packages/loaders/github/package.json
+++ b/packages/loaders/github/package.json
@@ -34,7 +34,7 @@
     "@graphql-tools/graphql-tag-pluck": "7.2.9",
     "cross-undici-fetch": "^0.4.0",
     "sync-fetch": "0.4.1",
-    "tslib": "~2.4.0"
+    "tslib": "^2.4.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/loaders/graphql-file/package.json
+++ b/packages/loaders/graphql-file/package.json
@@ -37,7 +37,7 @@
     "@graphql-tools/utils": "8.6.12",
     "globby": "^11.0.3",
     "unixify": "^1.0.0",
-    "tslib": "~2.4.0"
+    "tslib": "^2.4.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/loaders/json-file/package.json
+++ b/packages/loaders/json-file/package.json
@@ -33,7 +33,7 @@
     "@graphql-tools/utils": "8.6.12",
     "globby": "^11.0.3",
     "unixify": "^1.0.0",
-    "tslib": "~2.4.0"
+    "tslib": "^2.4.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/loaders/module/package.json
+++ b/packages/loaders/module/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@graphql-tools/utils": "8.6.12",
-    "tslib": "~2.4.0"
+    "tslib": "^2.4.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/loaders/prisma/package.json
+++ b/packages/loaders/prisma/package.json
@@ -48,7 +48,7 @@
     "lodash": "^4.17.20",
     "replaceall": "^0.1.6",
     "scuid": "^1.1.0",
-    "tslib": "~2.4.0",
+    "tslib": "^2.4.0",
     "yaml-ast-parser": "^0.0.43"
   },
   "publishConfig": {

--- a/packages/loaders/url/package.json
+++ b/packages/loaders/url/package.json
@@ -60,7 +60,7 @@
     "isomorphic-ws": "^4.0.1",
     "meros": "^1.1.4",
     "sync-fetch": "^0.4.0",
-    "tslib": "^2.3.0",
+    "tslib": "^2.4.0",
     "value-or-promise": "^1.0.11",
     "ws": "^8.3.0"
   },

--- a/packages/merge/package.json
+++ b/packages/merge/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@graphql-tools/utils": "8.6.12",
-    "tslib": "~2.4.0"
+    "tslib": "^2.4.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -35,7 +35,7 @@
     "@graphql-tools/schema": "8.3.13",
     "@graphql-tools/utils": "8.6.12",
     "fast-json-stable-stringify": "^2.1.0",
-    "tslib": "~2.4.0"
+    "tslib": "^2.4.0"
   },
   "devDependencies": {
     "casual": "1.6.2"

--- a/packages/node-require/package.json
+++ b/packages/node-require/package.json
@@ -35,7 +35,7 @@
     "@graphql-tools/load": "7.5.13",
     "@graphql-tools/graphql-file-loader": "7.3.14",
     "@graphql-tools/utils": "8.6.12",
-    "tslib": "~2.4.0"
+    "tslib": "^2.4.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/optimize/package.json
+++ b/packages/optimize/package.json
@@ -32,7 +32,7 @@
     "input": "./src/index.ts"
   },
   "dependencies": {
-    "tslib": "~2.4.0"
+    "tslib": "^2.4.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/relay-operation-optimizer/package.json
+++ b/packages/relay-operation-optimizer/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@graphql-tools/utils": "8.6.12",
     "relay-compiler": "12.0.0",
-    "tslib": "~2.4.0"
+    "tslib": "^2.4.0"
   },
   "devDependencies": {
     "@types/relay-compiler": "8.0.2"

--- a/packages/resolvers-composition/package.json
+++ b/packages/resolvers-composition/package.json
@@ -37,7 +37,7 @@
     "@graphql-tools/utils": "8.6.12",
     "lodash": "4.17.21",
     "micromatch": "^4.0.4",
-    "tslib": "~2.4.0"
+    "tslib": "^2.4.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@graphql-tools/merge": "8.2.13",
     "@graphql-tools/utils": "8.6.12",
-    "tslib": "~2.4.0",
+    "tslib": "^2.4.0",
     "value-or-promise": "1.0.11"
   },
   "publishConfig": {

--- a/packages/stitch/package.json
+++ b/packages/stitch/package.json
@@ -42,7 +42,7 @@
     "@graphql-tools/schema": "8.3.13",
     "@graphql-tools/utils": "8.6.12",
     "@graphql-tools/wrap": "8.4.19",
-    "tslib": "~2.4.0",
+    "tslib": "^2.4.0",
     "value-or-promise": "^1.0.11"
   },
   "publishConfig": {

--- a/packages/stitching-directives/package.json
+++ b/packages/stitching-directives/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@graphql-tools/delegate": "8.7.10",
     "@graphql-tools/utils": "8.6.12",
-    "tslib": "~2.4.0"
+    "tslib": "^2.4.0"
   },
   "devDependencies": {
     "@graphql-tools/schema": "8.3.13"

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -35,7 +35,7 @@
     "graphql-scalars": "1.17.0"
   },
   "dependencies": {
-    "tslib": "~2.4.0"
+    "tslib": "^2.4.0"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/webpack-loader/package.json
+++ b/packages/webpack-loader/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@graphql-tools/optimize": "1.2.0",
     "@graphql-tools/webpack-loader-runtime": "6.3.1",
-    "tslib": "~2.4.0"
+    "tslib": "^2.4.0"
   },
   "devDependencies": {
     "@types/webpack": "5.28.0"

--- a/packages/wrap/package.json
+++ b/packages/wrap/package.json
@@ -35,7 +35,7 @@
     "@graphql-tools/delegate": "8.7.10",
     "@graphql-tools/schema": "8.3.13",
     "@graphql-tools/utils": "8.6.12",
-    "tslib": "~2.4.0",
+    "tslib": "^2.4.0",
     "value-or-promise": "1.0.11"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13263,7 +13263,7 @@ tslib@1.11.1, tslib@^1.0.0, tslib@^1.11.1, tslib@^1.8.1, tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1, tslib@~2.4.0:
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==


### PR DESCRIPTION
## Description

The `tslib` dependency present in several packages is not using a caret range, which usually causes it to be duplicated multiple times in the dependency tree.
This PR changes all packages using it to the `^2.4.0` range.

Related #3695

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The test suite was executed with `yarn test` to ensure the dependency bump didn't break anything.

**Test Environment**:

- OS: Ubuntu 20.04.4 LTS on WSL 2 on Windows 10 19044.1706
- NodeJS: 18.1.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

I didn't create a Changeset to leave the decision for the maintainers.