### PR TITLE
merge extensions in incremental result merging

### DIFF
--- a/.changeset/seven-boats-push.md
+++ b/.changeset/seven-boats-push.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/utils': patch
+---
+
+incremental merge also merges extensions

--- a/packages/utils/src/mergeIncrementalResult.ts
+++ b/packages/utils/src/mergeIncrementalResult.ts
@@ -9,29 +9,29 @@ export function mergeIncrementalResult({
   incrementalResult: ExecutionResult;
   executionResult: ExecutionResult;
 }) {
-  if (incrementalResult.path) {
-    const path = ['data', ...incrementalResult.path];
-    executionResult.data = executionResult.data || {};
-    if (incrementalResult.items) {
-      for (const item of incrementalResult.items) {
-        dset(executionResult, path, item);
-      }
+  const path = ['data', ...(incrementalResult.path ?? [])];
+
+  if (incrementalResult.items) {
+    for (const item of incrementalResult.items) {
+      dset(executionResult, path, item);
+      // Increment the last path segment (the array index) to merge the next item at the next index
+      (path[path.length - 1] as number)++;
     }
-    if (incrementalResult.data) {
-      dset(executionResult, ['data', ...incrementalResult.path], incrementalResult.data);
-    }
-  } else if (incrementalResult.data) {
-    executionResult.data = executionResult.data || {};
-    Object.assign(executionResult.data, incrementalResult.data);
   }
+
+  if (incrementalResult.data) {
+    dset(executionResult, path, incrementalResult.data);
+  }
+
   if (incrementalResult.errors) {
     executionResult.errors = executionResult.errors || [];
-    (executionResult.errors as GraphQLError[]).push(...executionResult.errors);
+    (executionResult.errors as GraphQLError[]).push(...incrementalResult.errors);
   }
+
   if (incrementalResult.extensions) {
-    executionResult.extensions = executionResult.extensions || {};
-    Object.assign(executionResult.extensions, incrementalResult.extensions);
+    dset(executionResult, 'extensions', incrementalResult.extensions);
   }
+
   if (incrementalResult.incremental) {
     incrementalResult.incremental.forEach(incrementalSubResult => {
       mergeIncrementalResult({

--- a/packages/utils/src/mergeIncrementalResult.ts
+++ b/packages/utils/src/mergeIncrementalResult.ts
@@ -28,6 +28,10 @@ export function mergeIncrementalResult({
     executionResult.errors = executionResult.errors || [];
     (executionResult.errors as GraphQLError[]).push(...executionResult.errors);
   }
+  if (incrementalResult.extensions) {
+    executionResult.extensions = executionResult.extensions || {};
+    Object.assign(executionResult.extensions, incrementalResult.extensions);
+  }
   if (incrementalResult.incremental) {
     incrementalResult.incremental.forEach(incrementalSubResult => {
       mergeIncrementalResult({

--- a/packages/utils/tests/mergeIncrementalResult.spec.ts
+++ b/packages/utils/tests/mergeIncrementalResult.spec.ts
@@ -1,0 +1,182 @@
+import { GraphQLError } from 'graphql';
+import { mergeIncrementalResult } from '../src/mergeIncrementalResult';
+
+describe('mergeIncrementalResult', () => {
+  it('should merge data without path', () => {
+    const executionResult = { data: { user: { name: 'John' } } };
+    const incrementalResult = { data: { user: { age: 42 } } };
+
+    mergeIncrementalResult({ incrementalResult, executionResult });
+
+    expect(executionResult).toEqual({ data: { user: { age: 42, name: 'John' } } });
+  });
+
+  it('should deep merge data with basic path', () => {
+    const executionResult = { data: { user: { name: 'John' } } };
+    const incrementalResult = { path: [], data: { user: { age: 42 } } };
+
+    mergeIncrementalResult({ incrementalResult, executionResult });
+
+    expect(executionResult).toEqual({ data: { user: { age: 42, name: 'John' } } });
+  });
+
+  it('should merge data at path', () => {
+    const executionResult = { data: { user: { name: 'John' } } };
+    const incrementalResult = { path: ['user'], data: { age: 42 } };
+
+    mergeIncrementalResult({ incrementalResult, executionResult });
+
+    expect(executionResult).toEqual({ data: { user: { age: 42, name: 'John' } } });
+  });
+
+  it('should push items', () => {
+    const executionResult = { data: { user: { name: 'John' } } };
+    const incrementalResult = {
+      path: ['user', 'comments', 0],
+      items: ['comment 1', 'comment 2'],
+    };
+
+    mergeIncrementalResult({ incrementalResult, executionResult });
+
+    expect(executionResult).toEqual({
+      data: {
+        user: {
+          name: 'John',
+          comments: ['comment 1', 'comment 2'],
+        },
+      },
+    });
+  });
+
+  it('should push items at path', () => {
+    const executionResult = { data: { user: { name: 'John', comments: ['comment 1', 'comment 2'] } } };
+    const incrementalResult = {
+      path: ['user', 'comments', 2],
+      items: ['comment 3', 'comment 4'],
+    };
+
+    mergeIncrementalResult({ incrementalResult, executionResult });
+
+    expect(executionResult).toEqual({
+      data: {
+        user: {
+          name: 'John',
+          comments: ['comment 1', 'comment 2', 'comment 3', 'comment 4'],
+        },
+      },
+    });
+  });
+
+  it('should merge items at path', () => {
+    const executionResult = {
+      data: {
+        user: {
+          name: 'John',
+          comments: [{ id: 1 }, { id: 2 }],
+        },
+      },
+    };
+
+    const incrementalResult = {
+      path: ['user', 'comments', 0],
+      items: [{ text: 'comment 1' }, { text: 'comment 2' }],
+    };
+
+    mergeIncrementalResult({ incrementalResult, executionResult });
+
+    expect(executionResult).toEqual({
+      data: {
+        user: {
+          name: 'John',
+          comments: [
+            { id: 1, text: 'comment 1' },
+            { id: 2, text: 'comment 2' },
+          ],
+        },
+      },
+    });
+  });
+
+  it('should add errors', () => {
+    const executionResult = { data: { user: { name: 'John' } } };
+    const incrementalResult = { errors: [new GraphQLError('error 1'), new GraphQLError('error 2')] };
+
+    mergeIncrementalResult({ incrementalResult, executionResult });
+
+    expect(executionResult).toEqual({
+      data: { user: { name: 'John' } },
+      errors: [new GraphQLError('error 1'), new GraphQLError('error 2')],
+    });
+  });
+
+  it('should keep errors', () => {
+    const executionResult = { errors: [new GraphQLError('error 1')] };
+    const incrementalResult = { data: { user: { name: 'John' } }, path: [] };
+
+    mergeIncrementalResult({ incrementalResult, executionResult });
+
+    expect(executionResult).toEqual({
+      data: { user: { name: 'John' } },
+      errors: [new GraphQLError('error 1')],
+    });
+  });
+
+  it('should merge errors', () => {
+    const executionResult = { errors: [new GraphQLError('error 1')] };
+
+    const incrementalResult = { errors: [new GraphQLError('error 2'), new GraphQLError('error 3')] };
+
+    mergeIncrementalResult({ incrementalResult, executionResult });
+
+    expect(executionResult).toEqual({
+      errors: [new GraphQLError('error 1'), new GraphQLError('error 2'), new GraphQLError('error 3')],
+    });
+  });
+
+  it('should keep extensions', () => {
+    const exeuctionResult = { data: { user: { name: 'John' } }, extensions: { foo: 'bar' } };
+    const incrementalResult = { data: { user: { age: 42 } }, path: [] };
+
+    mergeIncrementalResult({ incrementalResult, executionResult: exeuctionResult });
+
+    expect(exeuctionResult).toEqual({
+      data: { user: { age: 42, name: 'John' } },
+      extensions: { foo: 'bar' },
+    });
+  });
+
+  it('should add extensions', () => {
+    const exeuctionResult = { data: { user: { name: 'John' } } };
+    const incrementalResult = { data: { user: { age: 42 } }, path: [], extensions: { ext1: 'ext1' } };
+
+    mergeIncrementalResult({ incrementalResult, executionResult: exeuctionResult });
+
+    expect(exeuctionResult).toEqual({
+      data: { user: { age: 42, name: 'John' } },
+      extensions: { ext1: 'ext1' },
+    });
+  });
+
+  it('should merge extensions', () => {
+    const exeuctionResult = { data: { user: { name: 'John' } }, extensions: { ext1: { a: 'a' } } };
+    const incrementalResult = { data: { user: { age: 42 } }, path: [], extensions: { ext1: { b: 'b' }, ext2: 'ext2' } };
+
+    mergeIncrementalResult({ incrementalResult, executionResult: exeuctionResult });
+
+    expect(exeuctionResult).toEqual({
+      data: { user: { age: 42, name: 'John' } },
+      extensions: { ext1: { a: 'a', b: 'b' }, ext2: 'ext2' },
+    });
+  });
+
+  it('should let incremental result override previous extensions', () => {
+    const executionResult = { extensions: { ext1: { a: 'a' } } };
+    const incrementalResult = { extensions: { ext1: { a: 'b' } } };
+
+    mergeIncrementalResult({ incrementalResult, executionResult });
+
+    expect(executionResult).toEqual({
+      extensions: { ext1: { a: 'b' } },
+    });
+  });
+});


### PR DESCRIPTION
## Description

The function implementing merging of incremental results was not merging extensions, discarding it.

## Related

needed by https://github.com/n1ru4l/envelop/pull/1896

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
