### PR TITLE
Export DirectableGraphQLObject type

### DIFF
--- a/.changeset/stupid-pans-breathe.md
+++ b/.changeset/stupid-pans-breathe.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/utils': patch
+---
+
+Exports the `DirectableGraphQLObject` type.

--- a/packages/utils/src/get-directives.ts
+++ b/packages/utils/src/get-directives.ts
@@ -39,7 +39,7 @@ type SchemaOrTypeNode =
   | FieldDefinitionNode
   | InputValueDefinitionNode;
 
-type DirectableGraphQLObject =
+export type DirectableGraphQLObject =
   | GraphQLSchema
   | GraphQLSchemaConfig
   | GraphQLNamedType


### PR DESCRIPTION
## Description

Exports the `DirectableGraphQLObject` type since it may be useful to library consumers. 

Related #5443

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

It has not given the size of the change.