### PR TITLE
Fix git-loader for windows paths

### DIFF
--- a/packages/loaders/git/src/index.ts
+++ b/packages/loaders/git/src/index.ts
@@ -17,6 +17,9 @@ function extractData(pointer: string): null | {
   ref: string;
   path: string;
 } {
+  if (!parts.startsWith('git')) {
+    return null;
+  }
   const parts = pointer.replace(/^git\:/i, '').split(':');
 
   if (!parts || parts.length !== 2) {

--- a/packages/loaders/git/src/index.ts
+++ b/packages/loaders/git/src/index.ts
@@ -17,7 +17,7 @@ function extractData(pointer: string): null | {
   ref: string;
   path: string;
 } {
-  if (!parts.startsWith('git')) {
+  if (!pointer.startsWith('git')) {
     return null;
   }
   const parts = pointer.replace(/^git\:/i, '').split(':');


### PR DESCRIPTION
_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

The loader attempts to load windows-like file paths. If the incoming pointer is a glob (or any windows path with a colon)  such as:
`C:\projects\my-project\src\schema\**\*.graphql`

The `extractData` function will return 
```
{
  ref: 'C',
  path: '\\projects\\my-project\\src\\schema\\**\\*.graphql'
}
```
And it will throw:
```
            Unable to load the file tree from git: Error: Command failed: git ls-tree -r --name-only C
    fatal: Not a valid object name C
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
