### PR TITLE
When using useGETForQueries make the URL as short as possible by stripping out all ignored characters

### DIFF
--- a/.changeset/weak-news-cough.md
+++ b/.changeset/weak-news-cough.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/url-loader': patch
+---
+
+When using useGETForQueries make the URL as short as possible by stripping out all ignored characters

--- a/packages/loaders/url/src/index.ts
+++ b/packages/loaders/url/src/index.ts
@@ -2,6 +2,7 @@
 /// <reference lib="dom" />
 import {
   print,
+  stripIgnoredCharacters,
   IntrospectionOptions,
   GraphQLError,
   buildASTSchema,
@@ -275,7 +276,7 @@ export class UrlLoader implements Loader<LoadFromUrlOptions> {
       ? `${dummyHostname}${HTTP_URL}`
       : `${dummyHostname}/${HTTP_URL}`;
     const urlObj = new URL(validUrl);
-    urlObj.searchParams.set('query', query);
+    urlObj.searchParams.set('query', stripIgnoredCharacters(query));
     if (variables && Object.keys(variables).length > 0) {
       urlObj.searchParams.set('variables', JSON.stringify(variables));
     }


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Related #4658

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] [Test](https://github.com/ardatan/graphql-tools/blob/27bdc23713a5176485ac940fc5431256b4f2de8d/packages/loaders/url/tests/url-loader.spec.ts#L147-L168) still runs successfully
- [x] Already using this in our production environment with a patch.

**Test Environment**:

- OS:
- `@graphql-tools/...`:
- NodeJS:

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
