### PR TITLE
Add missing `exports.*.types` entries

### DIFF
--- a/.changeset/strange-parents-poke.md
+++ b/.changeset/strange-parents-poke.md
@@ -1,0 +1,36 @@
+---
+'@graphql-tools/batch-delegate': patch
+'@graphql-tools/batch-execute': patch
+'@graphql-tools/delegate': patch
+'@graphql-tools/graphql-tag-pluck': patch
+'graphql-tools': patch
+'@graphql-tools/import': patch
+'@graphql-tools/jest-transform': patch
+'@graphql-tools/links': patch
+'@graphql-tools/load': patch
+'@graphql-tools/load-files': patch
+'@graphql-tools/apollo-engine-loader': patch
+'@graphql-tools/code-file-loader': patch
+'@graphql-tools/git-loader': patch
+'@graphql-tools/github-loader': patch
+'@graphql-tools/graphql-file-loader': patch
+'@graphql-tools/json-file-loader': patch
+'@graphql-tools/module-loader': patch
+'@graphql-tools/prisma-loader': patch
+'@graphql-tools/url-loader': patch
+'@graphql-tools/merge': patch
+'@graphql-tools/mock': patch
+'@graphql-tools/node-require': patch
+'@graphql-tools/optimize': patch
+'@graphql-tools/relay-operation-optimizer': patch
+'@graphql-tools/resolvers-composition': patch
+'@graphql-tools/schema': patch
+'@graphql-tools/stitch': patch
+'@graphql-tools/stitching-directives': patch
+'@graphql-tools/utils': patch
+'@graphql-tools/webpack-loader': patch
+'@graphql-tools/webpack-loader-runtime': patch
+'@graphql-tools/wrap': patch
+---
+
+Add missing exports.types field in package.json exports

--- a/packages/batch-delegate/package.json
+++ b/packages/batch-delegate/package.json
@@ -13,6 +13,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/batch-execute/package.json
+++ b/packages/batch-execute/package.json
@@ -13,6 +13,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/delegate/package.json
+++ b/packages/delegate/package.json
@@ -13,6 +13,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/graphql-tag-pluck/package.json
+++ b/packages/graphql-tag-pluck/package.json
@@ -13,6 +13,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/graphql-tools/package.json
+++ b/packages/graphql-tools/package.json
@@ -13,6 +13,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/import/package.json
+++ b/packages/import/package.json
@@ -14,6 +14,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/jest-transform/package.json
+++ b/packages/jest-transform/package.json
@@ -13,6 +13,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/links/package.json
+++ b/packages/links/package.json
@@ -13,6 +13,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/load-files/package.json
+++ b/packages/load-files/package.json
@@ -14,6 +14,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/load/package.json
+++ b/packages/load/package.json
@@ -14,6 +14,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/loaders/apollo-engine/package.json
+++ b/packages/loaders/apollo-engine/package.json
@@ -14,6 +14,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/loaders/code-file/package.json
+++ b/packages/loaders/code-file/package.json
@@ -14,6 +14,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/loaders/git/package.json
+++ b/packages/loaders/git/package.json
@@ -14,6 +14,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/loaders/github/package.json
+++ b/packages/loaders/github/package.json
@@ -14,6 +14,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/loaders/graphql-file/package.json
+++ b/packages/loaders/graphql-file/package.json
@@ -14,6 +14,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/loaders/json-file/package.json
+++ b/packages/loaders/json-file/package.json
@@ -14,6 +14,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/loaders/module/package.json
+++ b/packages/loaders/module/package.json
@@ -14,6 +14,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/loaders/prisma/package.json
+++ b/packages/loaders/prisma/package.json
@@ -14,6 +14,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/loaders/url/package.json
+++ b/packages/loaders/url/package.json
@@ -14,6 +14,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/merge/package.json
+++ b/packages/merge/package.json
@@ -14,6 +14,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -13,6 +13,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/node-require/package.json
+++ b/packages/node-require/package.json
@@ -13,6 +13,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/optimize/package.json
+++ b/packages/optimize/package.json
@@ -13,6 +13,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/relay-operation-optimizer/package.json
+++ b/packages/relay-operation-optimizer/package.json
@@ -25,6 +25,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/resolvers-composition/package.json
+++ b/packages/resolvers-composition/package.json
@@ -14,6 +14,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -13,6 +13,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/stitch/package.json
+++ b/packages/stitch/package.json
@@ -13,6 +13,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/stitching-directives/package.json
+++ b/packages/stitching-directives/package.json
@@ -13,6 +13,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -14,6 +14,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/webpack-loader-runtime/package.json
+++ b/packages/webpack-loader-runtime/package.json
@@ -13,6 +13,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/webpack-loader/package.json
+++ b/packages/webpack-loader/package.json
@@ -13,6 +13,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },

--- a/packages/wrap/package.json
+++ b/packages/wrap/package.json
@@ -13,6 +13,7 @@
   "module": "dist/index.mjs",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "require": "./dist/index.js",
       "import": "./dist/index.mjs"
     },


### PR DESCRIPTION
## Description

Hey @ardatan, we're working towards ESM + CJS builds on Apollo Server and ran into a TS build issue with the `@graphql-tools/schema` and `@graphql-tools/mock` packages when we switched over to `moduleResolution: 'nodenext'`. We're having to make a similar change ourselves with the additional "types" field under the exports.

I tested this change out locally and it solved the TS compile errors. I went ahead and extrapolated the fix to all of the packages here since it seemed sensible.

There's no good anchor to link you to, but here's some documentation, if you search for `"types"` you should see what I'm referring to:
https://www.typescriptlang.org/docs/handbook/esm-node.html

Thanks!

Happy to open an issue if it's required. Skipping the step for now since I need to step away for the evening.

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested locally within the Apollo Server project

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
