### PR TITLE
Fix Github loader responding with  401 with invalid credentials

### DIFF
--- a/.changeset/tidy-mangos-wash.md
+++ b/.changeset/tidy-mangos-wash.md
@@ -1,0 +1,17 @@
+---
+'@graphql-tools/github-loader': patch
+---
+
+Fix Github loader responding with 401 with invalid credentials
+
+Running the GitHub loader on a private repository with a missing or invalid GitHub token masks the real error as [object Object].
+This happens because the GitHub GraphQL api returns 401 unauthorized if the token is not valid.
+After some debugging the only http status code i could find that triggers this is 401.
+With the returned payload being:
+
+This update fixes the problem for 401 by passing status to `handleResponse` and checking if that is 401 and reporting the correct message returned from Github.
+The response from github being:
+
+```
+{"message":"Bad credentials","documentation_url":"https://docs.github.com/graphql"}
+```

--- a/packages/loaders/github/src/index.ts
+++ b/packages/loaders/github/src/index.ts
@@ -68,7 +68,8 @@ export class GithubLoader implements Loader<GithubLoaderOptions> {
       this.prepareRequest({ owner, ref, path, name, options })
     );
     const response = await request.json();
-    return this.handleResponse({ pointer, path, options, response });
+    const status = request.status;
+    return this.handleResponse({ pointer, path, options, response, status });
   }
 
   loadSync(pointer: string, options: GithubLoaderOptions): Source[] {
@@ -79,14 +80,29 @@ export class GithubLoader implements Loader<GithubLoaderOptions> {
     const fetch = options.customFetch || syncFetch;
     const request = fetch('https://api.github.com/graphql', this.prepareRequest({ owner, ref, path, name, options }));
     const response = request.json();
-    return this.handleResponse({ pointer, path, options, response });
+    const status = request.status;
+    return this.handleResponse({ pointer, path, options, response, status });
   }
 
-  handleResponse({ pointer, path, options, response }: { pointer: string; path: string; options: any; response: any }) {
+  handleResponse({
+    pointer,
+    path,
+    options,
+    response,
+    status,
+  }: {
+    pointer: string;
+    path: string;
+    options: any;
+    response: any;
+    status: number;
+  }) {
     let errorMessage: string | null = null;
 
     if (response.errors && response.errors.length > 0) {
       errorMessage = response.errors.map((item: Error) => item.message).join(', ');
+    } else if (status === 401) {
+      errorMessage = response.message;
     } else if (!response.data) {
       errorMessage = response;
     }


### PR DESCRIPTION
Github graphql API responds with HTTP status 401 when the token is
invalid.

<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description
Running the GitHub loader on a private repository with a missing or invalid GitHub token masks the real error as [object Object].
This happens because the GitHub GraphQL api returns 401 unauthorized if the token is not valid.
After some debugging the only http status code i could find that triggers this is 401.
With the returned payload being:

This PR fixes the problem for 401 by passing status to `handleResponse` and checking if that is 401 and reporting the correct message returned from Github. 
The response from github being: 
```
{"message":"Bad credentials","documentation_url":"https://docs.github.com/graphql"}
```

Related #4578 

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Run the old version vs this PR in a side by side comparison in the current project. 
- [X] Ran project tests + lint + typescript checks to verify that nothing broke. 

**Test Environment**:

- OS: MacOS
- `@graphql-tools/github-loader`: 7.3.1
- NodeJS: 16.15.1

## Checklist:

- [X] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests and linter rules pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments

This solution is fairly simple. The reason for just including 401 or checking if the status code != 200 and then checking for a message is because during testing i only found 401 to be an issue. This however is up for discussion if a "catch-all" is the preferred method of solving this issue. 
A more complete solution could possibly include the documentation url from the response body.
