### PR TITLE
Requires tslib

### DIFF
--- a/.changeset/light-cups-kneel.md
+++ b/.changeset/light-cups-kneel.md
@@ -1,0 +1,5 @@
+---
+"@graphql-tools/executor": patch
+---
+
+add `tslib` as a dependency

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -55,6 +55,7 @@
     "@repeaterjs/repeater": "3.0.4",
     "@graphql-tools/utils": "9.0.0",
     "@graphql-typed-document-node/core": "3.1.1",
+    "tslib": "^2.4.0",
     "value-or-promise": "1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

When using Yarn 3, the usage of `@graphql-tools/executor` results in an error because it is requiring tslib but it isn't labeling it as a dependency.

`Error: @graphql-tools/executor tried to access tslib, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.` 

It's marked as a dependency in pretty much every other package in the repo. It looks like the tslib requirement is being put in place by the typescript compilation process because it's not referenced in the source code of the package, but it is in the exported code visible here at https://unpkg.com/browse/@graphql-tools/executor@0.0.4/cjs/index.js .

Related # (issue)

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules