### PR TITLE
fix(url-loader): ignore readable stream errors after completion

### DIFF
--- a/.changeset/curly-tools-refuse.md
+++ b/.changeset/curly-tools-refuse.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/url-loader': patch
+---
+
+Ignore readable stream errors after completion (browsers raise errors after canceling fetch requests)

--- a/packages/loaders/url/src/event-stream/handleReadableStream.ts
+++ b/packages/loaders/url/src/event-stream/handleReadableStream.ts
@@ -10,38 +10,49 @@ export function handleReadableStream(readableStream: ReadableStream<Uint8Array>)
       const reader = readableStream.getReader();
       let completed = false;
       function pump() {
-        return reader.read().then(({ done, value }) => {
-          if (completed) {
-            return;
-          }
-          if (value) {
-            const chunk = typeof value === 'string' ? value : textDecoder.decode(value, { stream: true });
-            for (const part of chunk.split('\n\n')) {
-              if (part) {
-                const eventStr = part.split('event: ')[1];
-                const dataStr = part.split('data: ')[1];
-                if (eventStr === 'complete') {
-                  observer.complete();
-                }
-                if (dataStr) {
-                  const data = JSON.parse(dataStr);
-                  observer.next(data.payload || data);
+        return reader
+          .read()
+          .then(({ done, value }) => {
+            if (completed) {
+              return;
+            }
+            if (value) {
+              const chunk = typeof value === 'string' ? value : textDecoder.decode(value, { stream: true });
+              for (const part of chunk.split('\n\n')) {
+                if (part) {
+                  const eventStr = part.split('event: ')[1];
+                  const dataStr = part.split('data: ')[1];
+                  if (eventStr === 'complete') {
+                    observer.complete();
+                  }
+                  if (dataStr) {
+                    const data = JSON.parse(dataStr);
+                    observer.next(data.payload || data);
+                  }
                 }
               }
             }
-          }
-          if (done) {
-            observer.complete();
-          } else {
-            pump();
-          }
-        });
+            if (done) {
+              observer.complete();
+            } else {
+              pump();
+            }
+          })
+          .catch(e => {
+            // canceling a request in browsers throws an error,
+            // ignore it to avoid uncaught promise exceptions
+            if (!completed) throw e;
+          });
       }
       pump();
       return {
         unsubscribe: () => {
-          reader.cancel();
           completed = true;
+          reader.cancel().catch(e => {
+            // canceling a request in browsers throws an error,
+            // ignore it to avoid uncaught promise exceptions
+            if (!completed) throw e;
+          });
         },
       };
     },

--- a/packages/loaders/url/tests/url-loader-browser.spec.ts
+++ b/packages/loaders/url/tests/url-loader-browser.spec.ts
@@ -298,6 +298,9 @@ describe('[url-loader] webpack bundle compat', () => {
         }
       `);
 
+      const pageerrorFn = jest.fn();
+      page.on('pageerror', pageerrorFn);
+
       const result = await page.evaluate(
         async (httpAddress, document) => {
           const module = window['GraphQLToolsUrlLoader'] as typeof UrlLoaderModule;
@@ -324,6 +327,9 @@ describe('[url-loader] webpack bundle compat', () => {
       expect(await responseClosed$!).toBe(true);
 
       expect(result).toStrictEqual(sentDatas.slice(0, 2));
+
+      // no uncaught errors should be reported (browsers raise errors when canceling requests)
+      expect(pageerrorFn).not.toBeCalled();
     });
   } else {
     it('dummy', () => {});


### PR DESCRIPTION
## Description

Canceling a `fetch` request in a browser throws an "user aborted" error in the reader and its cancel method.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

By using the `UrlLoader from @graphql-tools/url-loader` for GraphiQL's fetcher.

**Test Environment**:

- Chrome and Safari: `latest`
- `@graphql-tools/url-loader`: `7.13.2`

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
