### PR TITLE
fix(stitch): missing dep on @graphql-tools/executor

### DIFF
--- a/.changeset/nice-bulldogs-raise.md
+++ b/.changeset/nice-bulldogs-raise.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/stitch': patch
+---
+
+Add missing dependency on @graphql-tools/executor.

--- a/packages/stitch/package.json
+++ b/packages/stitch/package.json
@@ -58,6 +58,7 @@
   "dependencies": {
     "@graphql-tools/batch-delegate": "^8.4.27",
     "@graphql-tools/delegate": "^9.0.35",
+    "@graphql-tools/executor": "^0.0.20",
     "@graphql-tools/merge": "^8.4.1",
     "@graphql-tools/schema": "^9.0.18",
     "@graphql-tools/utils": "^9.2.1",


### PR DESCRIPTION
## Description

`@graphql-tools/stitch`: fix an issue with an undeclared dependency on `@graphql-tools/executor`

Package managers (pnpm, yarn pnp) strictly isolates the deps, without this `@graphql-tools/executor` seems to not be  resolvable. 

Related: https://github.com/ardatan/graphql-tools/issues/5234

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

Should fix:

![image](https://user-images.githubusercontent.com/259798/235429148-84b0c65f-4460-4bcf-b4b3-cb03acc862cd.png)

## How Has This Been Tested?

Haven't tested it, but I guess it should work


## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules


