### PR TITLE
Correction to `Type Merging > Null Records` documentation

### DIFF
--- a/website/src/pages/docs/schema-stitching/stitch-type-merging.mdx
+++ b/website/src/pages/docs/schema-stitching/stitch-type-merging.mdx
@@ -161,13 +161,13 @@ In this example, the `postUserById` resolver simply converts a submitted user ID
 
 ### Null Records
 
-The above example will always resolve a stubbed `User` record for _any_ requested ID. For example, requesting ID `7` (which has no associated posts) would return:
+The above example will always resolve a stubbed `User` record for _any_ requested ID. For example, requesting an ID of `INVALID_ID` (which has no associated posts) would return:
 
 ```json
-{ "id": "7", "posts": [] }
+{ "id": "INVALID_ID", "posts": [] }
 ```
 
-This fabricated record fulfills the not-null requirement of the `posts:[Post]!` field. However, it also makes the posts service awkwardly responsible for data it knows only by omission. A cleaner solution may be to loosen schema nullability down to `posts:[Post]`, and then return `null` for unknown user IDs without associated posts. Null is a valid mergable object as long as the unique fields it fulfills are nullable. See the related [handbook example](https://github.com/gmac/schema-stitching-handbook/tree/master/type-merging-nullables) for a detailed explanation.
+This fabricated record fulfills the not-null requirement of the `posts:[Post]!` field. However, it also makes the posts service awkwardly responsible for data it knows only by omission, and legitimizes invalid IDs. A cleaner solution may be to loosen schema nullability down to `posts:[Post]`, and then return `null` for unknown user IDs without associated posts. Null is a valid mergable object as long as the unique fields it fulfills are nullable. See the related [handbook example](https://github.com/gmac/schema-stitching-handbook/tree/master/type-merging-nullables) for a detailed explanation.
 
 ## Merging Flow
 


### PR DESCRIPTION
## Description

I just noticed a confusing typo in the [Type Merging > Null Records](https://the-guild.dev/graphql/tools/docs/schema-stitching/stitch-type-merging#null-records) documentation section. It mentions record `7` as an invalid record, but that is not accurate to the data in the previous example. I've updated the paragraph to use `INVALID_ID` as the null reference to obviate that this is an invalid ID being submitted to the service that we _expect_ not to receive data back for.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
