### PR TITLE
Copy Symbols as well in `copyOwnPropsIfNotPresent`

### DIFF
--- a/packages/mock/src/utils.ts
+++ b/packages/mock/src/utils.ts
@@ -34,6 +34,12 @@ export function copyOwnPropsIfNotPresent(target: Record<string, any>, source: Re
       Object.defineProperty(target, prop, propertyDescriptor == null ? {} : propertyDescriptor);
     }
   }
+  for (const symb of Object.getOwnPropertySymbols(source)) {
+    if (!Object.getOwnPropertyDescriptor(target, symb)) {
+      const propertyDescriptor = Object.getOwnPropertyDescriptor(source, symb);
+      Object.defineProperty(target, symb, propertyDescriptor == null ? {} : propertyDescriptor);
+    }
+  }
 }
 
 export function copyOwnProps(target: Record<string, any>, ...sources: Array<Record<string, any>>) {


### PR DESCRIPTION
Hi!

I had issues with mocking lib - we use `ObjectId` from Mongo as an ID scalar type, so after introducing mocking to our schema it started to fail. After hefty amount of time debugging it turned out that `ObjectId` is implemented in such a way that is is stored as buffer as `Symbol(id)`. Function that is being used in `@graphql-tools/mock` uses `Object.getOwnPropertyNames` which **doesn't** list `Symbol`s. The solution I've implemented you can see in this PR.