### PR TITLE
Stitched schema loses error 'extensions' when batched

### DIFF
--- a/.changeset/dry-boats-smash.md
+++ b/.changeset/dry-boats-smash.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/batch-execute': patch
+---
+
+fix: batched executor returns original error when it has no path

--- a/packages/batch-execute/src/splitResult.ts
+++ b/packages/batch-execute/src/splitResult.ts
@@ -41,7 +41,7 @@ export function splitResult({ data, errors }: ExecutionResult, numResults: numbe
       } else {
         splitResults.forEach(result => {
           const resultErrors = (result.errors = (result.errors || []) as GraphQLError[]);
-          resultErrors.push(createGraphQLError(error.message));
+          resultErrors.push(error);
         });
       }
     }

--- a/packages/batch-execute/src/splitResult.ts
+++ b/packages/batch-execute/src/splitResult.ts
@@ -2,7 +2,7 @@
 
 import { GraphQLError } from 'graphql';
 
-import { createGraphQLError, ExecutionResult, relocatedError } from '@graphql-tools/utils';
+import { ExecutionResult, relocatedError } from '@graphql-tools/utils';
 
 import { parseKey } from './prefix.js';
 

--- a/packages/batch-execute/tests/batchExecute.test.ts
+++ b/packages/batch-execute/tests/batchExecute.test.ts
@@ -186,7 +186,16 @@ describe('batch execution', () => {
     expect(executorCalls).toEqual(1);
   });
 
-  it('returns original error fields when no path', async () => {
+  it('pathed errors contain extensions', async () => {
+    const [first] = (await Promise.all([batchExec({ document: parse('{ extension }') })])) as ExecutionResult[];
+
+    expect(first?.errors?.length).toEqual(1);
+    expect(first?.errors?.[0].message).toMatch(/boom/);
+    expect(first?.errors?.[0].extensions).toEqual({ foo: 'bar' });
+    expect(executorCalls).toEqual(1);
+  });
+
+  it('non pathed errors contain extensions', async () => {
     const errorExec: Executor = (): MaybeAsyncIterable<ExecutionResult> => {
       return { errors: [new GraphQLError('boom', { extensions: { foo: 'bar' } })] };
     };

--- a/packages/batch-execute/tests/batchExecute.test.ts
+++ b/packages/batch-execute/tests/batchExecute.test.ts
@@ -30,7 +30,7 @@ describe('batch execution', () => {
         field2: () => '2',
         field3: (_root, { input }) => String(input),
         boom: (_root, { message }) => new Error(message),
-        extension: () => new GraphQLError('boom', { extensions: extensions }),
+        extension: () => new GraphQLError('boom', undefined, undefined, undefined, undefined, undefined, extensions),
         widget: () => ({ name: 'wingnut' }),
       },
     },
@@ -200,7 +200,7 @@ describe('batch execution', () => {
 
   it('non pathed errors contain extensions', async () => {
     const errorExec: Executor = (): MaybeAsyncIterable<ExecutionResult> => {
-      return { errors: [new GraphQLError('boom', { extensions })] };
+      return { errors: [new GraphQLError('boom', undefined, undefined, undefined, undefined, undefined, extensions)] };
     };
     const batchExec = createBatchingExecutor(errorExec);
 

--- a/packages/batch-execute/tests/batchExecute.test.ts
+++ b/packages/batch-execute/tests/batchExecute.test.ts
@@ -1,4 +1,4 @@
-import { parse, print, OperationDefinitionNode, validate, GraphQLError } from 'graphql';
+import { parse, print, OperationDefinitionNode, validate } from 'graphql';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { createBatchingExecutor } from '@graphql-tools/batch-execute';
 import { createGraphQLError, ExecutionResult, Executor, MaybeAsyncIterable } from '@graphql-tools/utils';

--- a/packages/batch-execute/tests/batchExecute.test.ts
+++ b/packages/batch-execute/tests/batchExecute.test.ts
@@ -1,7 +1,7 @@
 import { parse, print, OperationDefinitionNode, validate, GraphQLError } from 'graphql';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { createBatchingExecutor } from '@graphql-tools/batch-execute';
-import { ExecutionResult, Executor, MaybeAsyncIterable } from '@graphql-tools/utils';
+import { createGraphQLError, ExecutionResult, Executor, MaybeAsyncIterable } from '@graphql-tools/utils';
 import { normalizedExecutor } from '@graphql-tools/executor';
 
 describe('batch execution', () => {
@@ -30,7 +30,7 @@ describe('batch execution', () => {
         field2: () => '2',
         field3: (_root, { input }) => String(input),
         boom: (_root, { message }) => new Error(message),
-        extension: () => new GraphQLError('boom', undefined, undefined, undefined, undefined, undefined, extensions),
+        extension: () => createGraphQLError('boom', { extensions }),
         widget: () => ({ name: 'wingnut' }),
       },
     },
@@ -200,7 +200,7 @@ describe('batch execution', () => {
 
   it('non pathed errors contain extensions', async () => {
     const errorExec: Executor = (): MaybeAsyncIterable<ExecutionResult> => {
-      return { errors: [new GraphQLError('boom', undefined, undefined, undefined, undefined, undefined, extensions)] };
+      return { errors: [createGraphQLError('boom', { extensions })] };
     };
     const batchExec = createBatchingExecutor(errorExec);
 


### PR DESCRIPTION
## Description

When an error that contains no path is returned in a batched operation the extensions are lost. 

I have changed it to just return the original error but we could wrap it like so.
```js
          resultErrors.push(createGraphQLError(error.message, { ...error, originalError: error.originalError}));
```

Related # ([4732](https://github.com/ardatan/graphql-tools/issues/4732))

I ran into this issue and found the only way I could replicate it is on non pathed batch queries. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Unit tested 

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

