### PR TITLE
Make @graphql-tools/schema compatible with TypeScript 4.7 w/ nodeResolution:node16

### DIFF
--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -15,7 +15,7 @@
     ".": {
       "require": "./dist/index.js",
       "import": "./dist/index.mjs",
-      "types": "./index.d.ts"
+      "types": "./dist/index.d.ts"
     },
     "./*": {
       "require": "./dist/*.js",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -14,7 +14,8 @@
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs"
+      "import": "./dist/index.mjs",
+      "types": "./index.d.ts"
     },
     "./*": {
       "require": "./dist/*.js",


### PR DESCRIPTION
Without the explicit 'types' export TS 4.7 will look for ./dist/index.d.mjs