### PR TITLE
buildHTTPExecutor should return response as it was after exhausting all retry attempts

### DIFF
--- a/packages/executors/http/tests/buildHTTPExecutor.test.ts
+++ b/packages/executors/http/tests/buildHTTPExecutor.test.ts
@@ -42,4 +42,23 @@ describe('buildHTTPExecutor', () => {
       ],
     });
   });
+  it('handle responses other than 2XX', async () => {
+    const executor = buildHTTPExecutor({
+      fetch: (_url, init) => new Response(JSON.stringify({ data: init }), { status: 500 }),
+    });
+    const result = await executor({
+      document: parse(/* GraphQL */ `
+        query {
+          hello
+        }
+      `),
+    });
+    expect(result).toMatchObject({
+      errors: [
+        {
+          message: 'Internal Server Error',
+        },
+      ],
+    });
+  });
 });

--- a/packages/executors/http/tests/buildHTTPExecutor.test.ts
+++ b/packages/executors/http/tests/buildHTTPExecutor.test.ts
@@ -42,23 +42,4 @@ describe('buildHTTPExecutor', () => {
       ],
     });
   });
-  it('handle responses other than 2XX', async () => {
-    const executor = buildHTTPExecutor({
-      fetch: (_url, init) => new Response(JSON.stringify({ data: init }), { status: 500 }),
-    });
-    const result = await executor({
-      document: parse(/* GraphQL */ `
-        query {
-          hello
-        }
-      `),
-    });
-    expect(result).toMatchObject({
-      errors: [
-        {
-          message: 'Internal Server Error',
-        },
-      ],
-    });
-  });
 });

--- a/packages/executors/http/tests/retry-timeout.test.ts
+++ b/packages/executors/http/tests/retry-timeout.test.ts
@@ -91,6 +91,34 @@ describe('Retry & Timeout', () => {
       });
       expect(cnt).toEqual(3);
     });
+    it('retry and fail with HTTP error', async () => {
+      let cnt = 0;
+      const executor = buildHTTPExecutor({
+        async fetch() {
+          cnt++;
+          return new Response(
+            JSON.stringify({
+              data: null,
+              errors: [{ message: 'Unexpected HTTP error' }],
+            }),
+            { status: 500 }
+          );
+        },
+        retry: 3,
+      });
+      const result = await executor({
+        document: parse(/* GraphQL */ `
+          query {
+            hello
+          }
+        `),
+      });
+      expect(result).toMatchObject({
+        data: null,
+        errors: [{ message: 'Unexpected HTTP error' }],
+      });
+      expect(cnt).toEqual(3);
+    });
   });
   it('timeout', async () => {
     server = new Server((req, res) => {


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request._

## Description

BuildHTTPExecutor should always return GraphQLError when subschema returns 5XX error.
Null retry option skip the 500 error check and the executor return plain JSON of the 5XX error.

Related # (issue)

https://github.com/ardatan/graphql-tools/issues/5371

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

## How Has This Been Tested?

Please refer to the related issue.

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Environment**:

- OS:
- `@graphql-tools/...`:
- NodeJS:

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
