### PR TITLE
Introduce 'batch' flag, improve loadSchema and merge wrapped schemas properly

### DIFF
--- a/.changeset/angry-bobcats-double.md
+++ b/.changeset/angry-bobcats-double.md
@@ -1,0 +1,7 @@
+---
+'@graphql-tools/load': patch
+---
+
+No longer call `mergeSchemas` if a single schema is loaded.
+Previously all typeDefs and resolvers were extracted and the schema was rebuilt from scratch.
+But this is not necessary if there is only one schema loaded with `loadSchema`

--- a/.changeset/gold-timers-thank.md
+++ b/.changeset/gold-timers-thank.md
@@ -4,7 +4,7 @@
 '@graphql-tools/utils': minor
 ---
 
-`mergeSchemas` was skipping `defaultFieldResolver` and `defaultMergedResolver` by default while extracting resolvers for each given schema to reduce the overhead. But this doesn't work properly if you mix wrapped schemas and local schemas. So new `all` flag is introduced in `getResolversFromSchema` to put default field resolvers in the extracted resolver map for `mergeSchemas`.
+`mergeSchemas` was skipping `defaultFieldResolver` and `defaultMergedResolver` by default while extracting resolvers for each given schema to reduce the overhead. But this doesn't work properly if you mix wrapped schemas and local schemas. So new `includeDefaultMergedResolver` flag is introduced in `getResolversFromSchema` to put default "proxy" resolvers in the extracted resolver map for `mergeSchemas`.
 
 This fixes an issue with alias issue, so nested aliased fields weren't resolved properly because of the missing `defaultMergedResolver` in the final merged schema which should come from the wrapped schema.
 

--- a/.changeset/gold-timers-thank.md
+++ b/.changeset/gold-timers-thank.md
@@ -1,0 +1,10 @@
+---
+'@graphql-tools/load': minor
+'@graphql-tools/schema': minor
+'@graphql-tools/utils': minor
+---
+
+`mergeSchemas` was skipping `defaultFieldResolver` and `defaultMergedResolver` by default while extracting resolvers for each given schema to reduce the overhead. But this doesn't work properly if you mix wrapped schemas and local schemas. So new `all` flag is introduced in `getResolversFromSchema` to put default field resolvers in the extracted resolver map for `mergeSchemas`.
+
+This fixes an issue with alias issue, so nested aliased fields weren't resolved properly because of the missing `defaultMergedResolver` in the final merged schema which should come from the wrapped schema.
+

--- a/.changeset/gold-timers-thank.md
+++ b/.changeset/gold-timers-thank.md
@@ -7,4 +7,3 @@
 `mergeSchemas` was skipping `defaultFieldResolver` and `defaultMergedResolver` by default while extracting resolvers for each given schema to reduce the overhead. But this doesn't work properly if you mix wrapped schemas and local schemas. So new `includeDefaultMergedResolver` flag is introduced in `getResolversFromSchema` to put default "proxy" resolvers in the extracted resolver map for `mergeSchemas`.
 
 This fixes an issue with alias issue, so nested aliased fields weren't resolved properly because of the missing `defaultMergedResolver` in the final merged schema which should come from the wrapped schema.
-

--- a/.changeset/sweet-clouds-grab.md
+++ b/.changeset/sweet-clouds-grab.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/url-loader': minor
+---
+
+New 'batch' flag! Now you can configure your remote schema to batch parallel queries to the upstream.

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "packages/**/src/**/*.{ts,tsx}": [
       "eslint --fix"
     ],
-    "**/*.{ts,tsx,graphql,yml}": [
+    "**/*.{ts,tsx,graphql,yml,md,mdx}": [
       "prettier --write"
     ]
   },

--- a/packages/load/src/schema.ts
+++ b/packages/load/src/schema.ts
@@ -37,13 +37,14 @@ export async function loadSchema(
   });
 
   const { schemas, typeDefs } = collectSchemasAndTypeDefs(sources);
+  schemas.push(...(options.schemas ?? []));
   const mergeSchemasOptions: MergeSchemasConfig = {
     ...options,
     schemas: schemas.concat(options.schemas ?? []),
     typeDefs,
   };
 
-  const schema = mergeSchemas(mergeSchemasOptions);
+  const schema = typeDefs?.length === 0 && schemas?.length === 1 ? schemas[0] : mergeSchemas(mergeSchemasOptions);
 
   if (options?.includeSources) {
     includeSources(schema, sources);

--- a/packages/loaders/url/src/index.ts
+++ b/packages/loaders/url/src/index.ts
@@ -133,6 +133,10 @@ export interface LoadFromUrlOptions extends BaseLoaderOptions, Partial<Introspec
    * Connection Parameters for WebSockets connection
    */
   connectionParams?: any;
+  /**
+   * Enable Batching
+   */
+  batch?: boolean;
 }
 
 function isCompatibleUri(uri: string): boolean {
@@ -815,6 +819,7 @@ export class UrlLoader implements Loader<LoadFromUrlOptions> {
       source.schema = wrapSchema({
         schema: source.schema,
         executor,
+        batch: options?.batch,
       });
     }
 

--- a/packages/schema/src/merge-schemas.ts
+++ b/packages/schema/src/merge-schemas.ts
@@ -27,7 +27,7 @@ export function mergeSchemas(config: MergeSchemasConfig) {
   const schemas = config.schemas || [];
   for (const schema of schemas) {
     extractedTypeDefs.push(schema);
-    extractedResolvers.push(getResolversFromSchema(schema));
+    extractedResolvers.push(getResolversFromSchema(schema, true));
     extractedSchemaExtensions.push(extractExtensionsFromSchema(schema));
   }
 

--- a/packages/utils/src/getResolversFromSchema.ts
+++ b/packages/utils/src/getResolversFromSchema.ts
@@ -11,12 +11,10 @@ import {
 
 import { IResolvers } from './Interfaces';
 
-const DEFAULT_FIELD_RESOLVERS = ['defaultFieldResolver', 'defaultMergedResolver'];
-
 export function getResolversFromSchema(
   schema: GraphQLSchema,
-  // Include default field resolvers
-  all?: boolean
+  // Include default merged resolvers
+  includeDefaultMergedResolver?: boolean
 ): IResolvers {
   const resolvers = Object.create(null);
 
@@ -65,7 +63,16 @@ export function getResolversFromSchema(
             resolvers[typeName][fieldName] = resolvers[typeName][fieldName] || {};
             resolvers[typeName][fieldName].subscribe = field.subscribe;
           }
-          if (field.resolve != null && (all || !DEFAULT_FIELD_RESOLVERS.includes(field.resolve.name))) {
+          if (field.resolve != null && field.resolve?.name !== 'defaultFieldResolver') {
+            switch (field.resolve?.name) {
+              case 'defaultMergedResolver':
+                if (!includeDefaultMergedResolver) {
+                  continue;
+                }
+                break;
+              case 'defaultFieldResolver':
+                continue;
+            }
             resolvers[typeName][fieldName] = resolvers[typeName][fieldName] || {};
             resolvers[typeName][fieldName].resolve = field.resolve;
           }

--- a/packages/utils/src/getResolversFromSchema.ts
+++ b/packages/utils/src/getResolversFromSchema.ts
@@ -11,7 +11,13 @@ import {
 
 import { IResolvers } from './Interfaces';
 
-export function getResolversFromSchema(schema: GraphQLSchema): IResolvers {
+const DEFAULT_FIELD_RESOLVERS = ['defaultFieldResolver', 'defaultMergedResolver'];
+
+export function getResolversFromSchema(
+  schema: GraphQLSchema,
+  // Include default field resolvers
+  all?: boolean
+): IResolvers {
   const resolvers = Object.create(null);
 
   const typeMap = schema.getTypeMap();
@@ -59,11 +65,7 @@ export function getResolversFromSchema(schema: GraphQLSchema): IResolvers {
             resolvers[typeName][fieldName] = resolvers[typeName][fieldName] || {};
             resolvers[typeName][fieldName].subscribe = field.subscribe;
           }
-          if (
-            field.resolve != null &&
-            field.resolve?.name !== 'defaultFieldResolver' &&
-            field.resolve?.name !== 'defaultMergedResolver'
-          ) {
+          if (field.resolve != null && (all || !DEFAULT_FIELD_RESOLVERS.includes(field.resolve.name))) {
             resolvers[typeName][fieldName] = resolvers[typeName][fieldName] || {};
             resolvers[typeName][fieldName].resolve = field.resolve;
           }

--- a/packages/wrap/tests/makeRemoteExecutableSchema.test.ts
+++ b/packages/wrap/tests/makeRemoteExecutableSchema.test.ts
@@ -17,7 +17,7 @@ describe('remote queries', () => {
     schema = wrapSchema(remoteSubschemaConfig);
   });
 
-  test('should work', async () => {
+  test('should handle interfaces correctly', async () => {
     const query = /* GraphQL */ `
       {
         interfaceTest(kind: ONE) {
@@ -45,6 +45,28 @@ describe('remote queries', () => {
 
     const result = await graphql({ schema, source: query });
     expect(result).toEqual(expected);
+  });
+
+  test('should handle aliases properly', async () => {
+    const query = /* GraphQL */ `
+      query AliasedExample {
+        propertyInAnArray: properties(limit: 1) {
+          id
+          name
+          loc: location {
+            title: name
+          }
+        }
+      }
+    `;
+
+    const result: any = await graphql({ schema, source: query });
+
+    expect(result?.data?.['propertyInAnArray']).toHaveLength(1);
+    expect(result?.data?.['propertyInAnArray'][0]['id']).toBeTruthy();
+    expect(result?.data?.['propertyInAnArray'][0]['name']).toBeTruthy();
+    expect(result?.data?.['propertyInAnArray'][0]['loc']).toBeTruthy();
+    expect(result?.data?.['propertyInAnArray'][0]['loc']['title']).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
`loadSchema`;
No longer call `mergeSchemas` if a single schema is loaded.
Previously all typeDefs and resolvers were extracted and the schema was rebuilt from scratch.
But this is not necessary if there is only one schema loaded with `loadSchema`


`mergeSchemas` was skipping `defaultFieldResolver` and `defaultMergedResolver` by default while extracting resolvers for each given schema to reduce the overhead. But this doesn't work properly if you mix wrapped schemas and local schemas. So new `includeDefaultMergedResolver` flag is introduced in `getResolversFromSchema` to put default "proxy" resolvers in the extracted resolver map for `mergeSchemas`.

This fixes an issue with alias issue, so nested aliased fields weren't resolved properly because of the missing `defaultMergedResolver` in the final merged schema which should come from the wrapped schema.

`UrlLoader`:
New 'batch' flag! Now you can configure your remote schema to batch parallel queries to the upstream.

Closes: https://github.com/ardatan/graphql-tools/issues/3267