### PR TITLE
Read and use the `connectionParams` from operation extensions

### DIFF
--- a/.changeset/early-donkeys-join.md
+++ b/.changeset/early-donkeys-join.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/executor-graphql-ws': minor
+---
+
+Read and use `connectionParams` from operation extensions

--- a/packages/loaders/url/src/index.ts
+++ b/packages/loaders/url/src/index.ts
@@ -91,7 +91,7 @@ export interface LoadFromUrlOptions extends BaseLoaderOptions, Partial<Introspec
   /**
    * Connection Parameters for WebSockets connection
    */
-  connectionParams?: any;
+  connectionParams?: Record<string, unknown> | (() => Record<string, unknown>);
   /**
    * Enable Batching
    */
@@ -154,7 +154,7 @@ export class UrlLoader implements Loader<LoadFromUrlOptions> {
   buildWSExecutor(
     subscriptionsEndpoint: string,
     webSocketImpl: typeof WebSocket,
-    connectionParams?: Record<string, any>
+    connectionParams?: Record<string, unknown> | (() => Record<string, unknown>)
   ): Executor {
     const WS_URL = switchProtocols(subscriptionsEndpoint, {
       https: 'wss',


### PR DESCRIPTION
Continuation task of https://github.com/Urigo/graphql-mesh/pull/4724

Uses the `connectionParams` from the operation extensions to extend the WebSocket connection parameters.

Are there any security implications with doing this?