### PR TITLE
Add batch delegate lazy options from keys

### DIFF
--- a/.changeset/curly-dolls-deny.md
+++ b/.changeset/curly-dolls-deny.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/batch-delegate': patch
+---
+
+Pass `keys` to lazyOptionsFn

--- a/packages/batch-delegate/src/getLoader.ts
+++ b/packages/batch-delegate/src/getLoader.ts
@@ -1,4 +1,4 @@
-import { getNamedType, GraphQLOutputType, GraphQLList, GraphQLSchema, print } from 'graphql';
+import { getNamedType, GraphQLList, GraphQLOutputType, GraphQLSchema, print } from 'graphql';
 
 import DataLoader from 'dataloader';
 
@@ -33,7 +33,7 @@ function createBatchFn<K = any>(options: BatchDelegateOptions) {
         return relocatedError(originalError, originalError.path.slice(0, 0).concat(originalError.path.slice(2)));
       },
       args: argsFromKeys(keys),
-      ...(lazyOptionsFn == null ? options : lazyOptionsFn(options)),
+      ...(lazyOptionsFn == null ? options : lazyOptionsFn(options, keys)),
     });
 
     if (results instanceof Error) {

--- a/packages/batch-delegate/src/getLoader.ts
+++ b/packages/batch-delegate/src/getLoader.ts
@@ -1,4 +1,4 @@
-import { getNamedType, GraphQLList, GraphQLOutputType, GraphQLSchema, print } from 'graphql';
+import { getNamedType, GraphQLOutputType, GraphQLList, GraphQLSchema, print } from 'graphql';
 
 import DataLoader from 'dataloader';
 

--- a/packages/batch-delegate/src/types.ts
+++ b/packages/batch-delegate/src/types.ts
@@ -7,7 +7,8 @@ export type BatchDelegateFn<TContext = Record<string, any>, K = any> = (
 ) => any;
 
 export type BatchDelegateOptionsFn<TContext = Record<string, any>, K = any> = (
-  batchDelegateOptions: BatchDelegateOptions<TContext, K>
+  batchDelegateOptions: BatchDelegateOptions<TContext, K>,
+  keys: ReadonlyArray<K>
 ) => IDelegateToSchemaOptions<TContext>;
 
 export interface BatchDelegateOptions<TContext = Record<string, any>, K = any, V = any, C = K>

--- a/packages/batch-delegate/src/types.ts
+++ b/packages/batch-delegate/src/types.ts
@@ -17,7 +17,7 @@ export interface BatchDelegateOptions<TContext = Record<string, any>, K = any, V
   key: K;
   argsFromKeys?: (keys: ReadonlyArray<K>) => Record<string, any>;
   valuesFromResults?: (results: any, keys: ReadonlyArray<K>) => Array<V>;
-  lazyOptionsFn?: BatchDelegateOptionsFn;
+  lazyOptionsFn?: BatchDelegateOptionsFn<TContext, K>;
 }
 
 export interface CreateBatchDelegateFnOptions<TContext = Record<string, any>, K = any, V = any, C = K>
@@ -25,5 +25,5 @@ export interface CreateBatchDelegateFnOptions<TContext = Record<string, any>, K 
   dataLoaderOptions?: DataLoader.Options<K, V, C>;
   argsFromKeys?: (keys: ReadonlyArray<K>) => Record<string, any>;
   valuesFromResults?: (results: any, keys: ReadonlyArray<K>) => Array<V>;
-  lazyOptionsFn?: (batchDelegateOptions: BatchDelegateOptions<TContext, K>) => IDelegateToSchemaOptions<TContext>;
+  lazyOptionsFn?: BatchDelegateOptionsFn<TContext, K>;
 }

--- a/packages/batch-delegate/tests/basic.example.test.ts
+++ b/packages/batch-delegate/tests/basic.example.test.ts
@@ -1,5 +1,5 @@
 import { execute, isIncrementalResult } from '@graphql-tools/executor';
-import { OperationTypeNode, parse } from 'graphql';
+import { GraphQLObjectType, Kind, OperationTypeNode, parse } from 'graphql';
 
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { batchDelegateToSchema } from '@graphql-tools/batch-delegate';
@@ -164,6 +164,153 @@ describe('batch delegation within basic stitching example', () => {
                 key: user.postIds,
                 context,
                 info,
+              });
+            },
+          },
+        },
+      },
+    });
+
+    const query = /* GraphQL */ `
+      query {
+        users(ids: [1, 7]) {
+          id
+          posts {
+            id
+            title
+          }
+        }
+      }
+    `;
+
+    const result = await execute({ schema: stitchedSchema, document: parse(query) });
+    expect(numCalls).toEqual(1);
+
+    if (isIncrementalResult(result)) throw Error('result is incremental');
+
+    expect(result.data).toEqual({
+      users: [
+        {
+          id: '1',
+          posts: [
+            { id: '2', title: 'Post 2' },
+            { id: '3', title: 'Post 3' },
+          ],
+        },
+        {
+          id: '7',
+          posts: [
+            { id: '8', title: 'Post 8' },
+            { id: '9', title: 'Post 9' },
+          ],
+        },
+      ],
+    });
+  });
+
+  test('works with keys passed to lazyOptionsFn', async () => {
+    let numCalls = 0;
+
+    const postsSchema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        type Post {
+          id: ID!
+          title: String
+        }
+
+        type Page {
+          posts(ids: [ID]!): [Post]!
+        }
+
+        type Query {
+          page: Page
+        }
+      `,
+      resolvers: {
+        Page: {
+          posts: (_, args) => {
+            numCalls += 1;
+            return args.ids.map((id: unknown) => ({ id, title: `Post ${id}` }));
+          },
+        },
+        Query: {
+          page: () => ({}),
+        },
+      },
+    });
+
+    const usersSchema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        type User {
+          id: ID!
+          postIds: [ID]!
+        }
+
+        type Query {
+          users(ids: [ID!]!): [User]!
+        }
+      `,
+      resolvers: {
+        Query: {
+          users: (_, args) => {
+            return args.ids.map((id: unknown) => {
+              return { id, postIds: [Number(id) + 1, Number(id) + 2] };
+            });
+          },
+        },
+      },
+    });
+
+    const linkTypeDefs = /* GraphQL */ `
+      extend type User {
+        posts: [Post]!
+      }
+    `;
+
+    const stitchedSchema = stitchSchemas({
+      subschemas: [postsSchema, usersSchema],
+      typeDefs: linkTypeDefs,
+      resolvers: {
+        User: {
+          posts: {
+            selectionSet: `{ postIds }`,
+            resolve(user, _args, context, info) {
+              return batchDelegateToSchema({
+                schema: postsSchema,
+                operation: 'query' as OperationTypeNode,
+                fieldName: 'page',
+                key: user.postIds,
+                context,
+                info,
+                valuesFromResults: ({ posts }) => posts,
+                lazyOptionsFn: (options, keys) => ({
+                  ...options,
+                  returnType: postsSchema.getType('Page') as GraphQLObjectType,
+                  args: {},
+                  selectionSet: {
+                    kind: Kind.SELECTION_SET,
+                    selections: [
+                      {
+                        kind: Kind.FIELD,
+                        name: { kind: Kind.NAME, value: 'posts' },
+                        arguments: [
+                          {
+                            kind: Kind.ARGUMENT,
+                            name: { kind: Kind.NAME, value: 'ids' },
+                            value: {
+                              kind: Kind.LIST,
+                              values: keys.map(key => ({
+                                kind: Kind.INT,
+                                value: key,
+                              })),
+                            },
+                          },
+                        ],
+                        selectionSet: info.fieldNodes[0].selectionSet,
+                      },
+                    ],
+                  },
+                }),
               });
             },
           },


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->
## Description
`lazyOptionsFn` now accepts `keys` as an argument.
This way user can create a custom `options` based on the `keys`.

Beforehand It was not possible to pass arguments to an nested field.
Now it can be done with a custom `selectionSet` based on the `keys`.

Related #5102

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Added a test with `lazyOptionsFn` returning custom `selectionSet` based on `keys`.

- [X] works with keys passed to lazyOptionsFn

**Test Environment**:

- OS: Windows 11
- NodeJS: 16.4.0

## Checklist:

- [X] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

