### PR TITLE
New 'disable' flag for UrlLoaderOptions.credentials

### DIFF
--- a/.changeset/sharp-paws-call.md
+++ b/.changeset/sharp-paws-call.md
@@ -1,0 +1,9 @@
+---
+'@graphql-tools/url-loader': minor
+---
+
+Some environments like CF Workers don't support `credentials` in RequestInit object. But by default UrlLoader sends 'same-origin' and it wasn't possible to disable it. Now you can pass 'disable' to remove `credentials` property from RequestInit object completely.
+
+```ts
+new UrlLoader().load(url, { credentials: 'disable' })
+```


### PR DESCRIPTION
Closes https://github.com/ardatan/graphql-tools/issues/4550

Some environments like CF Workers don't support `credentials` in RequestInit object. But by default UrlLoader sends 'same-origin' and it wasn't possible to disable it. Now you can pass 'disable' to remove `credentials` property from RequestInit object completely.