### PR TITLE
Support matching template literals which are declared 'as const'

### DIFF
--- a/.changeset/weak-tomatoes-act.md
+++ b/.changeset/weak-tomatoes-act.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/graphql-tag-pluck': minor
+---
+
+Adds support for matching graphql queries declared with typescript's 'as const' expression. eg. graphql(`query myQuery(...)` as const)

--- a/packages/graphql-tag-pluck/tests/graphql-tag-pluck.test.ts
+++ b/packages/graphql-tag-pluck/tests/graphql-tag-pluck.test.ts
@@ -230,6 +230,44 @@ describe('graphql-tag-pluck', () => {
       );
     });
 
+    it("should pluck graphql template literals from .ts that use an 'as const' assertion", async () => {
+      const sources = await pluck(
+        'tmp-XXXXXX.ts',
+        freeText(`
+        import { graphql } from '../somewhere'
+        import { Document } from 'graphql'
+
+        const fragment: Document = graphql(\`
+            fragment Foo on FooType {
+              id
+            }
+          \`as const)
+
+          const doc: Document = graphql(\`
+            query foo {
+              foo {
+                ...Foo
+              }
+            }
+            \` as const)
+      `)
+      );
+
+      expect(sources.map(source => source.body).join('\n\n')).toEqual(
+        freeText(`
+        fragment Foo on FooType {
+          id
+        }
+
+        query foo {
+          foo {
+            ...Foo
+          }
+        }
+      `)
+      );
+    });
+
     it('should pluck graphql-tag template literals from .ts file', async () => {
       const sources = await pluck(
         'tmp-XXXXXX.ts',


### PR DESCRIPTION
## Description

As described in the related issue, this introduces the ability for the graphql-tag-pluck package to match graphql queries that have declared with the typescript `as const` assertion. The reason you would do this is to force typescript to narrow the type to a string literal instead of just `string` which fixes a performance issue when using `@graphql-codegen/client-preset`

Related #4873 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Existing tests continue to pass without modification
- [x] A new test has been added to cover the `as const` scenario. 

**Test Environment**:

- OS: mac os ventura
- `@graphql-tools/...`:
- NodeJS: v18.9.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments


