### PR TITLE
fix(wrap): Fixed __typename being added more than once in TransformCompositeFields

### DIFF
--- a/.changeset/stupid-wolves-fail.md
+++ b/.changeset/stupid-wolves-fail.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/wrap': patch
+---
+
+Fixed \_\_typename being added more than once in TransformCompositeFields

--- a/packages/wrap/src/transforms/TransformCompositeFields.ts
+++ b/packages/wrap/src/transforms/TransformCompositeFields.ts
@@ -137,9 +137,12 @@ export default class TransformCompositeFields<TContext = Record<string, any>>
 
     const parentTypeName = parentType.name;
     let newSelections: Array<SelectionNode> = [];
+    let typeNameExists = node.selections.some(
+      selection => selection.kind === Kind.FIELD && selection.name.value === '__typename'
+    );
 
     for (const selection of node.selections) {
-      if (selection.kind !== Kind.FIELD) {
+      if (selection.kind !== Kind.FIELD || selection.name.value === '__typename') {
         newSelections.push(selection);
         continue;
       }
@@ -148,6 +151,7 @@ export default class TransformCompositeFields<TContext = Record<string, any>>
 
       // See https://github.com/ardatan/graphql-tools/issues/2282
       if (
+        !typeNameExists &&
         (this.dataTransformer != null || this.errorsTransformer != null) &&
         (this.subscriptionTypeName == null || parentTypeName !== this.subscriptionTypeName)
       ) {
@@ -158,6 +162,7 @@ export default class TransformCompositeFields<TContext = Record<string, any>>
             value: '__typename',
           },
         });
+        typeNameExists = true;
       }
 
       let transformedSelection: Maybe<SelectionNode | Array<SelectionNode>>;

--- a/packages/wrap/tests/transformTransformCompositeFields.test.ts
+++ b/packages/wrap/tests/transformTransformCompositeFields.test.ts
@@ -99,4 +99,41 @@ describe('TransformCompositeFields', () => {
       product: { _id: 'R2D2C3P0' },
     });
   });
+
+  test('does not include __typename more than once on execution when a data transformer exists', async () => {
+    const transformSelectionSetSpy = jest.spyOn(TransformCompositeFields.prototype as any, 'transformSelectionSet');
+    const transformedSchema = wrapSchema({
+      schema: baseSchema,
+      transforms: [
+        new TransformCompositeFields(
+          (_typeName, _fieldName, fieldConfig) => fieldConfig,
+          undefined,
+          data => data
+        ),
+      ],
+    });
+
+    await execute({
+      schema: transformedSchema,
+      document: parse('{ product { _id __typename } }'),
+    });
+
+    expect(transformSelectionSetSpy).toHaveNthReturnedWith(
+      2,
+      expect.objectContaining({
+        selections: [
+          expect.objectContaining({ name: expect.objectContaining({ kind: 'Name', value: '__typename' }) }),
+          expect.objectContaining({
+            name: expect.objectContaining({ kind: 'Name', value: 'product' }),
+            selectionSet: expect.objectContaining({
+              selections: [
+                expect.objectContaining({ name: expect.objectContaining({ kind: 'Name', value: '_id' }) }),
+                expect.objectContaining({ name: expect.objectContaining({ kind: 'Name', value: '__typename' }) }),
+              ],
+            }),
+          }),
+        ],
+      })
+    );
+  });
 });


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

This PR fixes the field `__typename` being added more than once when using `TransformCompositeFields` transform, which also other transforms use under the hood. More information in the issue below.

Related #4820 

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

A Unit test has been added with this PR.

**Test Environment**:

- OS: macOS 12.5.1
- @graphql-tools/wrap: 9.2.9
- NodeJS: v16.15.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The unit test is using `spyOn` and `toHaveNthReturnedWith` which might not be appropriate, if there is a better way to test this problem, please advice.