### PR TITLE
fix(merge): Don't merge/override arguments for repeatable directives

### DIFF
--- a/.changeset/cyan-ears-knock.md
+++ b/.changeset/cyan-ears-knock.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/merge': patch
+---
+
+Don't merge/override arguments for repeatable directives

--- a/packages/merge/src/typedefs-mergers/enum-values.ts
+++ b/packages/merge/src/typedefs-mergers/enum-values.ts
@@ -1,4 +1,4 @@
-import { EnumValueDefinitionNode } from 'graphql';
+import { DirectiveDefinitionNode, EnumValueDefinitionNode } from 'graphql';
 import { mergeDirectives } from './directives.js';
 import { Config } from './merge-typedefs.js';
 import { compareNodes } from '@graphql-tools/utils';
@@ -6,7 +6,8 @@ import { compareNodes } from '@graphql-tools/utils';
 export function mergeEnumValues(
   first: ReadonlyArray<EnumValueDefinitionNode> | undefined,
   second: ReadonlyArray<EnumValueDefinitionNode> | undefined,
-  config?: Config
+  config?: Config,
+  directives?: Record<string, DirectiveDefinitionNode>
 ): EnumValueDefinitionNode[] {
   if (config?.consistentEnumMerge) {
     const reversed: Array<EnumValueDefinitionNode> = [];
@@ -28,7 +29,7 @@ export function mergeEnumValues(
       if (enumValueMap.has(enumValue)) {
         const firstValue: any = enumValueMap.get(enumValue);
         firstValue.description = secondValue.description || firstValue.description;
-        firstValue.directives = mergeDirectives(secondValue.directives, firstValue.directives);
+        firstValue.directives = mergeDirectives(secondValue.directives, firstValue.directives, directives);
       } else {
         enumValueMap.set(enumValue, secondValue);
       }

--- a/packages/merge/src/typedefs-mergers/enum.ts
+++ b/packages/merge/src/typedefs-mergers/enum.ts
@@ -1,4 +1,4 @@
-import { EnumTypeDefinitionNode, EnumTypeExtensionNode, Kind } from 'graphql';
+import { DirectiveDefinitionNode, EnumTypeDefinitionNode, EnumTypeExtensionNode, Kind } from 'graphql';
 import { mergeDirectives } from './directives.js';
 import { mergeEnumValues } from './enum-values.js';
 import { Config } from './merge-typedefs.js';
@@ -6,7 +6,8 @@ import { Config } from './merge-typedefs.js';
 export function mergeEnum(
   e1: EnumTypeDefinitionNode | EnumTypeExtensionNode,
   e2: EnumTypeDefinitionNode | EnumTypeExtensionNode,
-  config?: Config
+  config?: Config,
+  directives?: Record<string, DirectiveDefinitionNode>
 ): EnumTypeDefinitionNode | EnumTypeExtensionNode {
   if (e2) {
     return {
@@ -17,7 +18,7 @@ export function mergeEnum(
           ? 'EnumTypeDefinition'
           : 'EnumTypeExtension',
       loc: e1.loc,
-      directives: mergeDirectives(e1.directives, e2.directives, config),
+      directives: mergeDirectives(e1.directives, e2.directives, config, directives),
       values: mergeEnumValues(e1.values, e2.values, config),
     } as any;
   }

--- a/packages/merge/src/typedefs-mergers/fields.ts
+++ b/packages/merge/src/typedefs-mergers/fields.ts
@@ -1,5 +1,5 @@
 import { Config } from './merge-typedefs.js';
-import { FieldDefinitionNode, InputValueDefinitionNode, TypeNode, NameNode } from 'graphql';
+import { FieldDefinitionNode, InputValueDefinitionNode, TypeNode, NameNode, DirectiveDefinitionNode } from 'graphql';
 import { extractType, isWrappingTypeNode, isListTypeNode, isNonNullTypeNode, printTypeNode } from './utils.js';
 import { mergeDirectives } from './directives.js';
 import { compareNodes } from '@graphql-tools/utils';
@@ -25,7 +25,8 @@ export function mergeFields<T extends FieldDefNode>(
   type: { name: NameNode },
   f1: ReadonlyArray<T> | undefined,
   f2: ReadonlyArray<T> | undefined,
-  config?: Config
+  config?: Config,
+  directives?: Record<string, DirectiveDefinitionNode>
 ): T[] {
   const result: T[] = [];
   if (f2 != null) {
@@ -41,7 +42,7 @@ export function mergeFields<T extends FieldDefNode>(
           preventConflicts(type, existing, field, config?.throwOnConflict);
 
         newField.arguments = mergeArguments(field['arguments'] || [], existing['arguments'] || [], config);
-        newField.directives = mergeDirectives(field.directives, existing.directives, config);
+        newField.directives = mergeDirectives(field.directives, existing.directives, config, directives);
         newField.description = field.description || existing.description;
         result[existingIndex] = newField;
       } else {

--- a/packages/merge/src/typedefs-mergers/input-type.ts
+++ b/packages/merge/src/typedefs-mergers/input-type.ts
@@ -1,12 +1,19 @@
 import { Config } from './merge-typedefs.js';
-import { InputObjectTypeDefinitionNode, InputValueDefinitionNode, InputObjectTypeExtensionNode, Kind } from 'graphql';
+import {
+  InputObjectTypeDefinitionNode,
+  InputValueDefinitionNode,
+  InputObjectTypeExtensionNode,
+  Kind,
+  DirectiveDefinitionNode,
+} from 'graphql';
 import { mergeFields } from './fields.js';
 import { mergeDirectives } from './directives.js';
 
 export function mergeInputType(
   node: InputObjectTypeDefinitionNode | InputObjectTypeExtensionNode,
   existingNode: InputObjectTypeDefinitionNode | InputObjectTypeExtensionNode,
-  config?: Config
+  config?: Config,
+  directives?: Record<string, DirectiveDefinitionNode>
 ): InputObjectTypeDefinitionNode | InputObjectTypeExtensionNode {
   if (existingNode) {
     try {
@@ -21,7 +28,7 @@ export function mergeInputType(
             : 'InputObjectTypeExtension',
         loc: node.loc,
         fields: mergeFields<InputValueDefinitionNode>(node, node.fields, existingNode.fields, config),
-        directives: mergeDirectives(node.directives, existingNode.directives, config),
+        directives: mergeDirectives(node.directives, existingNode.directives, config, directives),
       } as any;
     } catch (e: any) {
       throw new Error(`Unable to merge GraphQL input type "${node.name.value}": ${e.message}`);

--- a/packages/merge/src/typedefs-mergers/interface.ts
+++ b/packages/merge/src/typedefs-mergers/interface.ts
@@ -1,5 +1,5 @@
 import { Config } from './merge-typedefs.js';
-import { InterfaceTypeDefinitionNode, InterfaceTypeExtensionNode, Kind } from 'graphql';
+import { DirectiveDefinitionNode, InterfaceTypeDefinitionNode, InterfaceTypeExtensionNode, Kind } from 'graphql';
 import { mergeFields } from './fields.js';
 import { mergeDirectives } from './directives.js';
 import { mergeNamedTypeArray } from './merge-named-type-array.js';
@@ -7,7 +7,8 @@ import { mergeNamedTypeArray } from './merge-named-type-array.js';
 export function mergeInterface(
   node: InterfaceTypeDefinitionNode | InterfaceTypeExtensionNode,
   existingNode: InterfaceTypeDefinitionNode | InterfaceTypeExtensionNode,
-  config?: Config
+  config?: Config,
+  directives?: Record<string, DirectiveDefinitionNode>
 ): InterfaceTypeDefinitionNode | InterfaceTypeExtensionNode {
   if (existingNode) {
     try {
@@ -22,7 +23,7 @@ export function mergeInterface(
             : 'InterfaceTypeExtension',
         loc: node.loc,
         fields: mergeFields(node, node.fields, existingNode.fields, config),
-        directives: mergeDirectives(node.directives, existingNode.directives, config),
+        directives: mergeDirectives(node.directives, existingNode.directives, config, directives),
         interfaces: node['interfaces']
           ? mergeNamedTypeArray(node['interfaces'], existingNode['interfaces'], config)
           : undefined,

--- a/packages/merge/src/typedefs-mergers/merge-nodes.ts
+++ b/packages/merge/src/typedefs-mergers/merge-nodes.ts
@@ -1,5 +1,5 @@
 import { Config } from './merge-typedefs.js';
-import { DefinitionNode, Kind, SchemaDefinitionNode, SchemaExtensionNode } from 'graphql';
+import { DefinitionNode, DirectiveDefinitionNode, Kind, SchemaDefinitionNode, SchemaExtensionNode } from 'graphql';
 import { mergeType } from './type.js';
 import { mergeEnum } from './enum.js';
 import { mergeScalar } from './scalar.js';
@@ -20,8 +20,12 @@ export function isNamedDefinitionNode(definitionNode: DefinitionNode): definitio
   return 'name' in definitionNode;
 }
 
-export function mergeGraphQLNodes(nodes: ReadonlyArray<DefinitionNode>, config?: Config): MergedResultMap {
-  const mergedResultMap = {} as MergedResultMap;
+export function mergeGraphQLNodes(
+  nodes: ReadonlyArray<DefinitionNode>,
+  config?: Config,
+  directives: Record<string, DirectiveDefinitionNode> = {}
+): MergedResultMap {
+  const mergedResultMap = directives as MergedResultMap;
   for (const nodeDefinition of nodes) {
     if (isNamedDefinitionNode(nodeDefinition)) {
       const name = nodeDefinition.name?.value;
@@ -39,27 +43,27 @@ export function mergeGraphQLNodes(nodes: ReadonlyArray<DefinitionNode>, config?:
         switch (nodeDefinition.kind) {
           case Kind.OBJECT_TYPE_DEFINITION:
           case Kind.OBJECT_TYPE_EXTENSION:
-            mergedResultMap[name] = mergeType(nodeDefinition, mergedResultMap[name] as any, config);
+            mergedResultMap[name] = mergeType(nodeDefinition, mergedResultMap[name] as any, config, directives);
             break;
           case Kind.ENUM_TYPE_DEFINITION:
           case Kind.ENUM_TYPE_EXTENSION:
-            mergedResultMap[name] = mergeEnum(nodeDefinition, mergedResultMap[name] as any, config);
+            mergedResultMap[name] = mergeEnum(nodeDefinition, mergedResultMap[name] as any, config, directives);
             break;
           case Kind.UNION_TYPE_DEFINITION:
           case Kind.UNION_TYPE_EXTENSION:
-            mergedResultMap[name] = mergeUnion(nodeDefinition, mergedResultMap[name] as any, config);
+            mergedResultMap[name] = mergeUnion(nodeDefinition, mergedResultMap[name] as any, config, directives);
             break;
           case Kind.SCALAR_TYPE_DEFINITION:
           case Kind.SCALAR_TYPE_EXTENSION:
-            mergedResultMap[name] = mergeScalar(nodeDefinition, mergedResultMap[name] as any, config);
+            mergedResultMap[name] = mergeScalar(nodeDefinition, mergedResultMap[name] as any, config, directives);
             break;
           case Kind.INPUT_OBJECT_TYPE_DEFINITION:
           case Kind.INPUT_OBJECT_TYPE_EXTENSION:
-            mergedResultMap[name] = mergeInputType(nodeDefinition, mergedResultMap[name] as any, config);
+            mergedResultMap[name] = mergeInputType(nodeDefinition, mergedResultMap[name] as any, config, directives);
             break;
           case Kind.INTERFACE_TYPE_DEFINITION:
           case Kind.INTERFACE_TYPE_EXTENSION:
-            mergedResultMap[name] = mergeInterface(nodeDefinition, mergedResultMap[name] as any, config);
+            mergedResultMap[name] = mergeInterface(nodeDefinition, mergedResultMap[name] as any, config, directives);
             break;
           case Kind.DIRECTIVE_DEFINITION:
             mergedResultMap[name] = mergeDirective(nodeDefinition, mergedResultMap[name] as any);

--- a/packages/merge/src/typedefs-mergers/scalar.ts
+++ b/packages/merge/src/typedefs-mergers/scalar.ts
@@ -1,11 +1,12 @@
-import { Kind, ScalarTypeDefinitionNode, ScalarTypeExtensionNode } from 'graphql';
+import { DirectiveDefinitionNode, Kind, ScalarTypeDefinitionNode, ScalarTypeExtensionNode } from 'graphql';
 import { mergeDirectives } from './directives.js';
 import { Config } from './merge-typedefs.js';
 
 export function mergeScalar(
   node: ScalarTypeDefinitionNode | ScalarTypeExtensionNode,
   existingNode: ScalarTypeDefinitionNode | ScalarTypeExtensionNode,
-  config?: Config
+  config?: Config,
+  directives?: Record<string, DirectiveDefinitionNode>
 ): ScalarTypeDefinitionNode | ScalarTypeExtensionNode {
   if (existingNode) {
     return {
@@ -18,7 +19,7 @@ export function mergeScalar(
           ? 'ScalarTypeDefinition'
           : 'ScalarTypeExtension',
       loc: node.loc,
-      directives: mergeDirectives(node.directives, existingNode.directives, config),
+      directives: mergeDirectives(node.directives, existingNode.directives, config, directives),
     } as any;
   }
 

--- a/packages/merge/src/typedefs-mergers/schema-def.ts
+++ b/packages/merge/src/typedefs-mergers/schema-def.ts
@@ -1,4 +1,10 @@
-import { Kind, OperationTypeDefinitionNode, SchemaDefinitionNode, SchemaExtensionNode } from 'graphql';
+import {
+  DirectiveDefinitionNode,
+  Kind,
+  OperationTypeDefinitionNode,
+  SchemaDefinitionNode,
+  SchemaExtensionNode,
+} from 'graphql';
 import { mergeDirectives } from './directives.js';
 import { Config } from './merge-typedefs.js';
 
@@ -26,7 +32,8 @@ function mergeOperationTypes(
 export function mergeSchemaDefs(
   node: SchemaDefinitionNode | SchemaExtensionNode,
   existingNode: SchemaDefinitionNode | SchemaExtensionNode,
-  config?: Config
+  config?: Config,
+  directives?: Record<string, DirectiveDefinitionNode>
 ): SchemaDefinitionNode | SchemaExtensionNode {
   if (existingNode) {
     return {
@@ -35,7 +42,7 @@ export function mergeSchemaDefs(
           ? Kind.SCHEMA_DEFINITION
           : Kind.SCHEMA_EXTENSION,
       description: node['description'] || existingNode['description'],
-      directives: mergeDirectives(node.directives, existingNode.directives, config),
+      directives: mergeDirectives(node.directives, existingNode.directives, config, directives),
       operationTypes: mergeOperationTypes(node.operationTypes, existingNode.operationTypes),
     } as any;
   }

--- a/packages/merge/src/typedefs-mergers/type.ts
+++ b/packages/merge/src/typedefs-mergers/type.ts
@@ -1,5 +1,5 @@
 import { Config } from './merge-typedefs.js';
-import { Kind, ObjectTypeDefinitionNode, ObjectTypeExtensionNode } from 'graphql';
+import { DirectiveDefinitionNode, Kind, ObjectTypeDefinitionNode, ObjectTypeExtensionNode } from 'graphql';
 import { mergeFields } from './fields.js';
 import { mergeDirectives } from './directives.js';
 import { mergeNamedTypeArray } from './merge-named-type-array.js';
@@ -7,7 +7,8 @@ import { mergeNamedTypeArray } from './merge-named-type-array.js';
 export function mergeType(
   node: ObjectTypeDefinitionNode | ObjectTypeExtensionNode,
   existingNode: ObjectTypeDefinitionNode | ObjectTypeExtensionNode,
-  config?: Config
+  config?: Config,
+  directives?: Record<string, DirectiveDefinitionNode>
 ): ObjectTypeDefinitionNode | ObjectTypeExtensionNode {
   if (existingNode) {
     try {
@@ -22,7 +23,7 @@ export function mergeType(
             : 'ObjectTypeExtension',
         loc: node.loc,
         fields: mergeFields(node, node.fields, existingNode.fields, config),
-        directives: mergeDirectives(node.directives, existingNode.directives, config),
+        directives: mergeDirectives(node.directives, existingNode.directives, config, directives),
         interfaces: mergeNamedTypeArray(node.interfaces, existingNode.interfaces, config),
       } as any;
     } catch (e: any) {

--- a/packages/merge/src/typedefs-mergers/union.ts
+++ b/packages/merge/src/typedefs-mergers/union.ts
@@ -1,4 +1,4 @@
-import { Kind, UnionTypeDefinitionNode, UnionTypeExtensionNode } from 'graphql';
+import { DirectiveDefinitionNode, Kind, UnionTypeDefinitionNode, UnionTypeExtensionNode } from 'graphql';
 import { mergeDirectives } from './directives.js';
 import { mergeNamedTypeArray } from './merge-named-type-array.js';
 import { Config } from './merge-typedefs.js';
@@ -6,14 +6,15 @@ import { Config } from './merge-typedefs.js';
 export function mergeUnion(
   first: UnionTypeDefinitionNode | UnionTypeExtensionNode,
   second: UnionTypeDefinitionNode | UnionTypeExtensionNode,
-  config?: Config
+  config?: Config,
+  directives?: Record<string, DirectiveDefinitionNode>
 ): UnionTypeDefinitionNode | UnionTypeExtensionNode {
   if (second) {
     return {
       name: first.name,
       description: first['description'] || second['description'],
       // ConstXNode has been introduced in v16 but it is not compatible with XNode so we do `as any` for backwards compatibility
-      directives: mergeDirectives(first.directives, second.directives, config) as any,
+      directives: mergeDirectives(first.directives, second.directives, config, directives) as any,
       kind:
         config?.convertExtensions || first.kind === 'UnionTypeDefinition' || second.kind === 'UnionTypeDefinition'
           ? Kind.UNION_TYPE_DEFINITION


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

According to [GraphQL Spec](https://spec.graphql.org/October2021/#example-67869) directives might be marked as repeatable, that means a GraphQL node might have more than one the same directive with different set of arguments. Currently `@graphql-tools/merge` package while merging doesn't respect `repeatable` directives and as a result overrides multiple same directives on one node and keeps only the last one. Which doesn't happen if directives declared in a node that isn't overridden. By this PR I merge directives definitions first and then use `isRepeatable` flag to merge directives properly.

Related #4767 

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
