### PR TITLE
fix(git-loader): respect leading './' for globs

### DIFF
--- a/.changeset/short-spies-help.md
+++ b/.changeset/short-spies-help.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/git-loader': minor
+---
+
+respect leading './' for globs

--- a/packages/graphql-tag-pluck/src/index.ts
+++ b/packages/graphql-tag-pluck/src/index.ts
@@ -17,7 +17,7 @@ const traverse = getDefault(traversePkg);
  */
 export interface GraphQLTagPluckOptions {
   /**
-   * Additional options for determining how a file is parsed.An array of packages that are responsible for exporting the GraphQL string parser function. The following modules are supported by default:
+   * Additional options for determining how a file is parsed. An array of packages that are responsible for exporting the GraphQL string parser function. The following modules are supported by default:
    * ```js
    * {
    *   modules: [

--- a/packages/loaders/git/src/index.ts
+++ b/packages/loaders/git/src/index.ts
@@ -82,10 +82,14 @@ export class GitLoader implements Loader<GitLoaderOptions> {
       refsForPaths.get(ref).push(`!${unixify(path)}`);
     }
 
+    const filePathPrefix = path.startsWith('./') ? './' : '';
+
     const resolved: string[] = [];
     await Promise.all(
       [...refsForPaths.entries()].map(async ([ref, paths]) => {
-        resolved.push(...micromatch(await readTreeAtRef(ref), paths).map(filePath => `git:${ref}:${filePath}`));
+        resolved.push(
+          ...micromatch(await readTreeAtRef(ref), paths).map(filePath => `git:${ref}:${filePathPrefix}${filePath}`)
+        );
       })
     );
     return resolved;
@@ -116,9 +120,13 @@ export class GitLoader implements Loader<GitLoaderOptions> {
       refsForPaths.get(ref).push(`!${unixify(path)}`);
     }
 
+    const filePathPrefix = path.startsWith('./') ? './' : '';
+
     const resolved: string[] = [];
     for (const [ref, paths] of refsForPaths.entries()) {
-      resolved.push(...micromatch(readTreeAtRefSync(ref), paths).map(filePath => `git:${ref}:${filePath}`));
+      resolved.push(
+        ...micromatch(readTreeAtRefSync(ref), paths).map(filePath => `git:${ref}:${filePathPrefix}${filePath}`)
+      );
     }
     return resolved;
   }

--- a/packages/loaders/git/src/index.ts
+++ b/packages/loaders/git/src/index.ts
@@ -82,13 +82,15 @@ export class GitLoader implements Loader<GitLoaderOptions> {
       refsForPaths.get(ref).push(`!${unixify(path)}`);
     }
 
-    const filePathPrefix = path.startsWith('./') ? './' : '';
+    const maybeLeadingDotSlash = path.startsWith('./') ? './' : '';
 
     const resolved: string[] = [];
     await Promise.all(
       [...refsForPaths.entries()].map(async ([ref, paths]) => {
         resolved.push(
-          ...micromatch(await readTreeAtRef(ref), paths).map(filePath => `git:${ref}:${filePathPrefix}${filePath}`)
+          ...micromatch(await readTreeAtRef(ref), paths).map(
+            filePath => `git:${ref}:${maybeLeadingDotSlash}${filePath}`
+          )
         );
       })
     );
@@ -120,12 +122,12 @@ export class GitLoader implements Loader<GitLoaderOptions> {
       refsForPaths.get(ref).push(`!${unixify(path)}`);
     }
 
-    const filePathPrefix = path.startsWith('./') ? './' : '';
+    const maybeLeadingDotSlash = path.startsWith('./') ? './' : '';
 
     const resolved: string[] = [];
     for (const [ref, paths] of refsForPaths.entries()) {
       resolved.push(
-        ...micromatch(readTreeAtRefSync(ref), paths).map(filePath => `git:${ref}:${filePathPrefix}${filePath}`)
+        ...micromatch(readTreeAtRefSync(ref), paths).map(filePath => `git:${ref}:${maybeLeadingDotSlash}${filePath}`)
       );
     }
     return resolved;

--- a/packages/loaders/git/src/index.ts
+++ b/packages/loaders/git/src/index.ts
@@ -237,7 +237,6 @@ export class GitLoader implements Loader<GitLoaderOptions> {
     try {
       if (isGlob(path)) {
         const resolvedPaths = this.resolveGlobsSync(pointer, asArray(options.ignore || []));
-        const finalResult: Source[] = [];
         for (const path of resolvedPaths) {
           if (this.canLoadSync(path)) {
             const results = this.loadSync(path, options);

--- a/packages/loaders/git/tests/__snapshots__/loader.spec.ts.snap
+++ b/packages/loaders/git/tests/__snapshots__/loader.spec.ts.snap
@@ -65,6 +65,71 @@ exports[`GitLoader load async should load type definitions from a pluckable file
 }
 `;
 
+exports[`GitLoader load async should work when loading glob paths that start with './' 1`] = `
+{
+  "definitions": [
+    {
+      "description": undefined,
+      "directives": [],
+      "fields": [
+        {
+          "arguments": [],
+          "description": undefined,
+          "directives": [],
+          "kind": "FieldDefinition",
+          "loc": {
+            "end": 28,
+            "start": 15,
+          },
+          "name": {
+            "kind": "Name",
+            "loc": {
+              "end": 20,
+              "start": 15,
+            },
+            "value": "hello",
+          },
+          "type": {
+            "kind": "NamedType",
+            "loc": {
+              "end": 28,
+              "start": 22,
+            },
+            "name": {
+              "kind": "Name",
+              "loc": {
+                "end": 28,
+                "start": 22,
+              },
+              "value": "String",
+            },
+          },
+        },
+      ],
+      "interfaces": [],
+      "kind": "ObjectTypeDefinition",
+      "loc": {
+        "end": 30,
+        "start": 0,
+      },
+      "name": {
+        "kind": "Name",
+        "loc": {
+          "end": 10,
+          "start": 5,
+        },
+        "value": "Query",
+      },
+    },
+  ],
+  "kind": "Document",
+  "loc": {
+    "end": 31,
+    "start": 0,
+  },
+}
+`;
+
 exports[`GitLoader load sync should load type definitions from a pluckable file 1`] = `
 {
   "definitions": [
@@ -125,6 +190,71 @@ exports[`GitLoader load sync should load type definitions from a pluckable file 
   "kind": "Document",
   "loc": {
     "end": 30,
+    "start": 0,
+  },
+}
+`;
+
+exports[`GitLoader load sync should work when loading glob paths that start with './' 1`] = `
+{
+  "definitions": [
+    {
+      "description": undefined,
+      "directives": [],
+      "fields": [
+        {
+          "arguments": [],
+          "description": undefined,
+          "directives": [],
+          "kind": "FieldDefinition",
+          "loc": {
+            "end": 28,
+            "start": 15,
+          },
+          "name": {
+            "kind": "Name",
+            "loc": {
+              "end": 20,
+              "start": 15,
+            },
+            "value": "hello",
+          },
+          "type": {
+            "kind": "NamedType",
+            "loc": {
+              "end": 28,
+              "start": 22,
+            },
+            "name": {
+              "kind": "Name",
+              "loc": {
+                "end": 28,
+                "start": 22,
+              },
+              "value": "String",
+            },
+          },
+        },
+      ],
+      "interfaces": [],
+      "kind": "ObjectTypeDefinition",
+      "loc": {
+        "end": 30,
+        "start": 0,
+      },
+      "name": {
+        "kind": "Name",
+        "loc": {
+          "end": 10,
+          "start": 5,
+        },
+        "value": "Query",
+      },
+    },
+  ],
+  "kind": "Document",
+  "loc": {
+    "end": 31,
     "start": 0,
   },
 }

--- a/packages/loaders/git/tests/loader.spec.ts
+++ b/packages/loaders/git/tests/loader.spec.ts
@@ -1,4 +1,5 @@
 import { execSync } from 'child_process';
+import * as path from 'path';
 
 import { GitLoader } from '../src/index.js';
 import { runTests } from '../../../testing/utils.js';
@@ -63,6 +64,16 @@ describe('GitLoader', () => {
       it('should simply ignore a non git path', async () => {
         const result = await load('./pluckable.ts', {});
         expect(result).toEqual([]);
+      });
+
+      it("should work when loading glob paths that start with './'", async () => {
+        const saveCwd = process.cwd();
+        process.chdir(path.resolve(__dirname, 'test-files', 'a'));
+
+        const [result] = await load(`git:${lastCommit}:./**/*.graphql`, {});
+        expect(result.document).toMatchSnapshot();
+
+        process.chdir(saveCwd);
       });
     });
   });

--- a/packages/loaders/git/tests/test-files/a/b/file.graphql
+++ b/packages/loaders/git/tests/test-files/a/b/file.graphql
@@ -1,0 +1,3 @@
+type Query {
+  hello: String
+}


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

See #5243 for issue details.

The issue occurs because `git ls-tree -r --name-only ref` in a subdirectory returns paths relative to cwd. `git show ref:file`, however, does not respect that relative path. Instead, it requires either a path relative to the root git directory or a `./`, neither of which `git ls-tree` provides.

This is simply fixed by adding back a leading `./` if the original path contained one.

Also fixed an error that `loadSync` not worked at all with globs.

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

n/a

## How Has This Been Tested?

- Tests pass
- I applied the patch on an own project and it works now

**Test Environment**:

n/a

## Checklist:

- [ ] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a