### PR TITLE
Loop through entire error path to find key match

### DIFF
--- a/.changeset/bright-moons-suffer.md
+++ b/.changeset/bright-moons-suffer.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/batch-execute': patch
+---
+
+GraphQL Errors with prefixed path elements will now correctly be split

--- a/packages/batch-execute/src/prefix.ts
+++ b/packages/batch-execute/src/prefix.ts
@@ -4,11 +4,46 @@ export function createPrefix(index: string): string {
   return `_${index}_`;
 }
 
-export function parseKey(prefixedKey: string): { index: number; originalKey: string } {
-  const match = /^_([\d]+)_(.*)$/.exec(prefixedKey);
+export type KeyMatch = { index: number; originalKey: string };
+
+function matchKey(prefixedKey: string): KeyMatch | null {
+  const match = /^_(\d+)_(.*)$/.exec(prefixedKey);
   if (match && match.length === 3 && !isNaN(Number(match[1])) && match[2]) {
     return { index: Number(match[1]), originalKey: match[2] };
   }
+  return null;
+}
 
-  throw new Error(`Key ${prefixedKey} is not correctly prefixed`);
+export function parseKey(prefixedKey: string): KeyMatch {
+  const match = matchKey(prefixedKey);
+
+  if (!match) {
+    throw new Error(`Key ${prefixedKey} is not correctly prefixed`);
+  }
+
+  return match;
+}
+
+export function parseKeyFromPath(
+  path: readonly (string | number)[],
+): KeyMatch & { keyOffset: number } {
+  let keyOffset = 0;
+  let match: KeyMatch | null = null;
+
+  // Keep looping over path until we've found a match or path has no more items left
+  for (; !match && keyOffset < path.length; keyOffset++) {
+    const pathKey = path[keyOffset];
+    if (typeof pathKey === 'string') {
+      match = matchKey(pathKey);
+    }
+  }
+
+  if (!match) {
+    throw new Error(`Path ${path.join('.')} does not contain correctly prefixed key`);
+  }
+
+  return {
+    ...match,
+    keyOffset,
+  };
 }

--- a/packages/batch-execute/src/splitResult.ts
+++ b/packages/batch-execute/src/splitResult.ts
@@ -2,7 +2,7 @@
 
 import { GraphQLError } from 'graphql';
 import { ExecutionResult, relocatedError } from '@graphql-tools/utils';
-import { parseKey } from './prefix.js';
+import { parseKey, parseKeyFromPath } from './prefix.js';
 
 /**
  * Split and transform result of the query produced by the `merge` function
@@ -34,9 +34,8 @@ export function splitResult(
   if (errors) {
     for (const error of errors) {
       if (error.path) {
-        const parsedKey = parseKey(error.path[0] as string);
-        const { index, originalKey } = parsedKey;
-        const newError = relocatedError(error, [originalKey, ...error.path.slice(1)]);
+        const { index, originalKey, keyOffset } = parseKeyFromPath(error.path);
+        const newError = relocatedError(error, [originalKey, ...error.path.slice(keyOffset)]);
         const resultErrors = (splitResults[index].errors = (splitResults[index].errors ||
           []) as GraphQLError[]);
         resultErrors.push(newError);

--- a/packages/batch-execute/tests/batchExecute.test.ts
+++ b/packages/batch-execute/tests/batchExecute.test.ts
@@ -22,6 +22,7 @@ describe('batch execution', () => {
         field2: String
         field3(input: String): String
         boom(message: String): String
+        boomWithPath(message: String, path: [String]): String
         extension: String
         widget: Widget
       }
@@ -35,6 +36,7 @@ describe('batch execution', () => {
         field2: () => '2',
         field3: (_root, { input }) => String(input),
         boom: (_root, { message }) => new Error(message),
+        boomWithPath: (_root, { message, path }) => createGraphQLError(message, { path }),
         extension: () => createGraphQLError('boom', { extensions }),
         widget: () => ({ name: 'wingnut' }),
       },
@@ -220,5 +222,26 @@ describe('batch execution', () => {
     expect(first?.errors?.length).toEqual(1);
     expect(first?.errors?.[0].message).toMatch(/boom/);
     expect(first?.errors?.[0].extensions).toEqual(extensions);
+  });
+
+  it('handles unprefixed query name in graphql error path', async () => {
+    const [first, second] = (await Promise.all([
+      batchExec({
+        document: parse(
+          '{ boomWithPath(message: "unexpected error", path: ["some-prefix", "_0_boomWithPath", "foo"]) }',
+        ),
+      }),
+      batchExec({
+        document: parse(
+          '{ boomWithPath(message: "another unexpected error", path: ["some", "other", "prefix", "_1_boomWithPath", "bar"]) }',
+        ),
+      }),
+    ])) as ExecutionResult[];
+
+    expect(first?.errors?.[0].message).toEqual('unexpected error');
+    expect(first?.errors?.[0].path).toEqual(['boomWithPath', 'foo']);
+    expect(second?.errors?.[0].message).toEqual('another unexpected error');
+    expect(second?.errors?.[0].path).toEqual(['boomWithPath', 'bar']);
+    expect(executorCalls).toEqual(1);
   });
 });


### PR DESCRIPTION
## Description

Key parsing logic for the `GraphQLError` `path` array is modified to search for the first item that satisfies the the batch key format. This allows external GraphQL API's to prefix error paths while still rewriting the error correctly for the consumer of `@graphql-tools/batch-execute`.

Related #5520 #5481 

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I've provided a unit test to confirm the validity of the implemenation.

**Test Environment**:

- OS: MacOS
- `@graphql-tools/...`: `batch-execute`
- NodeJS: v18.14.2

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

