### PR TITLE
fix(batch-execute): handle unprefixed paths in errors

### DIFF
--- a/packages/batch-execute/src/splitResult.ts
+++ b/packages/batch-execute/src/splitResult.ts
@@ -32,9 +32,18 @@ export function splitResult(
   }
 
   if (errors) {
+    let unprefixedKeyIndex = 0;
+
     for (const error of errors) {
       if (error.path) {
-        const parsedKey = parseKey(error.path[0] as string);
+        let parsedKey: ReturnType<typeof parseKey>;
+        try {
+          parsedKey = parseKey(error.path[0] as string);
+        } catch {
+          parsedKey = { originalKey: error.path[0] as string, index: unprefixedKeyIndex };
+        }
+
+        unprefixedKeyIndex++;
         const { index, originalKey } = parsedKey;
         const newError = relocatedError(error, [originalKey, ...error.path.slice(1)]);
         const resultErrors = (splitResults[index].errors = (splitResults[index].errors ||

--- a/packages/batch-execute/tests/batchExecute.test.ts
+++ b/packages/batch-execute/tests/batchExecute.test.ts
@@ -22,6 +22,7 @@ describe('batch execution', () => {
         field2: String
         field3(input: String): String
         boom(message: String): String
+        boomWithPath(message: String): String
         extension: String
         widget: Widget
       }
@@ -35,6 +36,8 @@ describe('batch execution', () => {
         field2: () => '2',
         field3: (_root, { input }) => String(input),
         boom: (_root, { message }) => new Error(message),
+        boomWithPath: (_root, { message }) =>
+          createGraphQLError(message, { path: ['BoomWithPathQueryName'] }),
         extension: () => createGraphQLError('boom', { extensions }),
         widget: () => ({ name: 'wingnut' }),
       },
@@ -220,5 +223,17 @@ describe('batch execution', () => {
     expect(first?.errors?.length).toEqual(1);
     expect(first?.errors?.[0].message).toMatch(/boom/);
     expect(first?.errors?.[0].extensions).toEqual(extensions);
+  });
+
+  it('handles unprefixed query name in graphql error path', async () => {
+    const [first] = (await Promise.all([
+      batchExec({
+        document: parse('{ boomWithPath(message: "unexpected error") }'),
+      }),
+    ])) as ExecutionResult[];
+
+    expect(first?.errors?.[0].message).toEqual('unexpected error');
+    expect(first?.errors?.[0].path).toEqual(['BoomWithPathQueryName']);
+    expect(executorCalls).toEqual(1);
   });
 });


### PR DESCRIPTION
I've encountered an unexpected case where a graphql server, which is out of my control, returned an error response which has the original query name as the first element of the path list within the graphql error, which then resulted in what seemed like a slightly misleading error being thrown.

To the best of my ability, I've created this PR to demonstrate the issue. However, I may not have the knowledge or context to determine if this change fits well. Feel free to take over, reject or close if this type of change is undesired.

Thanks.