### PR TITLE
Adding support for module import paths

### DIFF
--- a/.changeset/violet-cows-impress.md
+++ b/.changeset/violet-cows-impress.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/import': minor
+---
+
+Minor bump to support import installed modules

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,13 +8,19 @@ const tsconfig = require(TSCONFIG);
 
 const ESM_PACKAGES = ['graphql', 'graphql-upload', 'fs-capacitor'];
 
+const moduleNameMap = {
+  //This line is to enable testing import with require.resolve, which would normally get intercepted
+  '^@graphql\-tools\/import\/(.*).graphql$': `${ROOT_DIR}/packages/import/$1.graphql`,
+  ...pathsToModuleNameMapper(tsconfig.compilerOptions.paths, { prefix: `${ROOT_DIR}/` })
+};
+
 module.exports = {
   testEnvironment: 'node',
   rootDir: ROOT_DIR,
   restoreMocks: true,
   reporters: ['default'],
   modulePathIgnorePatterns: ['dist', 'test-assets', 'test-files', 'fixtures', '.bob'],
-  moduleNameMapper: pathsToModuleNameMapper(tsconfig.compilerOptions.paths, { prefix: `${ROOT_DIR}/` }),
+  moduleNameMapper: moduleNameMap,
   collectCoverage: false,
   cacheDirectory: resolve(ROOT_DIR, `${CI ? '' : 'node_modules/'}.cache/jest`),
   transform: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,8 +10,8 @@ const ESM_PACKAGES = ['graphql', 'graphql-upload', 'fs-capacitor'];
 
 const moduleNameMap = {
   //This line is to enable testing import with require.resolve, which would normally get intercepted
-  '^@graphql\-tools\/import\/(.*).graphql$': `${ROOT_DIR}/packages/import/$1.graphql`,
-  ...pathsToModuleNameMapper(tsconfig.compilerOptions.paths, { prefix: `${ROOT_DIR}/` })
+  '^@graphql-tools/import/(.*).graphql$': `${ROOT_DIR}/packages/import/$1.graphql`,
+  ...pathsToModuleNameMapper(tsconfig.compilerOptions.paths, { prefix: `${ROOT_DIR}/` }),
 };
 
 module.exports = {

--- a/packages/import/src/index.ts
+++ b/packages/import/src/index.ts
@@ -93,12 +93,24 @@ export function processImport(
       };
 }
 
+function isRequirePath(filePath: string): boolean {
+  return filePath.startsWith('require:');
+}
+
+function resolveRequirePath(filePath: string): string {
+  return require.resolve(filePath.slice(8));
+}
+
 function visitFile(
   filePath: string,
   cwd: string,
   visitedFiles: VisitedFilesMap,
   predefinedImports: Record<string, string>
 ): Map<string, Set<DefinitionNode>> {
+  // Support paths to npm modules
+  if (isRequirePath(filePath)) {
+    filePath = resolveRequirePath(filePath);
+  }
   if (!isAbsolute(filePath) && !(filePath in predefinedImports)) {
     filePath = resolveFilePath(cwd, filePath);
   }

--- a/packages/import/tests/schema/fixtures/require-paths/a.graphql
+++ b/packages/import/tests/schema/fixtures/require-paths/a.graphql
@@ -1,0 +1,3 @@
+type A {
+  field: String
+}

--- a/packages/import/tests/schema/fixtures/require-paths/b.graphql
+++ b/packages/import/tests/schema/fixtures/require-paths/b.graphql
@@ -1,0 +1,5 @@
+# import A from "require:@graphql-tools/import/tests/schema/fixtures/require-paths/a.graphql"
+
+type B {
+  a: A
+}

--- a/packages/import/tests/schema/import-schema.spec.ts
+++ b/packages/import/tests/schema/import-schema.spec.ts
@@ -650,6 +650,20 @@ describe('importSchema', () => {
     expect(actualSDL).toBeSimilarGqlDoc(expectedSDL);
   });
 
+  test('require paths', () => {
+    const expectedSDL = /* GraphQL */ `
+      type A {
+        field: String
+      }
+
+      type B {
+        a: A
+      }
+    `;
+    const actualSDL = importSchema('./fixtures/require-paths/b.graphql');
+    expect(actualSDL).toBeSimilarGqlDoc(expectedSDL);
+  });
+
   test('root field imports', () => {
     const expectedSDL = /* GraphQL */ `
       type Query {

--- a/website/docs/schema-loading.mdx
+++ b/website/docs/schema-loading.mdx
@@ -139,6 +139,14 @@ type Comment {
 }
 ```
 
+Import also supports paths to installed modules. Example:
+
+```graphql
+# import Post, Comment from "require:blog-graphql-types/schema.graphql
+```
+
+Note: this functionality resolves using `require.resolve` on matching paths.
+
 ### Binding to HTTP Server
 
 You can extend loaded schema with resolvers


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

This change adds support for `#import` statements to use paths to modules.

Example: 

```
# import A from "require:someModule/schema.graphql"
```

A simplified form, assuming the module package `main` points at a schema could be:

```
# import A from "require:someModule"
```

This is particularly useful for both published shared types and monorepos that wish to avoid relative paths between packages.

Related: https://github.com/ardatan/graphql-tools/discussions/4721

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

See `import-schema.spec.ts` test: "require paths"

**Test Environment**:

- OS:
- `@graphql-tools/...`:
- NodeJS:

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

Because jest intercepts require statements, I added a path override to the module mapper to ensure the test is able to run.
