### PR TITLE
Add @babel/core dependency to graphql-tag-pluck

### DIFF
--- a/.changeset/fast-seahorses-visit.md
+++ b/.changeset/fast-seahorses-visit.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/graphql-tag-pluck': patch
+---
+
+Add @babel/core dependency

--- a/packages/graphql-tag-pluck/package.json
+++ b/packages/graphql-tag-pluck/package.json
@@ -50,6 +50,7 @@
     "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "dependencies": {
+    "@babel/core": "^7.22.9",
     "@babel/parser": "^7.16.8",
     "@babel/plugin-syntax-import-assertions": "^7.20.0",
     "@babel/traverse": "^7.16.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -391,7 +391,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.22.9.tgz#71cdb00a1ce3a329ce4cbec3a44f9fef35669730"
   integrity sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==
 
-"@babel/core@7.22.9", "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.14.0", "@babel/core@^7.21.8":
+"@babel/core@7.22.9", "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.14.0", "@babel/core@^7.21.8", "@babel/core@^7.22.9":
   version "7.22.9"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.22.9.tgz#bd96492c68822198f33e8a256061da3cf391f58f"
   integrity sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==


### PR DESCRIPTION
## Description

Fixes yarn error:
```YN0002: │ @graphql-tools/graphql-tag-pluck@npm:8.0.1 [21b77] doesn't provide @babel/core (p8630f), requested by @babel/plugin-syntax-import-assertions```

Related https://github.com/ardatan/graphql-tools/issues/5066

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
