### PR TITLE
fix: apollo-client always requires React to be installed

### DIFF
--- a/.changeset/sweet-birds-attend.md
+++ b/.changeset/sweet-birds-attend.md
@@ -1,0 +1,7 @@
+---
+'@graphql-tools/executor-apollo-link': patch
+'@graphql-tools/graphql-tag-pluck': patch
+'@graphql-tools/links': patch
+---
+
+React is no longer required dependency with @apollo/client

--- a/packages/executors/apollo-link/src/index.ts
+++ b/packages/executors/apollo-link/src/index.ts
@@ -1,13 +1,9 @@
-import * as apolloImport from '@apollo/client';
+import { ApolloLink, FetchResult, Observable, Operation, RequestHandler } from '@apollo/client/core';
 import { ExecutionRequest, Executor, isAsyncIterable } from '@graphql-tools/utils';
 
-const apollo: typeof apolloImport = (apolloImport as any)?.default ?? apolloImport;
-
-function createApolloRequestHandler(executor: Executor): apolloImport.RequestHandler {
-  return function ApolloRequestHandler(
-    operation: apolloImport.Operation
-  ): apolloImport.Observable<apolloImport.FetchResult> {
-    return new apollo.Observable(observer => {
+function createApolloRequestHandler(executor: Executor): RequestHandler {
+  return function ApolloRequestHandler(operation: Operation): Observable<FetchResult> {
+    return new Observable(observer => {
       const executionRequest: ExecutionRequest = {
         document: operation.query,
         variables: operation.variables,
@@ -39,7 +35,7 @@ function createApolloRequestHandler(executor: Executor): apolloImport.RequestHan
   };
 }
 
-export class ExecutorLink extends apollo.ApolloLink {
+export class ExecutorLink extends ApolloLink {
   constructor(executor: Executor) {
     super(createApolloRequestHandler(executor));
   }

--- a/packages/graphql-tag-pluck/tests/graphql-tag-pluck.test.ts
+++ b/packages/graphql-tag-pluck/tests/graphql-tag-pluck.test.ts
@@ -1899,7 +1899,7 @@ describe('graphql-tag-pluck', () => {
       const sources = await pluck(
         'tmp-XXXXXX.js',
         freeText(`
-        import { gql } from '@apollo/client'
+        import { gql } from '@apollo/client/core'
 
         const fragment = gql(\`
           fragment Foo on FooType {

--- a/packages/links/src/AwaitVariablesLink.ts
+++ b/packages/links/src/AwaitVariablesLink.ts
@@ -1,6 +1,4 @@
-import * as apolloImport from '@apollo/client';
-
-const apollo: typeof apolloImport = (apolloImport as any)?.default ?? apolloImport;
+import { ApolloLink, FetchResult, NextLink, Observable, Operation } from '@apollo/client/core';
 
 function getFinalPromise(object: any): Promise<any> {
   return Promise.resolve(object).then(resolvedObject => {
@@ -24,12 +22,9 @@ function getFinalPromise(object: any): Promise<any> {
   });
 }
 
-export class AwaitVariablesLink extends apollo.ApolloLink {
-  request(
-    operation: apolloImport.Operation,
-    forward: apolloImport.NextLink
-  ): apolloImport.Observable<apolloImport.FetchResult> {
-    return new apollo.Observable(observer => {
+export class AwaitVariablesLink extends ApolloLink {
+  request(operation: Operation, forward: NextLink): Observable<FetchResult> {
+    return new Observable(observer => {
       let subscription: any;
       getFinalPromise(operation.variables)
         .then(resolvedVariables => {

--- a/packages/links/src/createServerHttpLink.ts
+++ b/packages/links/src/createServerHttpLink.ts
@@ -1,14 +1,12 @@
-import * as apolloImport from '@apollo/client';
+import { concat } from '@apollo/client/core';
 import { createUploadLink, formDataAppendFile, isExtractableFile } from 'apollo-upload-client';
 import FormData from 'form-data';
 import fetch from 'node-fetch';
 
 import { AwaitVariablesLink } from './AwaitVariablesLink.js';
 
-const apollo: typeof apolloImport = (apolloImport as any)?.default ?? apolloImport;
-
 export const createServerHttpLink = (options: any) =>
-  apollo.concat(
+  concat(
     new AwaitVariablesLink(),
     createUploadLink({
       ...options,

--- a/packages/links/src/linkToExecutor.ts
+++ b/packages/links/src/linkToExecutor.ts
@@ -1,5 +1,4 @@
-import * as apolloImport from '@apollo/client';
-
+import { ApolloLink, execute, Observable, toPromise } from '@apollo/client/core';
 import {
   Executor,
   ExecutionRequest,
@@ -8,13 +7,11 @@ import {
   getOperationASTFromRequest,
 } from '@graphql-tools/utils';
 
-const apollo: typeof apolloImport = (apolloImport as any)?.default ?? apolloImport;
-
-export function linkToExecutor(link: apolloImport.ApolloLink): Executor {
+export function linkToExecutor(link: ApolloLink): Executor {
   return function executorFromLink<TReturn, TArgs extends Record<string, any>, TContext>(
     request: ExecutionRequest<TArgs, TContext>
   ) {
-    const observable = apollo.execute(link, {
+    const observable = execute(link, {
       query: request.document,
       operationName: request.operationName,
       variables: request.variables,
@@ -24,11 +21,11 @@ export function linkToExecutor(link: apolloImport.ApolloLink): Executor {
         clientAwareness: {},
       },
       extensions: request.extensions,
-    }) as apolloImport.Observable<ExecutionResult<TReturn>>;
+    }) as Observable<ExecutionResult<TReturn>>;
     const operationAst = getOperationASTFromRequest(request);
     if (operationAst.operation === 'subscription') {
       return observableToAsyncIterable<ExecutionResult<TReturn>>(observable);
     }
-    return apollo.toPromise(observable);
+    return toPromise(observable);
   };
 }


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

`React` dependency is required when used import like `import * as apollo from '@apollo/client'`. Instead, they are suggesting to use `import { gql } from '@apollo/client/core` as described here - https://github.com/apollographql/apollo-client/issues/7318 .

There should be an opportunity to use `graphql-tools` without React as a required dependency. So, I changed imports as `apollo-client` team suggests.

Related # (issue)
https://github.com/ardatan/graphql-tools/issues/4897

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS: Mac OS Monterey 12.6.1
- `@graphql-tools/...`:  graphql-tag-pluck - 7.4.2, links - 8.3.24
- NodeJS: 18.12.0

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
