### PR TITLE
fix(filterSchema): exclude root type with no fields

### DIFF
--- a/packages/utils/src/filterSchema.ts
+++ b/packages/utils/src/filterSchema.ts
@@ -78,7 +78,7 @@ function filterRootFields(
   operation: 'Query' | 'Mutation' | 'Subscription',
   rootFieldFilter?: RootFieldFilter,
   argumentFilter?: ArgumentFilter
-): GraphQLObjectType {
+): GraphQLObjectType | null {
   if (rootFieldFilter || argumentFilter) {
     const config = type.toConfig();
     for (const fieldName in config.fields) {
@@ -93,7 +93,7 @@ function filterRootFields(
         }
       }
     }
-    return new GraphQLObjectType(config);
+    return Object.keys(config.fields).length > 0 ? new GraphQLObjectType(config) : null;
   }
   return type;
 }

--- a/packages/utils/tests/filterSchema.test.ts
+++ b/packages/utils/tests/filterSchema.test.ts
@@ -28,6 +28,28 @@ describe('filterSchema', () => {
     expect((filtered.getType('Mutation') as GraphQLObjectType).getFields()['omitThis']).toBeUndefined();
   });
 
+  it('filters root type', () => {
+    const schema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          keep: String
+        }
+        type Mutation {
+          omitThis(id: ID): String
+        }
+      `,
+    });
+
+    const filtered = filterSchema({
+      schema,
+      rootFieldFilter: (_opName, fieldName) => fieldName?.startsWith('keep') ?? false,
+    });
+
+    expect((filtered.getType('Query') as GraphQLObjectType).getFields()['keep']).toBeDefined();
+    expect((filtered.getType('Query') as GraphQLObjectType).getFields()['omit']).toBeUndefined();
+    expect(filtered.getType('Mutation')).toBeUndefined();
+  });
+
   it('filters types', () => {
     const schema = makeExecutableSchema({
       typeDefs: /* GraphQL */ `


### PR DESCRIPTION
## Description

We noticed that in some cases `filterSchema()` would result in schemas that fail `validateSchema()` with "Type Mutation must define one or more fields". 

```js
import { filterSchema } from "@graphql-tools/utils";
import { buildSchema, printSchema } from "graphql";

const schema = buildSchema(`
  type Query { foo: Int }
  type Mutation { bar: Int }
`);

const filteredSchema = filterSchema({
  schema,
  rootFieldFilter(operation, rootFieldName) {
    return operation === "Query" && rootFieldName === "foo";
  }
});

console.log(printSchema(filteredSchema));
/*
type Query {
  foo: Int
}

type Mutation
*/
console.log(validateSchema(filteredSchema));
/*
[
  GraphQLError: Type Mutation must define one or more fields.
  ...
]  
*/
```

The fix in this PR is to return `null` from `filterRootFields` when there are no fields on the resulting type. The current workaround is the run `pruneSchema()` after `filterSchema()`. Thanks!

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Somebody could be relying on this buggy behavior but I'm not sure why. 

## Screenshots/Sandbox (if appropriate/relevant):

https://codesandbox.io/s/sleepy-grothendieck-doty3h?file=/src/index.ts

## How Has This Been Tested?

Added unit test in PR

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

