### PR TITLE
Add missing import extension, check with lint

### DIFF
--- a/.changeset/short-melons-tell.md
+++ b/.changeset/short-melons-tell.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/utils': patch
+---
+
+Fix build break in v8.13.0 in some ESM environments.

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,8 +4,14 @@ module.exports = {
   parserOptions: {
     project: './tsconfig.json',
   },
-  extends: ['eslint:recommended', 'standard', 'prettier', 'plugin:@typescript-eslint/recommended'],
-  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'standard',
+    'prettier',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:import/typescript',
+  ],
+  plugins: ['@typescript-eslint', 'import'],
   rules: {
     'no-empty': 'off',
     'no-console': 'off',
@@ -93,6 +99,14 @@ module.exports = {
         'no-throw-literal': 'off',
         'promise/param-names': 'off',
       },
+    },
+    {
+      // Require extensions on all imports (other than package imports) outside
+      // of tests, as some ESM environments expect this when loading files.
+      // We don't check tests because they don't get compiled into the packages.
+      files: ['**/*.ts'],
+      excludedFiles: ['**/{test,tests,testing}/**/*.{ts,js}', '*.{spec,test}.{ts,js}'],
+      rules: { 'import/extensions': ['error', 'ignorePackages'] },
     },
   ],
   ignorePatterns: [

--- a/packages/utils/src/Path.ts
+++ b/packages/utils/src/Path.ts
@@ -1,4 +1,4 @@
-import { Maybe } from './types';
+import { Maybe } from './types.js';
 
 export interface Path {
   readonly prev: Path | undefined;

--- a/packages/utils/src/jsutils.ts
+++ b/packages/utils/src/jsutils.ts
@@ -1,4 +1,4 @@
-import { MaybePromise } from './executor';
+import { MaybePromise } from './executor.js';
 
 export function isIterableObject(value: unknown): value is Iterable<unknown> {
   return value != null && typeof value === 'object' && Symbol.iterator in value;


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

This is a build regression from #4778. I can file an issue if you really want me to.

## Description

Some pure-ESM processors (eg, `tsc` with `moduleResolution: 'nodenext') require extensions on all imports. #4778 added two import-less extensions. This PR fixes them and adds linting (from an already-installed plugin) to catch future errors. Test execution does not appear to require these extensions so we only check non-test files (there's another 17 errors to fix if you want to check tests too).

While this requirement isn't documented anywhere I found quickly, I have to assume it's intentional (since #4539) because every other import uses it.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

n/a

## How Has This Been Tested?

#4778 (specifically, `@graphql-tools/utils@8.13.0` [broke a build](https://app.circleci.com/pipelines/github/apollographql/apollo-server/18021/workflows/7293cdd3-8dd6-42ad-a9b9-b32cc07127a9/jobs/142855) in my project.

The breakage pointed directly at these two lines.

The lint rule I added also found only these two lines. So I fixed them. I have not yet actually verified that the built package fixes my original problem, but it sure seems likely.
## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

Pretty simple I hope.