### PR TITLE
Fix error when visiting __type fields

### DIFF
--- a/.changeset/fluffy-masks-develop.md
+++ b/.changeset/fluffy-masks-develop.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/utils': patch
+---
+
+Fixes introspection query issues when visiting field '\_\_type'

--- a/packages/utils/src/visitResult.ts
+++ b/packages/utils/src/visitResult.ts
@@ -11,6 +11,7 @@ import {
   isObjectType,
   OperationDefinitionNode,
   GraphQLError,
+  TypeMetaFieldDef,
   TypeNameMetaFieldDef,
   FragmentDefinitionNode,
   SchemaMetaFieldDef,
@@ -239,6 +240,9 @@ function visitObjectValue(
           break;
         case '__schema':
           fieldType = SchemaMetaFieldDef.type;
+          break;
+        case '__type':
+          fieldType = TypeMetaFieldDef.type;
           break;
       }
     }

--- a/packages/utils/tests/visitResult.test.ts
+++ b/packages/utils/tests/visitResult.test.ts
@@ -58,6 +58,22 @@ describe('visiting results', () => {
     expect(() => visitResult(result, introspectionRequest, schema, undefined)).not.toThrow();
   });
 
+  it('should visit with type query and visitor map without throwing', async () => {
+    const introspectionRequest: ExecutionRequest = {
+      document: parse('{ __type(name: "Test") { __typename name } }'),
+      variables: {},
+    };
+
+    const result = {
+      data: {
+        __type: {
+          __typename: '__Type',
+        },
+      },
+    };
+    expect(() => visitResult(result, introspectionRequest, schema, {})).not.toThrow();
+  });
+
   it('should visit with a request with introspection fields without throwing', async () => {
     const introspectionRequest: ExecutionRequest = {
       document: parse(getIntrospectionQuery()),


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

This fixes an issue with introspection queries that affects other guild projects when using `@envelop/response-cache`

Related #5015 

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I've added a test case for the visitResult function that fails currently and passes after the changes

- [ ] Test A (fails): yarn test visitResult on the first commit (`772861f357fe3fcfbb7aa413ac479b50ef41a359`)
- [ ] Test B (passes): yarn test visitResult on the second commit (`07ae1a1179004146909ae6cf2b500a82f48e3a0a`)

**Test Environment**:

- OS: Linux (codespaces container)
- `@graphql-tools/utils`: 9.1.4
- NodeJS: 14.x

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
