### PR TITLE
Smaller resolver package

### DIFF
--- a/.changeset/slow-nails-develop.md
+++ b/.changeset/slow-nails-develop.md
@@ -3,4 +3,5 @@
 '@graphql-tools/schema': patch
 ---
 
-New light resolvers package
+New `@graphql-tools/resolvers` package. This package is useful for attaching resolver to the plain non executable schemas created with `buildSchema` of `graphql-js`.
+Compared to `addResolversToSchema`, it doesn't run additional heal processes etc because it expects the schema already doesn't have any resolvers.

--- a/.changeset/slow-nails-develop.md
+++ b/.changeset/slow-nails-develop.md
@@ -1,0 +1,6 @@
+---
+'@graphql-tools/resolvers': patch
+'@graphql-tools/schema': patch
+---
+
+New light resolvers package

--- a/packages/resolvers/package.json
+++ b/packages/resolvers/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@graphql-tools/resolvers",
+  "version": "0.0.0",
+  "description": "A zero dependency package that adds resolvers to the existing schema",
+  "repository": {
+    "type": "git",
+    "url": "ardatan/graphql-tools",
+    "directory": "packages/resolvers"
+  },
+  "license": "MIT",
+  "sideEffects": false,
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    },
+    "./*": {
+      "require": "./dist/*.js",
+      "import": "./dist/*.mjs"
+    }
+  },
+  "typings": "dist/index.d.ts",
+  "typescript": {
+    "definition": "dist/index.d.ts"
+  },
+  "peerDependencies": {
+    "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+  },
+  "buildOptions": {
+    "input": "./src/index.ts"
+  },
+  "dependencies": {
+    "tslib": "~2.4.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "directory": "dist"
+  }
+}

--- a/packages/resolvers/src/index.ts
+++ b/packages/resolvers/src/index.ts
@@ -1,0 +1,123 @@
+import {
+  GraphQLEnumType,
+  GraphQLField,
+  GraphQLFieldConfig,
+  GraphQLScalarType,
+  GraphQLSchema,
+  isEnumType,
+  isInterfaceType,
+  isObjectType,
+  isScalarType,
+  isUnionType,
+} from 'graphql';
+
+export function setFieldProperties(
+  field: GraphQLField<any, any> | GraphQLFieldConfig<any, any>,
+  propertiesObj: Record<string, any>
+) {
+  for (const propertyName in propertiesObj) {
+    field[propertyName] = propertiesObj[propertyName];
+  }
+}
+
+export function addResolversToExistingSchema(schema: GraphQLSchema, resolvers: any) {
+  const typeMap = schema.getTypeMap();
+  for (const typeName in resolvers) {
+    const type = schema.getType(typeName);
+    const resolverValue = resolvers[typeName];
+
+    if (isScalarType(type)) {
+      for (const fieldName in resolverValue) {
+        if (fieldName.startsWith('__')) {
+          type[fieldName.substring(2)] = resolverValue[fieldName];
+        } else if (fieldName === 'astNode' && type.astNode != null) {
+          type.astNode = {
+            ...type.astNode,
+            description: (resolverValue as GraphQLScalarType)?.astNode?.description ?? type.astNode.description,
+            directives: (type.astNode.directives ?? []).concat(
+              (resolverValue as GraphQLScalarType)?.astNode?.directives ?? []
+            ),
+          };
+        } else if (fieldName === 'extensionASTNodes' && type.extensionASTNodes != null) {
+          type.extensionASTNodes = type.extensionASTNodes.concat(
+            (resolverValue as GraphQLScalarType)?.extensionASTNodes ?? []
+          );
+        } else if (
+          fieldName === 'extensions' &&
+          type.extensions != null &&
+          (resolverValue as GraphQLScalarType).extensions != null
+        ) {
+          type.extensions = Object.assign(
+            Object.create(null),
+            type.extensions,
+            (resolverValue as GraphQLScalarType).extensions
+          );
+        } else {
+          type[fieldName] = resolverValue[fieldName];
+        }
+      }
+    } else if (isEnumType(type)) {
+      const config = type.toConfig();
+      const enumValueConfigMap = config.values;
+
+      for (const fieldName in resolverValue) {
+        if (fieldName.startsWith('__')) {
+          config[fieldName.substring(2)] = resolverValue[fieldName];
+        } else if (fieldName === 'astNode' && config.astNode != null) {
+          config.astNode = {
+            ...config.astNode,
+            description: (resolverValue as GraphQLScalarType)?.astNode?.description ?? config.astNode.description,
+            directives: (config.astNode.directives ?? []).concat(
+              (resolverValue as GraphQLEnumType)?.astNode?.directives ?? []
+            ),
+          };
+        } else if (fieldName === 'extensionASTNodes' && config.extensionASTNodes != null) {
+          config.extensionASTNodes = config.extensionASTNodes.concat(
+            (resolverValue as GraphQLEnumType)?.extensionASTNodes ?? []
+          );
+        } else if (
+          fieldName === 'extensions' &&
+          type.extensions != null &&
+          (resolverValue as GraphQLEnumType).extensions != null
+        ) {
+          type.extensions = Object.assign(
+            Object.create(null),
+            type.extensions,
+            (resolverValue as GraphQLEnumType).extensions
+          );
+        } else if (enumValueConfigMap[fieldName]) {
+          enumValueConfigMap[fieldName].value = resolverValue[fieldName];
+        }
+      }
+
+      Object.assign(typeMap[typeName], new GraphQLEnumType(config));
+    } else if (isUnionType(type)) {
+      for (const fieldName in resolverValue) {
+        if (fieldName.startsWith('__')) {
+          type[fieldName.substring(2)] = resolverValue[fieldName];
+        }
+      }
+    } else if (isObjectType(type) || isInterfaceType(type)) {
+      for (const fieldName in resolverValue) {
+        if (fieldName.startsWith('__')) {
+          // this is for isTypeOf and resolveType and all the other stuff.
+          type[fieldName.substring(2)] = resolverValue[fieldName];
+          continue;
+        }
+
+        const fields = type.getFields();
+        const field = fields[fieldName];
+
+        if (field != null) {
+          const fieldResolve = resolverValue[fieldName];
+          if (typeof fieldResolve === 'function') {
+            // for convenience. Allows shorter syntax in resolver definition file
+            field.resolve = fieldResolve.bind(resolverValue);
+          } else {
+            setFieldProperties(field, fieldResolve);
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/schema/src/addResolversToSchema.ts
+++ b/packages/schema/src/addResolversToSchema.ts
@@ -9,7 +9,6 @@ import {
   GraphQLObjectType,
   isSpecifiedScalarType,
   GraphQLFieldResolver,
-  isScalarType,
   isEnumType,
   isUnionType,
   isInterfaceType,
@@ -25,13 +24,13 @@ import {
   MapperKind,
   forEachDefaultValue,
   serializeInputValue,
-  healSchema,
   parseInputValue,
   forEachField,
 } from '@graphql-tools/utils';
 
 import { checkForResolveTypeResolver } from './checkForResolveTypeResolver';
 import { extendResolversFromInterfaces } from './extendResolversFromInterfaces';
+import { addResolversToExistingSchema } from '@graphql-tools/resolvers';
 
 export function addResolversToSchema(
   schemaOrOptions: GraphQLSchema | IAddResolversToSchemaOptions,
@@ -139,7 +138,7 @@ export function addResolversToSchema(
   }
 
   schema = updateResolversInPlace
-    ? addResolversToExistingSchema(schema, resolvers, defaultFieldResolver)
+    ? addResolversToExistingSchemaWithHealing(schema, resolvers, defaultFieldResolver)
     : createNewSchemaWithResolvers(schema, resolvers, defaultFieldResolver);
 
   if (requireResolversForResolveType && requireResolversForResolveType !== 'ignore') {
@@ -149,115 +148,16 @@ export function addResolversToSchema(
   return schema;
 }
 
-function addResolversToExistingSchema(
+function addResolversToExistingSchemaWithHealing(
   schema: GraphQLSchema,
   resolvers: IResolvers,
   defaultFieldResolver?: GraphQLFieldResolver<any, any>
 ): GraphQLSchema {
-  const typeMap = schema.getTypeMap();
-  for (const typeName in resolvers) {
-    const type = schema.getType(typeName);
-    const resolverValue = resolvers[typeName];
-
-    if (isScalarType(type)) {
-      for (const fieldName in resolverValue) {
-        if (fieldName.startsWith('__')) {
-          type[fieldName.substring(2)] = resolverValue[fieldName];
-        } else if (fieldName === 'astNode' && type.astNode != null) {
-          type.astNode = {
-            ...type.astNode,
-            description: (resolverValue as GraphQLScalarType)?.astNode?.description ?? type.astNode.description,
-            directives: (type.astNode.directives ?? []).concat(
-              (resolverValue as GraphQLScalarType)?.astNode?.directives ?? []
-            ),
-          };
-        } else if (fieldName === 'extensionASTNodes' && type.extensionASTNodes != null) {
-          type.extensionASTNodes = type.extensionASTNodes.concat(
-            (resolverValue as GraphQLScalarType)?.extensionASTNodes ?? []
-          );
-        } else if (
-          fieldName === 'extensions' &&
-          type.extensions != null &&
-          (resolverValue as GraphQLScalarType).extensions != null
-        ) {
-          type.extensions = Object.assign(
-            Object.create(null),
-            type.extensions,
-            (resolverValue as GraphQLScalarType).extensions
-          );
-        } else {
-          type[fieldName] = resolverValue[fieldName];
-        }
-      }
-    } else if (isEnumType(type)) {
-      const config = type.toConfig();
-      const enumValueConfigMap = config.values;
-
-      for (const fieldName in resolverValue) {
-        if (fieldName.startsWith('__')) {
-          config[fieldName.substring(2)] = resolverValue[fieldName];
-        } else if (fieldName === 'astNode' && config.astNode != null) {
-          config.astNode = {
-            ...config.astNode,
-            description: (resolverValue as GraphQLScalarType)?.astNode?.description ?? config.astNode.description,
-            directives: (config.astNode.directives ?? []).concat(
-              (resolverValue as GraphQLEnumType)?.astNode?.directives ?? []
-            ),
-          };
-        } else if (fieldName === 'extensionASTNodes' && config.extensionASTNodes != null) {
-          config.extensionASTNodes = config.extensionASTNodes.concat(
-            (resolverValue as GraphQLEnumType)?.extensionASTNodes ?? []
-          );
-        } else if (
-          fieldName === 'extensions' &&
-          type.extensions != null &&
-          (resolverValue as GraphQLEnumType).extensions != null
-        ) {
-          type.extensions = Object.assign(
-            Object.create(null),
-            type.extensions,
-            (resolverValue as GraphQLEnumType).extensions
-          );
-        } else if (enumValueConfigMap[fieldName]) {
-          enumValueConfigMap[fieldName].value = resolverValue[fieldName];
-        }
-      }
-
-      typeMap[typeName] = new GraphQLEnumType(config);
-    } else if (isUnionType(type)) {
-      for (const fieldName in resolverValue) {
-        if (fieldName.startsWith('__')) {
-          type[fieldName.substring(2)] = resolverValue[fieldName];
-        }
-      }
-    } else if (isObjectType(type) || isInterfaceType(type)) {
-      for (const fieldName in resolverValue) {
-        if (fieldName.startsWith('__')) {
-          // this is for isTypeOf and resolveType and all the other stuff.
-          type[fieldName.substring(2)] = resolverValue[fieldName];
-          continue;
-        }
-
-        const fields = type.getFields();
-        const field = fields[fieldName];
-
-        if (field != null) {
-          const fieldResolve = resolverValue[fieldName];
-          if (typeof fieldResolve === 'function') {
-            // for convenience. Allows shorter syntax in resolver definition file
-            field.resolve = fieldResolve.bind(resolverValue);
-          } else {
-            setFieldProperties(field, fieldResolve);
-          }
-        }
-      }
-    }
-  }
+  addResolversToExistingSchema(schema, resolvers);
 
   // serialize all default values prior to healing fields with new scalar/enum types.
   forEachDefaultValue(schema, serializeInputValue);
-  // schema may have new scalar/enum types that require healing
-  healSchema(schema);
+
   // reparse all default values with new parsing functions.
   forEachDefaultValue(schema, parseInputValue);
 

--- a/packages/schema/src/addResolversToSchema.ts
+++ b/packages/schema/src/addResolversToSchema.ts
@@ -26,6 +26,7 @@ import {
   serializeInputValue,
   parseInputValue,
   forEachField,
+  healSchema,
 } from '@graphql-tools/utils';
 
 import { checkForResolveTypeResolver } from './checkForResolveTypeResolver';
@@ -160,6 +161,9 @@ function addResolversToExistingSchemaWithHealing(
 
   // reparse all default values with new parsing functions.
   forEachDefaultValue(schema, parseInputValue);
+
+  // schema may have new scalar/enum types that require healing
+  healSchema(schema);
 
   if (defaultFieldResolver != null) {
     forEachField(schema, field => {


### PR DESCRIPTION
New `@graphql-tools/resolvers` package. This package is useful for attaching resolver to the plain non executable schemas created with `buildSchema` of `graphql-js`.
Compared to `addResolversToSchema`, it doesn't run additional heal processes etc because it expects the schema already doesn't have any resolvers.


Hopefully this can reduce the bundle size of Yoga because we realized that `schema` package has a lot together with its `utils` dependency.