### PR TITLE
fix: batch delegation collapses two requests with different arguments into a single memoized loader

### DIFF
--- a/packages/batch-delegate/src/getLoader.ts
+++ b/packages/batch-delegate/src/getLoader.ts
@@ -76,14 +76,17 @@ export function getLoader<K = any, V = any, C = K>(options: BatchDelegateOptions
     fieldName = info.fieldName,
     dataLoaderOptions,
     fieldNodes = info.fieldNodes,
-    selectionSet = fieldNodes[0].selectionSet,
   } = options;
   const loaders = getLoadersMap<K, V, C>(context ?? GLOBAL_CONTEXT, schema);
 
   let cacheKey = fieldName;
 
-  if (selectionSet != null) {
-    cacheKey += memoizedPrint(selectionSet);
+  if (fieldNodes[0]?.selectionSet != null) {
+    const fieldNode = {
+      ...fieldNodes[0],
+      alias: undefined,
+    };
+    cacheKey += memoizedPrint(fieldNode);
   }
 
   let loader = loaders.get(cacheKey);

--- a/packages/batch-delegate/src/getLoader.ts
+++ b/packages/batch-delegate/src/getLoader.ts
@@ -81,7 +81,7 @@ export function getLoader<K = any, V = any, C = K>(options: BatchDelegateOptions
 
   let cacheKey = fieldName;
 
-  if (fieldNodes[0]?.selectionSet != null) {
+  if (fieldNodes[0]) {
     const fieldNode = {
       ...fieldNodes[0],
       alias: undefined,

--- a/packages/batch-delegate/tests/basic.example.test.ts
+++ b/packages/batch-delegate/tests/basic.example.test.ts
@@ -97,7 +97,7 @@ describe('batch delegation within basic stitching example', () => {
     expect(chirps[0].chirpedAtUser.email).not.toBe(null);
   });
 
-  test.only('uses a single call even when delegating the same field multiple times', async () => {
+  test('uses a single call even when delegating the same field multiple times', async () => {
     let numCalls = 0;
 
     const chirpSchema = makeExecutableSchema({

--- a/packages/batch-delegate/tests/cacheByArguments.test.ts
+++ b/packages/batch-delegate/tests/cacheByArguments.test.ts
@@ -1,0 +1,107 @@
+import { execute, isIncrementalResult } from '@graphql-tools/executor';
+import { OperationTypeNode, parse } from 'graphql';
+
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { batchDelegateToSchema } from '@graphql-tools/batch-delegate';
+import { stitchSchemas } from '@graphql-tools/stitch';
+
+describe('non-key arguments are taken into account when memoizing result', () => {
+  test('memoizes non-key arguments as part of batch delegation', async () => {
+    let numCalls = 0;
+
+    const chirpSchema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        type Chirp {
+          chirpedAtUserId: ID!
+        }
+
+        type Query {
+          trendingChirps: [Chirp]
+        }
+      `,
+      resolvers: {
+        Query: {
+          trendingChirps: () => [{ chirpedAtUserId: 1 }, { chirpedAtUserId: 2 }],
+        },
+      },
+    });
+
+    // Mocked author schema
+    const authorSchema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        type User {
+          email: String!
+        }
+
+        type Query {
+          usersByIds(ids: [ID!], obfuscateEmail: Boolean!): [User]
+        }
+      `,
+      resolvers: {
+        Query: {
+          usersByIds: (_root, args) => {
+            numCalls++;
+            return args.ids.map((id: string) => ({ email: args.obfuscateEmail ? '***' : `${id}@test.com` }));
+          },
+        },
+      },
+    });
+
+    const linkTypeDefs = /* GraphQL */ `
+      extend type Chirp {
+        chirpedAtUser(obfuscateEmail: Boolean!): User
+      }
+    `;
+
+    const stitchedSchema = stitchSchemas({
+      subschemas: [chirpSchema, authorSchema],
+      typeDefs: linkTypeDefs,
+      resolvers: {
+        Chirp: {
+          chirpedAtUser: {
+            selectionSet: `{ chirpedAtUserId }`,
+            resolve(chirp, args, context, info) {
+              return batchDelegateToSchema({
+                schema: authorSchema,
+                operation: 'query' as OperationTypeNode,
+                fieldName: 'usersByIds',
+                key: chirp.chirpedAtUserId,
+                argsFromKeys: ids => ({ ids, ...args }),
+                context,
+                info,
+              });
+            },
+          },
+        },
+      },
+    });
+
+    const query = /* GraphQL */ `
+      query {
+        trendingChirps {
+          withObfuscatedEmail: chirpedAtUser(obfuscateEmail: true) {
+            email
+          }
+          withoutObfuscatedEmail: chirpedAtUser(obfuscateEmail: false) {
+            email
+          }
+        }
+      }
+    `;
+
+    const result = await execute({ schema: stitchedSchema, document: parse(query) });
+
+    expect(numCalls).toEqual(2);
+
+    if (isIncrementalResult(result)) throw Error('result is incremental');
+
+    expect(result.errors).toBeUndefined();
+
+    const chirps: any = result.data!['trendingChirps'];
+    expect(chirps[0].withObfuscatedEmail.email).toBe(`***`);
+    expect(chirps[1].withObfuscatedEmail.email).toBe(`***`);
+
+    expect(chirps[0].withoutObfuscatedEmail.email).toBe(`1@test.com`);
+    expect(chirps[1].withoutObfuscatedEmail.email).toBe(`2@test.com`);
+  });
+});


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

When using `batchDelegateToSchema`, the cacheKey for fetching a memoized loader is created using either the requested field name (for fields returning scalars) or the field name + selection set (for fields returning composites). When using this in conjunction with non-key arguments (for instance via `argsFromKeys`), those arguments do not effect the cacheKey. Thus, delegating the same field multiple times with different arguments only ever result in one delegation.

The proposed fix changes the cacheKey construction. Instead of using only the `selectionSet` of a composite field node, it uses the entire field node (with the alias redacted). This goes for composite fields as well as scalar fields since both of them could be delegating with non-key arguments.

It seems to solve the issue (see `cacheByArguments.test.ts` for a test that fails using the old cacheKey construction method, that now passes). However, there might be nuances to delegation that I am missing (for instance, when would there ever be more than one field node in `fieldNodes`?).

Please have a look and see if my proposal makes sense to you.

Related to #5188

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] packages/batch-delegate/tests/cacheByArguments.test.ts (bug resolution)
- [ ] packages/batch-delegate/tests/basic.example.test.ts (new test to verify that resolver function call amount for batch delegations without non-key arguments is still 1, even if the same field is used multiple times with different aliases)

**Test Environment**:

- OS:
- `@graphql-tools/batch-delegate`: 8.4.25
- NodeJS: v16.13.2

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
