### PR TITLE
graphql-tools/load: use `debug` to log timers and errors

### DIFF
--- a/.changeset/silver-dingos-type.md
+++ b/.changeset/silver-dingos-type.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/load': minor
+---
+
+Enable debug logs via DEBUG=graphql-tools/load instead of DEBUG=true or DEBUG=1

--- a/packages/load/package.json
+++ b/packages/load/package.json
@@ -55,8 +55,9 @@
     "graphql-type-json": "0.3.2"
   },
   "dependencies": {
-    "@graphql-tools/utils": "9.1.1",
     "@graphql-tools/schema": "9.0.10",
+    "@graphql-tools/utils": "9.1.1",
+    "debug": "4.3.4",
     "p-limit": "3.1.0",
     "tslib": "^2.4.0"
   },

--- a/packages/load/src/filter-document-kind.ts
+++ b/packages/load/src/filter-document-kind.ts
@@ -1,5 +1,5 @@
 import { DocumentNode, DefinitionNode, Kind } from 'graphql';
-import { env } from 'process';
+import { log } from './utils/debug.js';
 
 /**
  * @internal
@@ -20,10 +20,8 @@ export const filterKind = (
     }
 
     if (invalidDefinitions.length > 0) {
-      if (env['DEBUG']) {
-        for (const d of invalidDefinitions) {
-          console.log(`Filtered document of kind ${d.kind} due to filter policy (${filterKinds.join(', ')})`);
-        }
+      for (const d of invalidDefinitions) {
+        log(`Filtered document of kind ${d.kind} due to filter policy (${filterKinds.join(', ')})`);
       }
     }
 

--- a/packages/load/src/load-typedefs.ts
+++ b/packages/load/src/load-typedefs.ts
@@ -4,7 +4,7 @@ import { applyDefaultOptions } from './load-typedefs/options.js';
 import { collectSources, collectSourcesSync } from './load-typedefs/collect-sources.js';
 import { parseSource } from './load-typedefs/parse.js';
 import { useLimit } from './utils/helpers.js';
-import { env } from 'process';
+import { time, timeEnd } from './utils/debug.js';
 
 const CONCURRENCY_LIMIT = 100;
 
@@ -30,9 +30,7 @@ export async function loadTypedefs<AdditionalConfig = Record<string, unknown>>(
   pointerOrPointers: UnnormalizedTypeDefPointer | UnnormalizedTypeDefPointer[],
   options: LoadTypedefsOptions<Partial<AdditionalConfig>>
 ): Promise<Source[]> {
-  if (env['DEBUG'] != null) {
-    console.time('@graphql-tools/load: loadTypedefs');
-  }
+  time('loadTypedefs');
   const { ignore, pointerOptionMap } = normalizePointers(pointerOrPointers);
 
   options.ignore = asArray(options.ignore || []);
@@ -67,9 +65,7 @@ export async function loadTypedefs<AdditionalConfig = Record<string, unknown>>(
 
   const result = prepareResult({ options, pointerOptionMap, validSources });
 
-  if (env['DEBUG'] != null) {
-    console.timeEnd('@graphql-tools/load: loadTypedefs');
-  }
+  timeEnd('loadTypedefs');
 
   return result;
 }
@@ -85,9 +81,7 @@ export function loadTypedefsSync<AdditionalConfig = Record<string, unknown>>(
   pointerOrPointers: UnnormalizedTypeDefPointer | UnnormalizedTypeDefPointer[],
   options: LoadTypedefsOptions<Partial<AdditionalConfig>>
 ): Source[] {
-  if (env['DEBUG'] != null) {
-    console.time('@graphql-tools/load: loadTypedefsSync');
-  }
+  time('loadTypedefsSync');
   const { ignore, pointerOptionMap } = normalizePointers(pointerOrPointers);
 
   options.ignore = asArray(options.ignore || []).concat(ignore);
@@ -114,9 +108,7 @@ export function loadTypedefsSync<AdditionalConfig = Record<string, unknown>>(
 
   const result = prepareResult({ options, pointerOptionMap, validSources });
 
-  if (env['DEBUG'] != null) {
-    console.timeEnd('@graphql-tools/load: loadTypedefsSync');
-  }
+  timeEnd('loadTypedefsSync');
 
   return result;
 }
@@ -132,9 +124,7 @@ function prepareResult({
   pointerOptionMap: any;
   validSources: Source[];
 }) {
-  if (env['DEBUG'] != null) {
-    console.time('@graphql-tools/load: prepareResult');
-  }
+  time('prepareResult');
   const pointerList = Object.keys(pointerOptionMap);
 
   if (pointerList.length > 0 && validSources.length === 0) {
@@ -150,8 +140,6 @@ function prepareResult({
   const sortedResult = options.sort
     ? validSources.sort((left, right) => compareStrings(left.location, right.location))
     : validSources;
-  if (env['DEBUG'] != null) {
-    console.timeEnd('@graphql-tools/load: prepareResult');
-  }
+  timeEnd('prepareResult');
   return sortedResult;
 }

--- a/packages/load/src/load-typedefs/load-file.ts
+++ b/packages/load/src/load-typedefs/load-file.ts
@@ -1,11 +1,9 @@
 import { Source, AggregateError } from '@graphql-tools/utils';
-import { env } from 'process';
 import { LoadTypedefsOptions } from '../load-typedefs.js';
+import { logError, time, timeEnd } from '../utils/debug.js';
 
 export async function loadFile(pointer: string, options: LoadTypedefsOptions): Promise<Source[]> {
-  if (env['DEBUG'] != null) {
-    console.time(`@graphql-tools/load: loadFile ${pointer}`);
-  }
+  time(`loadFile ${pointer}`);
   let results = options.cache?.[pointer];
 
   if (!results) {
@@ -17,9 +15,7 @@ export async function loadFile(pointer: string, options: LoadTypedefsOptions): P
           const loaderResults = await loader.load(pointer, options);
           loaderResults?.forEach(result => results!.push(result));
         } catch (error: any) {
-          if (env['DEBUG']) {
-            console.error(error);
-          }
+          logError(error);
           if (error instanceof AggregateError) {
             for (const errorElement of error.errors) {
               errors.push(errorElement);
@@ -47,17 +43,13 @@ export async function loadFile(pointer: string, options: LoadTypedefsOptions): P
     }
   }
 
-  if (env['DEBUG'] != null) {
-    console.timeEnd(`@graphql-tools/load: loadFile ${pointer}`);
-  }
+  timeEnd(`loadFile ${pointer}`);
 
   return results;
 }
 
 export function loadFileSync(pointer: string, options: LoadTypedefsOptions): Source[] {
-  if (env['DEBUG'] != null) {
-    console.time(`@graphql-tools/load: loadFileSync ${pointer}`);
-  }
+  time(`loadFileSync ${pointer}`);
   let results = options.cache?.[pointer];
 
   if (!results) {
@@ -69,9 +61,7 @@ export function loadFileSync(pointer: string, options: LoadTypedefsOptions): Sou
         const loaderResults = loader.loadSync!(pointer, options);
         loaderResults?.forEach(result => results!.push(result));
       } catch (error: any) {
-        if (env['DEBUG']) {
-          console.error(error);
-        }
+        error(error);
         if (error instanceof AggregateError) {
           for (const errorElement of error.errors) {
             errors.push(errorElement);
@@ -99,9 +89,7 @@ export function loadFileSync(pointer: string, options: LoadTypedefsOptions): Sou
     }
   }
 
-  if (env['DEBUG'] != null) {
-    console.timeEnd(`@graphql-tools/load: loadFileSync ${pointer}`);
-  }
+  timeEnd(`loadFileSync ${pointer}`);
 
   return results;
 }

--- a/packages/load/src/load-typedefs/load-file.ts
+++ b/packages/load/src/load-typedefs/load-file.ts
@@ -61,7 +61,7 @@ export function loadFileSync(pointer: string, options: LoadTypedefsOptions): Sou
         const loaderResults = loader.loadSync!(pointer, options);
         loaderResults?.forEach(result => results!.push(result));
       } catch (error: any) {
-        error(error);
+        logError(error);
         if (error instanceof AggregateError) {
           for (const errorElement of error.errors) {
             errors.push(errorElement);

--- a/packages/load/src/load-typedefs/parse.ts
+++ b/packages/load/src/load-typedefs/parse.ts
@@ -5,8 +5,8 @@ import {
   printWithComments,
   resetComments,
 } from '@graphql-tools/utils';
-import { env } from 'process';
 import { filterKind } from '../filter-document-kind.js';
+import { time, timeEnd } from '../utils/debug.js';
 
 type Options = any;
 type Input = {
@@ -22,9 +22,7 @@ type ParseOptions = {
 };
 
 export function parseSource({ partialSource, options, pointerOptionMap, addValidSource }: ParseOptions) {
-  if (env['DEBUG'] != null) {
-    console.time(`@graphql-tools/load: parseSource ${partialSource.location}`);
-  }
+  time(`parseSource ${partialSource.location}`);
   if (partialSource) {
     const input = prepareInput({
       source: partialSource,
@@ -41,9 +39,7 @@ export function parseSource({ partialSource, options, pointerOptionMap, addValid
       collectValidSources(input, addValidSource);
     }
   }
-  if (env['DEBUG'] != null) {
-    console.timeEnd(`@graphql-tools/load: parseSource ${partialSource.location}`);
-  }
+  timeEnd(`parseSource ${partialSource.location}`);
 }
 
 //
@@ -72,59 +68,41 @@ function prepareInput({
 }
 
 function parseSchema(input: Input) {
-  if (env['DEBUG'] != null) {
-    console.time(`@graphql-tools/load: parseSchema ${input.source.location}`);
-  }
+  time(`parseSchema ${input.source.location}`);
   if (input.source.schema) {
     input.source.rawSDL = printSchemaWithDirectives(input.source.schema, input.options);
   }
-  if (env['DEBUG'] != null) {
-    console.timeEnd(`@graphql-tools/load: parseSchema ${input.source.location}`);
-  }
+  timeEnd(`parseSchema ${input.source.location}`);
 }
 
 function parseRawSDL(input: Input) {
-  if (env['DEBUG'] != null) {
-    console.time(`@graphql-tools/load: parseRawSDL ${input.source.location}`);
-  }
+  time(`parseRawSDL ${input.source.location}`);
   if (input.source.rawSDL) {
     input.source.document = parseGraphQLSDL(input.source.location, input.source.rawSDL, input.options).document;
   }
-  if (env['DEBUG'] != null) {
-    console.timeEnd(`@graphql-tools/load: parseRawSDL ${input.source.location}`);
-  }
+  timeEnd(`parseRawSDL ${input.source.location}`);
 }
 
 function useKindsFilter(input: Input) {
-  if (env['DEBUG'] != null) {
-    console.time(`@graphql-tools/load: useKindsFilter ${input.source.location}`);
-  }
+  time(`useKindsFilter ${input.source.location}`);
   if (input.options.filterKinds) {
     input.source.document = filterKind(input.source.document, input.options.filterKinds);
   }
 }
 
 function useComments(input: Input) {
-  if (env['DEBUG'] != null) {
-    console.time(`@graphql-tools/load: useComments ${input.source.location}`);
-  }
+  time(`useComments ${input.source.location}`);
   if (!input.source.rawSDL && input.source.document) {
     input.source.rawSDL = printWithComments(input.source.document);
     resetComments();
   }
-  if (env['DEBUG'] != null) {
-    console.timeEnd(`@graphql-tools/load: useComments ${input.source.location}`);
-  }
+  timeEnd(`useComments ${input.source.location}`);
 }
 
 function collectValidSources(input: Input, addValidSource: AddValidSource) {
-  if (env['DEBUG'] != null) {
-    console.time(`@graphql-tools/load: collectValidSources ${input.source.location}`);
-  }
+  time(`collectValidSources ${input.source.location}`);
   if (input.source.document?.definitions && input.source.document.definitions.length > 0) {
     addValidSource(input.source);
   }
-  if (env['DEBUG'] != null) {
-    console.timeEnd(`@graphql-tools/load: collectValidSources ${input.source.location}`);
-  }
+  timeEnd(`collectValidSources ${input.source.location}`);
 }

--- a/packages/load/src/utils/debug.ts
+++ b/packages/load/src/utils/debug.ts
@@ -22,7 +22,7 @@ export function timeEnd(label: string) {
   const start = times[label];
   const stop = performance.now();
   const duration = stop - start;
-  debugLog(`label: ${duration.toFixed(1)}ms`);
+  debugLog(`${label}: ${duration.toFixed(1)}ms`);
   delete times[label];
 }
 

--- a/packages/load/src/utils/debug.ts
+++ b/packages/load/src/utils/debug.ts
@@ -1,0 +1,41 @@
+import debug from 'debug';
+import { performance } from 'perf_hooks';
+
+const debugLog = debug('graphql-tools/load');
+
+const times: { [label: string]: number } = {};
+
+/**
+ * Starts a timer with a label, similar to `console.time`.
+ */
+export function time(label: string) {
+  times[label] = performance.now();
+}
+
+/**
+ * Stops a timer with a label then logs to the console, similar to `console.timeEnd`.
+ */
+export function timeEnd(label: string) {
+  if (!times[label]) {
+    return;
+  }
+  const start = times[label];
+  const stop = performance.now();
+  const duration = stop - start;
+  debugLog(`label: ${duration.toFixed(1)}ms`);
+  delete times[label];
+}
+
+/**
+ * Logs an error to the console, if enabled via DEBUG=graphql-tools/load
+ */
+export function logError(error: string, ...rest: unknown[]) {
+  debugLog(`error: ${error}`, ...rest);
+}
+
+/**
+ * Logs a message to the console, if enabled via DEBUG=graphql-tools/load
+ */
+export function log(message: string, ...rest: unknown[]) {
+  debugLog(message, ...rest);
+}

--- a/packages/load/src/utils/pointers.ts
+++ b/packages/load/src/utils/pointers.ts
@@ -1,13 +1,11 @@
 import { asArray } from '@graphql-tools/utils';
-import { env } from 'process';
 import { UnnormalizedTypeDefPointer } from './../load-typedefs.js';
+import { time, timeEnd } from './debug.js';
 
 export function normalizePointers(
   unnormalizedPointerOrPointers: UnnormalizedTypeDefPointer | UnnormalizedTypeDefPointer[]
 ) {
-  if (env['DEBUG'] != null) {
-    console.time(`@graphql-tools/load: normalizePointers`);
-  }
+  time(`normalizePointers`);
   const ignore: string[] = [];
   const pointerOptionMap: Record<string, Record<string, any>> = {};
 
@@ -20,9 +18,7 @@ export function normalizePointers(
   };
 
   for (const rawPointer of asArray(unnormalizedPointerOrPointers)) {
-    if (env['DEBUG'] != null) {
-      console.time(`@graphql-tools/load: normalizePointers ${rawPointer}`);
-    }
+    time(`normalizePointers ${rawPointer}`);
     if (typeof rawPointer === 'string') {
       handlePointer(rawPointer);
     } else if (typeof rawPointer === 'object') {
@@ -32,12 +28,8 @@ export function normalizePointers(
     } else {
       throw new Error(`Invalid pointer '${rawPointer}'.`);
     }
-    if (env['DEBUG'] != null) {
-      console.timeEnd(`@graphql-tools/load: normalizePointers ${rawPointer}`);
-    }
+    timeEnd(`normalizePointers ${rawPointer}`);
   }
-  if (env['DEBUG'] != null) {
-    console.timeEnd(`@graphql-tools/load: normalizePointers`);
-  }
+  timeEnd(`normalizePointers`);
   return { ignore, pointerOptionMap };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1638,15 +1638,15 @@
     lru-cache "^6.0.0"
     tslib "^2.4.0"
 
-"@esbuild/android-arm@0.15.12":
-  version "0.15.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.15.12.tgz#e548b10a5e55b9e10537a049ebf0bc72c453b769"
-  integrity sha512-IC7TqIqiyE0MmvAhWkl/8AEzpOtbhRNDo7aph47We1NbE5w2bt/Q+giAhe0YYeVpYnIhGMcuZY92qDK6dQauvA==
+"@esbuild/android-arm@0.15.18":
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.15.18.tgz#266d40b8fdcf87962df8af05b76219bc786b4f80"
+  integrity sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==
 
-"@esbuild/linux-loong64@0.15.12":
-  version "0.15.12"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.15.12.tgz#475b33a2631a3d8ca8aa95ee127f9a61d95bf9c1"
-  integrity sha512-tZEowDjvU7O7I04GYvWQOS4yyP9E/7YlsB0jjw1Ycukgr2ycEzKyIk5tms5WnLBymaewc6VmRKnn5IJWgK4eFw==
+"@esbuild/linux-loong64@0.15.18":
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.15.18.tgz#128b76ecb9be48b60cf5cfc1c63a4f00691a3239"
+  integrity sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==
 
 "@eslint/eslintrc@^1.3.3":
   version "1.3.3"
@@ -5746,133 +5746,133 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-esbuild-android-64@0.15.12:
-  version "0.15.12"
-  resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.15.12.tgz#5e8151d5f0a748c71a7fbea8cee844ccf008e6fc"
-  integrity sha512-MJKXwvPY9g0rGps0+U65HlTsM1wUs9lbjt5CU19RESqycGFDRijMDQsh68MtbzkqWSRdEtiKS1mtPzKneaAI0Q==
+esbuild-android-64@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-android-64/-/esbuild-android-64-0.15.18.tgz#20a7ae1416c8eaade917fb2453c1259302c637a5"
+  integrity sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==
 
-esbuild-android-arm64@0.15.12:
-  version "0.15.12"
-  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.15.12.tgz#5ee72a6baa444bc96ffcb472a3ba4aba2cc80666"
-  integrity sha512-Hc9SEcZbIMhhLcvhr1DH+lrrec9SFTiRzfJ7EGSBZiiw994gfkVV6vG0sLWqQQ6DD7V4+OggB+Hn0IRUdDUqvA==
+esbuild-android-arm64@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-android-arm64/-/esbuild-android-arm64-0.15.18.tgz#9cc0ec60581d6ad267568f29cf4895ffdd9f2f04"
+  integrity sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==
 
-esbuild-darwin-64@0.15.12:
-  version "0.15.12"
-  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.15.12.tgz#70047007e093fa1b3ba7ef86f9b3fa63db51fe25"
-  integrity sha512-qkmqrTVYPFiePt5qFjP8w/S+GIUMbt6k8qmiPraECUWfPptaPJUGkCKrWEfYFRWB7bY23FV95rhvPyh/KARP8Q==
+esbuild-darwin-64@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-64/-/esbuild-darwin-64-0.15.18.tgz#428e1730ea819d500808f220fbc5207aea6d4410"
+  integrity sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==
 
-esbuild-darwin-arm64@0.15.12:
-  version "0.15.12"
-  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.12.tgz#41c951f23d9a70539bcca552bae6e5196696ae04"
-  integrity sha512-z4zPX02tQ41kcXMyN3c/GfZpIjKoI/BzHrdKUwhC/Ki5BAhWv59A9M8H+iqaRbwpzYrYidTybBwiZAIWCLJAkw==
+esbuild-darwin-arm64@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.18.tgz#b6dfc7799115a2917f35970bfbc93ae50256b337"
+  integrity sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==
 
-esbuild-freebsd-64@0.15.12:
-  version "0.15.12"
-  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.12.tgz#a761b5afd12bbedb7d56c612e9cfa4d2711f33f0"
-  integrity sha512-XFL7gKMCKXLDiAiBjhLG0XECliXaRLTZh6hsyzqUqPUf/PY4C6EJDTKIeqqPKXaVJ8+fzNek88285krSz1QECw==
+esbuild-freebsd-64@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.18.tgz#4e190d9c2d1e67164619ae30a438be87d5eedaf2"
+  integrity sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==
 
-esbuild-freebsd-arm64@0.15.12:
-  version "0.15.12"
-  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.12.tgz#6b0839d4d58deabc6cbd96276eb8cbf94f7f335e"
-  integrity sha512-jwEIu5UCUk6TjiG1X+KQnCGISI+ILnXzIzt9yDVrhjug2fkYzlLbl0K43q96Q3KB66v6N1UFF0r5Ks4Xo7i72g==
+esbuild-freebsd-arm64@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.18.tgz#18a4c0344ee23bd5a6d06d18c76e2fd6d3f91635"
+  integrity sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==
 
-esbuild-linux-32@0.15.12:
-  version "0.15.12"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.15.12.tgz#bd50bfe22514d434d97d5150977496e2631345b4"
-  integrity sha512-uSQuSEyF1kVzGzuIr4XM+v7TPKxHjBnLcwv2yPyCz8riV8VUCnO/C4BF3w5dHiVpCd5Z1cebBtZJNlC4anWpwA==
+esbuild-linux-32@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-32/-/esbuild-linux-32-0.15.18.tgz#9a329731ee079b12262b793fb84eea762e82e0ce"
+  integrity sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==
 
-esbuild-linux-64@0.15.12:
-  version "0.15.12"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.15.12.tgz#074bb2b194bf658245f8490f29c01ffcdfa8c931"
-  integrity sha512-QcgCKb7zfJxqT9o5z9ZUeGH1k8N6iX1Y7VNsEi5F9+HzN1OIx7ESxtQXDN9jbeUSPiRH1n9cw6gFT3H4qbdvcA==
+esbuild-linux-64@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-64/-/esbuild-linux-64-0.15.18.tgz#532738075397b994467b514e524aeb520c191b6c"
+  integrity sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==
 
-esbuild-linux-arm64@0.15.12:
-  version "0.15.12"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.12.tgz#3bf789c4396dc032875a122988efd6f3733f28f5"
-  integrity sha512-HtNq5xm8fUpZKwWKS2/YGwSfTF+339L4aIA8yphNKYJckd5hVdhfdl6GM2P3HwLSCORS++++7++//ApEwXEuAQ==
+esbuild-linux-arm64@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.18.tgz#5372e7993ac2da8f06b2ba313710d722b7a86e5d"
+  integrity sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==
 
-esbuild-linux-arm@0.15.12:
-  version "0.15.12"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.15.12.tgz#b91b5a8d470053f6c2c9c8a5e67ec10a71fe4a67"
-  integrity sha512-Wf7T0aNylGcLu7hBnzMvsTfEXdEdJY/hY3u36Vla21aY66xR0MS5I1Hw8nVquXjTN0A6fk/vnr32tkC/C2lb0A==
+esbuild-linux-arm@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-arm/-/esbuild-linux-arm-0.15.18.tgz#e734aaf259a2e3d109d4886c9e81ec0f2fd9a9cc"
+  integrity sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==
 
-esbuild-linux-mips64le@0.15.12:
-  version "0.15.12"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.12.tgz#2fb54099ada3c950a7536dfcba46172c61e580e2"
-  integrity sha512-Qol3+AvivngUZkTVFgLpb0H6DT+N5/zM3V1YgTkryPYFeUvuT5JFNDR3ZiS6LxhyF8EE+fiNtzwlPqMDqVcc6A==
+esbuild-linux-mips64le@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.18.tgz#c0487c14a9371a84eb08fab0e1d7b045a77105eb"
+  integrity sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==
 
-esbuild-linux-ppc64le@0.15.12:
-  version "0.15.12"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.12.tgz#9e3b8c09825fb27886249dfb3142a750df29a1b7"
-  integrity sha512-4D8qUCo+CFKaR0cGXtGyVsOI7w7k93Qxb3KFXWr75An0DHamYzq8lt7TNZKoOq/Gh8c40/aKaxvcZnTgQ0TJNg==
+esbuild-linux-ppc64le@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.18.tgz#af048ad94eed0ce32f6d5a873f7abe9115012507"
+  integrity sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==
 
-esbuild-linux-riscv64@0.15.12:
-  version "0.15.12"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.12.tgz#923d0f5b6e12ee0d1fe116b08e4ae4478fe40693"
-  integrity sha512-G9w6NcuuCI6TUUxe6ka0enjZHDnSVK8bO+1qDhMOCtl7Tr78CcZilJj8SGLN00zO5iIlwNRZKHjdMpfFgNn1VA==
+esbuild-linux-riscv64@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.18.tgz#423ed4e5927bd77f842bd566972178f424d455e6"
+  integrity sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==
 
-esbuild-linux-s390x@0.15.12:
-  version "0.15.12"
-  resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.12.tgz#3b1620220482b96266a0c6d9d471d451a1eab86f"
-  integrity sha512-Lt6BDnuXbXeqSlVuuUM5z18GkJAZf3ERskGZbAWjrQoi9xbEIsj/hEzVnSAFLtkfLuy2DE4RwTcX02tZFunXww==
+esbuild-linux-s390x@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.18.tgz#21d21eaa962a183bfb76312e5a01cc5ae48ce8eb"
+  integrity sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==
 
-esbuild-netbsd-64@0.15.12:
-  version "0.15.12"
-  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.12.tgz#276730f80da646859b1af5a740e7802d8cd73e42"
-  integrity sha512-jlUxCiHO1dsqoURZDQts+HK100o0hXfi4t54MNRMCAqKGAV33JCVvMplLAa2FwviSojT/5ZG5HUfG3gstwAG8w==
+esbuild-netbsd-64@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.18.tgz#ae75682f60d08560b1fe9482bfe0173e5110b998"
+  integrity sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==
 
-esbuild-openbsd-64@0.15.12:
-  version "0.15.12"
-  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.12.tgz#bd0eea1dd2ca0722ed489d88c26714034429f8ae"
-  integrity sha512-1o1uAfRTMIWNOmpf8v7iudND0L6zRBYSH45sofCZywrcf7NcZA+c7aFsS1YryU+yN7aRppTqdUK1PgbZVaB1Dw==
+esbuild-openbsd-64@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.18.tgz#79591a90aa3b03e4863f93beec0d2bab2853d0a8"
+  integrity sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==
 
-esbuild-sunos-64@0.15.12:
-  version "0.15.12"
-  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.15.12.tgz#5e56bf9eef3b2d92360d6d29dcde7722acbecc9e"
-  integrity sha512-nkl251DpoWoBO9Eq9aFdoIt2yYmp4I3kvQjba3jFKlMXuqQ9A4q+JaqdkCouG3DHgAGnzshzaGu6xofGcXyPXg==
+esbuild-sunos-64@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-sunos-64/-/esbuild-sunos-64-0.15.18.tgz#fd528aa5da5374b7e1e93d36ef9b07c3dfed2971"
+  integrity sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==
 
-esbuild-windows-32@0.15.12:
-  version "0.15.12"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.15.12.tgz#a4f1a301c1a2fa7701fcd4b91ef9d2620cf293d0"
-  integrity sha512-WlGeBZHgPC00O08luIp5B2SP4cNCp/PcS+3Pcg31kdcJPopHxLkdCXtadLU9J82LCfw4TVls21A6lilQ9mzHrw==
+esbuild-windows-32@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-32/-/esbuild-windows-32-0.15.18.tgz#0e92b66ecdf5435a76813c4bc5ccda0696f4efc3"
+  integrity sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==
 
-esbuild-windows-64@0.15.12:
-  version "0.15.12"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.15.12.tgz#bc2b467541744d653be4fe64eaa9b0dbbf8e07f6"
-  integrity sha512-VActO3WnWZSN//xjSfbiGOSyC+wkZtI8I4KlgrTo5oHJM6z3MZZBCuFaZHd8hzf/W9KPhF0lY8OqlmWC9HO5AA==
+esbuild-windows-64@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-64/-/esbuild-windows-64-0.15.18.tgz#0fc761d785414284fc408e7914226d33f82420d0"
+  integrity sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==
 
-esbuild-windows-arm64@0.15.12:
-  version "0.15.12"
-  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.12.tgz#9a7266404334a86be800957eaee9aef94c3df328"
-  integrity sha512-Of3MIacva1OK/m4zCNIvBfz8VVROBmQT+gRX6pFTLPngFYcj6TFH/12VveAqq1k9VB2l28EoVMNMUCcmsfwyuA==
+esbuild-windows-arm64@0.15.18:
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.18.tgz#5b5bdc56d341d0922ee94965c89ee120a6a86eb7"
+  integrity sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==
 
 esbuild@^0.14.2, esbuild@^0.15.0:
-  version "0.15.12"
-  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.15.12.tgz#6c8e22d6d3b7430d165c33848298d3fc9a1f251c"
-  integrity sha512-PcT+/wyDqJQsRVhaE9uX/Oq4XLrFh0ce/bs2TJh4CSaw9xuvI+xFrH2nAYOADbhQjUgAhNWC5LKoUsakm4dxng==
+  version "0.15.18"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.15.18.tgz#ea894adaf3fbc036d32320a00d4d6e4978a2f36d"
+  integrity sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==
   optionalDependencies:
-    "@esbuild/android-arm" "0.15.12"
-    "@esbuild/linux-loong64" "0.15.12"
-    esbuild-android-64 "0.15.12"
-    esbuild-android-arm64 "0.15.12"
-    esbuild-darwin-64 "0.15.12"
-    esbuild-darwin-arm64 "0.15.12"
-    esbuild-freebsd-64 "0.15.12"
-    esbuild-freebsd-arm64 "0.15.12"
-    esbuild-linux-32 "0.15.12"
-    esbuild-linux-64 "0.15.12"
-    esbuild-linux-arm "0.15.12"
-    esbuild-linux-arm64 "0.15.12"
-    esbuild-linux-mips64le "0.15.12"
-    esbuild-linux-ppc64le "0.15.12"
-    esbuild-linux-riscv64 "0.15.12"
-    esbuild-linux-s390x "0.15.12"
-    esbuild-netbsd-64 "0.15.12"
-    esbuild-openbsd-64 "0.15.12"
-    esbuild-sunos-64 "0.15.12"
-    esbuild-windows-32 "0.15.12"
-    esbuild-windows-64 "0.15.12"
-    esbuild-windows-arm64 "0.15.12"
+    "@esbuild/android-arm" "0.15.18"
+    "@esbuild/linux-loong64" "0.15.18"
+    esbuild-android-64 "0.15.18"
+    esbuild-android-arm64 "0.15.18"
+    esbuild-darwin-64 "0.15.18"
+    esbuild-darwin-arm64 "0.15.18"
+    esbuild-freebsd-64 "0.15.18"
+    esbuild-freebsd-arm64 "0.15.18"
+    esbuild-linux-32 "0.15.18"
+    esbuild-linux-64 "0.15.18"
+    esbuild-linux-arm "0.15.18"
+    esbuild-linux-arm64 "0.15.18"
+    esbuild-linux-mips64le "0.15.18"
+    esbuild-linux-ppc64le "0.15.18"
+    esbuild-linux-riscv64 "0.15.18"
+    esbuild-linux-s390x "0.15.18"
+    esbuild-netbsd-64 "0.15.18"
+    esbuild-openbsd-64 "0.15.18"
+    esbuild-sunos-64 "0.15.18"
+    esbuild-windows-32 "0.15.18"
+    esbuild-windows-64 "0.15.18"
+    esbuild-windows-arm64 "0.15.18"
 
 escalade@^3.1.1:
   version "3.1.1"


### PR DESCRIPTION
## Description

Instead of using `console.time` and `console.error`, this PR refactors `@graphql-tools/load` to use [debug](https://www.npmjs.com/package/debug), activated via `DEBUG=graphql-tools/load`.

`debug` is a very popular package used by libraries to log messages and allow the end-user to enable/disable logs with specific prefixes. For instance, to enable debug logs in eslint, you would run `DEBUG=eslint yarn eslint`. This PR applies the same concept to `graphql-tools/load`, where as in the old code it would print debug logs for any value of `DEBUG`.

Fixes #4777

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Debug logs will print like this:

<img width="1376" alt="image" src="https://user-images.githubusercontent.com/941453/206116261-86473f13-4ee2-47ae-b540-23e451619385.png">


## How Has This Been Tested?

Ran `yarn test packages/load/` and made sure the logs print properly with `DEBUG=graphql-tools/load`

**Test Environment**:

- OS: macOS 13.0
- `@graphql-tools/load`: 7.8.6
- NodeJS: v18.12.1

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
