### PR TITLE
fix(stitching): ensure transformSchema called only once

### DIFF
--- a/.changeset/dry-drinks-hammer.md
+++ b/.changeset/dry-drinks-hammer.md
@@ -1,0 +1,7 @@
+---
+'@graphql-tools/delegate': patch
+'@graphql-tools/stitch': patch
+'@graphql-tools/wrap': patch
+---
+
+Do not call `Transform.transformSchema` more than once

--- a/packages/delegate/src/Subschema.ts
+++ b/packages/delegate/src/Subschema.ts
@@ -25,7 +25,7 @@ export class Subschema<K = any, V = any, C = K, TContext = Record<string, any>>
 
   public createProxyingResolver?: CreateProxyingResolverFn<TContext>;
   public transforms: Array<Transform<any, TContext>>;
-  public transformedSchema: GraphQLSchema;
+  private _transformedSchema: GraphQLSchema | undefined;
 
   public merge?: Record<string, MergedTypeConfig<any, any, TContext>>;
 
@@ -38,8 +38,19 @@ export class Subschema<K = any, V = any, C = K, TContext = Record<string, any>>
 
     this.createProxyingResolver = config.createProxyingResolver;
     this.transforms = config.transforms ?? [];
-    this.transformedSchema = applySchemaTransforms(this.schema, config);
 
     this.merge = config.merge;
+  }
+
+  get transformedSchema(): GraphQLSchema {
+    if (!this._transformedSchema) {
+      console.warn('Transformed schema is not set yet. Returning a dummy one.');
+      this._transformedSchema = applySchemaTransforms(this.schema, this);
+    }
+    return this._transformedSchema;
+  }
+
+  set transformedSchema(value: GraphQLSchema) {
+    this._transformedSchema = value;
   }
 }

--- a/packages/stitch/src/typeCandidates.ts
+++ b/packages/stitch/src/typeCandidates.ts
@@ -13,7 +13,6 @@ import {
   OperationTypeNode,
 } from 'graphql';
 
-import { wrapSchema } from '@graphql-tools/wrap';
 import { Subschema, SubschemaConfig, StitchingInfo } from '@graphql-tools/delegate';
 import {
   GraphQLParseOptions,
@@ -29,6 +28,7 @@ import { MergeTypeCandidate, MergeTypeFilter, OnTypeConflict, TypeMergingOptions
 import { mergeCandidates } from './mergeCandidates.js';
 import { extractDefinitions } from './definitions.js';
 import { mergeTypeDefs } from '@graphql-tools/merge';
+import { wrapSchema } from '@graphql-tools/wrap';
 
 type CandidateSelector<TContext = Record<string, any>> = (
   candidates: Array<MergeTypeCandidate<TContext>>
@@ -80,7 +80,7 @@ export function buildTypeCandidates<TContext extends Record<string, any> = Recor
   const rootTypeNameMap = getRootTypeNameMap(schemaDefs);
 
   for (const subschema of subschemas) {
-    const schema = wrapSchema(subschema);
+    const schema = (subschema.transformedSchema = wrapSchema(subschema));
 
     const rootTypeMap = getRootTypeMap(schema);
     const rootTypes = getRootTypes(schema);

--- a/packages/wrap/src/wrapSchema.ts
+++ b/packages/wrap/src/wrapSchema.ts
@@ -6,13 +6,13 @@ import {
   GraphQLFieldResolver,
 } from 'graphql';
 
-import { MapperKind, mapSchema } from '@graphql-tools/utils';
+import { MapperKind, mapSchema, memoize1 } from '@graphql-tools/utils';
 
-import { SubschemaConfig, defaultMergedResolver, applySchemaTransforms } from '@graphql-tools/delegate';
+import { SubschemaConfig, defaultMergedResolver, applySchemaTransforms, Subschema } from '@graphql-tools/delegate';
 import { generateProxyingResolvers } from './generateProxyingResolvers.js';
 
-export function wrapSchema<TConfig extends Record<string, any> = Record<string, any>>(
-  subschemaConfig: SubschemaConfig<any, any, any, TConfig>
+export const wrapSchema = memoize1(function wrapSchema<TConfig extends Record<string, any> = Record<string, any>>(
+  subschemaConfig: SubschemaConfig<any, any, any, TConfig> | Subschema<any, any, any, TConfig>
 ): GraphQLSchema {
   const targetSchema = subschemaConfig.schema;
 
@@ -20,7 +20,7 @@ export function wrapSchema<TConfig extends Record<string, any> = Record<string, 
   const schema = createWrappingSchema(targetSchema, proxyingResolvers);
 
   return applySchemaTransforms(schema, subschemaConfig);
-}
+});
 
 function createWrappingSchema(
   schema: GraphQLSchema,


### PR DESCRIPTION
Fixes https://github.com/ardatan/graphql-tools/discussions/4631

After the refactor done in https://github.com/ardatan/graphql-tools/pull/4566, transforms are called twice.
This removes that call, too.