### PR TITLE
Fix subschemas merge

### DIFF
--- a/packages/stitch/src/createMergedTypeResolver.ts
+++ b/packages/stitch/src/createMergedTypeResolver.ts
@@ -19,7 +19,7 @@ export function createMergedTypeResolver<TContext extends Record<string, any> = 
     ) {
       return batchDelegateToSchema({
         schema: subschema,
-        operation: 'query' as OperationTypeNode,
+        operation: info.operation.operation as OperationTypeNode,
         fieldName,
         returnType: new GraphQLList(type),
         key,
@@ -45,7 +45,7 @@ export function createMergedTypeResolver<TContext extends Record<string, any> = 
     ) {
       return delegateToSchema({
         schema: subschema,
-        operation: 'query' as OperationTypeNode,
+        operation: info.operation.operation as OperationTypeNode,
         fieldName,
         returnType: type,
         args: args(originalResult),

--- a/packages/stitch/tests/stitchMutationSchema.ts
+++ b/packages/stitch/tests/stitchMutationSchema.ts
@@ -3,8 +3,8 @@ import { stitchSchemas } from '../src/stitchSchemas.js';
 import { graphql } from 'graphql';
 import { assertSome } from '@graphql-tools/utils';
 
-describe('Mutation of stitched schema merge', () => {
-  test('Has Mutation.*User, not Query.*User', async () => {
+describe('Mutations executed as mutation on stitched schema', () => {
+  test('Mutation executed when only mutation type is available', async () => {
     const sub0Schema = makeExecutableSchema({
       typeDefs: /* GraphQL */ `
         type Query {
@@ -121,7 +121,7 @@ describe('Mutation of stitched schema merge', () => {
     });
   });
 
-  test('Added Query.*User to both server', async () => {
+  test('Mutation executed when both mutation and query are available', async () => {
     const sub0Schema = makeExecutableSchema({
       typeDefs: /* GraphQL */ `
         type Query {

--- a/packages/stitch/tests/subschemasMerge.test.ts
+++ b/packages/stitch/tests/subschemasMerge.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { stitchSchemas } from '../src/stitchSchemas.js';
 import { graphql } from 'graphql';
@@ -25,12 +24,10 @@ describe('Mutation of stitched schema merge', () => {
       `,
       resolvers: {
         Mutation: {
-          // @ts-ignore
-          zeroUser: (o, { id }) => ({ id }),
+          zeroUser: ({} = {}, { id }) => ({ id }),
         },
         User: {
-          // @ts-ignore
-          zeroValue: (p, a, c, i) => `0: User: ${i.operation.operation}`,
+          zeroValue: ({} = {}, {} = {}, {} = {}, i) => `0: User: ${i.operation.operation}`,
           user: ({ id }) => ({ id }),
         },
       },
@@ -55,12 +52,10 @@ describe('Mutation of stitched schema merge', () => {
       `,
       resolvers: {
         Mutation: {
-          // @ts-ignore
-          oneUser: (o, { id }) => ({ id }),
+          oneUser: ({} = {}, { id }) => ({ id }),
         },
         User: {
-          // @ts-ignore
-          oneValue: (p, a, c, i) => `1: User: ${i.operation.operation}`,
+          oneValue: ({} = {}, {} = {}, {} = {}, i) => `1: User: ${i.operation.operation}`,
           user: ({ id }) => ({ id }),
         },
       },

--- a/packages/stitch/tests/subschemasMerge.test.ts
+++ b/packages/stitch/tests/subschemasMerge.test.ts
@@ -25,9 +25,11 @@ describe('Mutation of stitched schema merge', () => {
       `,
       resolvers: {
         Mutation: {
+          // @ts-ignore
           zeroUser: (o, { id }) => ({ id }),
         },
         User: {
+          // @ts-ignore
           zeroValue: (p, a, c, i) => `0: User: ${i.operation.operation}`,
           user: ({ id }) => ({ id }),
         },
@@ -53,9 +55,11 @@ describe('Mutation of stitched schema merge', () => {
       `,
       resolvers: {
         Mutation: {
+          // @ts-ignore
           oneUser: (o, { id }) => ({ id }),
         },
         User: {
+          // @ts-ignore
           oneValue: (p, a, c, i) => `1: User: ${i.operation.operation}`,
           user: ({ id }) => ({ id }),
         },

--- a/packages/stitch/tests/subschemasMerge.test.ts
+++ b/packages/stitch/tests/subschemasMerge.test.ts
@@ -1,0 +1,123 @@
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { stitchSchemas } from '../src/stitchSchemas.js';
+import { graphql } from 'graphql';
+import { assertSome } from '@graphql-tools/utils';
+
+describe('Mutation of stitched schema merge', () => {
+  test('operation should be mutation', async () => {
+    const sub0Schema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          placeholder: Placeholder
+        }
+        type Placeholder {
+          id: ID!
+        }
+        type Mutation {
+          zeroUser(id: ID): User
+        }
+        type User {
+          id: ID!
+          zeroValue: String
+          user: User!
+        }
+      `,
+      resolvers: {
+        Mutation: {
+          zeroUser: (o, { id }) => ({ id }),
+        },
+        User: {
+          zeroValue: (p, a, c, i) => `0: User: ${i.operation.operation}`,
+          user: ({ id }) => ({ id }),
+        },
+      },
+    });
+
+    const sub1Schema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          placeholder: Placeholder
+        }
+        type Placeholder {
+          id: ID!
+        }
+        type Mutation {
+          oneUser(id: ID): User
+        }
+        type User {
+          id: ID!
+          oneValue: String
+          user: User!
+        }
+      `,
+      resolvers: {
+        Mutation: {
+          oneUser: (o, { id }) => ({ id }),
+        },
+        User: {
+          oneValue: (p, a, c, i) => `1: User: ${i.operation.operation}`,
+          user: ({ id }) => ({ id }),
+        },
+      },
+    });
+    const mergedSchema = stitchSchemas({
+      subschemas: [
+        {
+          schema: sub1Schema,
+          merge: {
+            User: {
+              fieldName: 'oneUser',
+              selectionSet: '{ id }',
+              args: o => ({ id: o.id }),
+            },
+          },
+        },
+        {
+          schema: sub0Schema,
+          merge: {
+            User: {
+              fieldName: 'zeroUser',
+              selectionSet: '{ id }',
+              args: o => ({ id: o.id }),
+            },
+          },
+        },
+      ],
+      mergeTypes: true, // << default in v7
+    });
+    const { data } = await graphql({
+      schema: mergedSchema,
+      source: /* GraphQL */ `
+        mutation {
+          # or oneUser, which zeroValue becomes null
+          zeroUser(id: 1) {
+            __typename
+            id
+            zeroValue
+            oneValue
+            user {
+              __typename
+              id
+              zeroValue
+              oneValue
+            }
+          }
+        }
+      `,
+    });
+    assertSome(data);
+    const userData: any = data['zeroUser'];
+    expect(userData).toEqual({
+      __typename: 'User',
+      id: '1',
+      oneValue: '1: User: mutation',
+      zeroValue: '0: User: mutation',
+      user: {
+        __typename: 'User',
+        id: '1',
+        oneValue: '1: User: mutation',
+        zeroValue: '0: User: mutation',
+      },
+    });
+  });
+});

--- a/packages/stitch/tests/subschemasMerge.test.ts
+++ b/packages/stitch/tests/subschemasMerge.test.ts
@@ -4,7 +4,7 @@ import { graphql } from 'graphql';
 import { assertSome } from '@graphql-tools/utils';
 
 describe('Mutation of stitched schema merge', () => {
-  test('operation should be mutation', async () => {
+  test('Has Mutation.*User, not Query.*User', async () => {
     const sub0Schema = makeExecutableSchema({
       typeDefs: /* GraphQL */ `
         type Query {
@@ -51,6 +51,131 @@ describe('Mutation of stitched schema merge', () => {
         }
       `,
       resolvers: {
+        Mutation: {
+          oneUser: (_p, { id }) => ({ id }),
+        },
+        User: {
+          oneValue: (_p, _a, _c, i) => `1: User: ${i.operation.operation}`,
+          user: ({ id }) => ({ id }),
+        },
+      },
+    });
+    const mergedSchema = stitchSchemas({
+      subschemas: [
+        {
+          schema: sub1Schema,
+          merge: {
+            User: {
+              fieldName: 'oneUser',
+              selectionSet: '{ id }',
+              args: o => ({ id: o.id }),
+            },
+          },
+        },
+        {
+          schema: sub0Schema,
+          merge: {
+            User: {
+              fieldName: 'zeroUser',
+              selectionSet: '{ id }',
+              args: o => ({ id: o.id }),
+            },
+          },
+        },
+      ],
+      mergeTypes: true, // << default in v7
+    });
+    const { data } = await graphql({
+      schema: mergedSchema,
+      source: /* GraphQL */ `
+        mutation {
+          # or oneUser, which zeroValue becomes null
+          zeroUser(id: 1) {
+            __typename
+            id
+            zeroValue
+            oneValue
+            user {
+              __typename
+              id
+              zeroValue
+              oneValue
+            }
+          }
+        }
+      `,
+    });
+    assertSome(data);
+    const userData: any = data['zeroUser'];
+    expect(userData).toEqual({
+      __typename: 'User',
+      id: '1',
+      oneValue: '1: User: mutation',
+      zeroValue: '0: User: mutation',
+      user: {
+        __typename: 'User',
+        id: '1',
+        oneValue: '1: User: mutation',
+        zeroValue: '0: User: mutation',
+      },
+    });
+  });
+
+  test('Added Query.*User to both server', async () => {
+    const sub0Schema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          placeholder: Placeholder
+          zeroUser(id: ID): User
+        }
+        type Placeholder {
+          id: ID!
+        }
+        type Mutation {
+          zeroUser(id: ID): User
+        }
+        type User {
+          id: ID!
+          zeroValue: String
+          user: User!
+        }
+      `,
+      resolvers: {
+        Query: {
+          zeroUser: (_p, { id }) => ({ id }),
+        },
+        Mutation: {
+          zeroUser: (_p, { id }) => ({ id }),
+        },
+        User: {
+          zeroValue: (_p, _a, _c, i) => `0: User: ${i.operation.operation}`,
+          user: ({ id }) => ({ id }),
+        },
+      },
+    });
+
+    const sub1Schema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          placeholder: Placeholder
+          oneUser(id: ID): User
+        }
+        type Placeholder {
+          id: ID!
+        }
+        type Mutation {
+          oneUser(id: ID): User
+        }
+        type User {
+          id: ID!
+          oneValue: String
+          user: User!
+        }
+      `,
+      resolvers: {
+        Query: {
+          oneUser: (_p, { id }) => ({ id }),
+        },
         Mutation: {
           oneUser: (_p, { id }) => ({ id }),
         },

--- a/packages/stitch/tests/subschemasMerge.test.ts
+++ b/packages/stitch/tests/subschemasMerge.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { stitchSchemas } from '../src/stitchSchemas.js';
 import { graphql } from 'graphql';

--- a/packages/stitch/tests/subschemasMerge.test.ts
+++ b/packages/stitch/tests/subschemasMerge.test.ts
@@ -24,10 +24,10 @@ describe('Mutation of stitched schema merge', () => {
       `,
       resolvers: {
         Mutation: {
-          zeroUser: ({} = {}, { id }) => ({ id }),
+          zeroUser: (_p, { id }) => ({ id }),
         },
         User: {
-          zeroValue: ({} = {}, {} = {}, {} = {}, i) => `0: User: ${i.operation.operation}`,
+          zeroValue: (_p, _a, _c, i) => `0: User: ${i.operation.operation}`,
           user: ({ id }) => ({ id }),
         },
       },
@@ -52,10 +52,10 @@ describe('Mutation of stitched schema merge', () => {
       `,
       resolvers: {
         Mutation: {
-          oneUser: ({} = {}, { id }) => ({ id }),
+          oneUser: (_p, { id }) => ({ id }),
         },
         User: {
-          oneValue: ({} = {}, {} = {}, {} = {}, i) => `1: User: ${i.operation.operation}`,
+          oneValue: (_p, _a, _c, i) => `1: User: ${i.operation.operation}`,
           user: ({ id }) => ({ id }),
         },
       },


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

Bug fix for on graphql query is `mutation`, stitched schema executed `query` rather than `mutation`.  
On test v1, There is no `*User` in the field `Query` so it returns `null` when we use `Mutation` to query to server.
On test v2, We add `*User` to the field `Query`, We can see it return operation type to be `Query` even we query with `Mutation`.  
The bug is caused by hardcode `'query'` in stitched schema, changing to `info.operation.operation` can fix the bug. 
Detain explanation in #4508 

* Add failing test for the bug

* Fix the bug by changing `'query'` to `operation: info.operation.operation`

Co-authored-by: 
- @kftsehk
- @Abbywpy


<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):
![image](https://user-images.githubusercontent.com/20808792/172062871-14db57ce-df19-4c73-bed7-76a716ec7aa0.png)  
https://www.graphql-tools.com/docs/schema-stitching/stitch-type-merging#merging-flow  
If such field name is not defined in Query of stitched schema, the merged resolver fails silently returning null result.

## How Has This Been Tested?
### To reproduce
```
cd gateway
npm i
pip install awscli aws-sam-cli
sam local start-api -t ./local.yml -l message.log --host 0.0.0.0 -p 3000
```
query in both test case
```graphql
mutation {
  # or oneUser, which zeroValue becomes null
  zeroUser(id: 1) {
    __typename
    id
    zeroValue
    oneValue
    user {
      __typename
      id
      zeroValue
      oneValue
    }
  }
}
```
- [x] [Has Mutation.*User, not Query.*User](https://github.com/flyingmilktea/graphql-bug-reproduce/tree/mutation-fwd-query-v1)  
  
Result
```json
{
  "data": {
    "zeroUser": {
      "__typename": "User",
      "id": "1",
      "zeroValue": "0: User: mutation",
      "oneValue": null,
      "user": {
        "__typename": "User",
        "id": "1",
        "zeroValue": "0: User: mutation",
        "oneValue": null
      }
    }
  }
}
```  
- [x] [Added Query.*User to both server](https://github.com/flyingmilktea/graphql-bug-reproduce/tree/mutation-fwd-query-v2)  
  
Result
```json
{
  "data": {
    "zeroUser": {
      "__typename": "User",
      "id": "1",
      "zeroValue": "0: User: mutation",
      "oneValue": "1: User: query",
      "user": {
        "__typename": "User",
        "id": "1",
        "zeroValue": "0: User: mutation",
        "oneValue": "1: User: query"
      }
    }
  }
}
```  

**On both tests we expected result to be**
```json
{
  "data": {
    "zeroUser": {
      "__typename": "User",
      "id": "1",
      "zeroValue": "0: User: mutation",
      "oneValue": "1: User: mutation",
      "user": {
        "__typename": "User",
        "id": "1",
        "zeroValue": "0: User: mutation",
        "oneValue": "1: User: mutation"
      }
    }
  }
}
```

**Test Environment**:

- OS: Linux 4.18.0-372.9.1.el8.x86_64
- `@graphql-tools/graphql-file-loader: ^7.3.14`
- `@graphql-tools/load: ^7.5.13`
- `@graphql-tools/schema: ^8.3.13`
- `@graphql-tools/stitch: ^8.6.12`
- `@graphql-yoga/node: ^2.8.0`
- `@vendia/serverless-express: ^4.8.0`
- NodeJS: v14.19.3

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
