### PR TITLE
fix(graphql-ws-executor): changed initialization of graphql-ws client

### DIFF
--- a/.changeset/tender-lions-arrive.md
+++ b/.changeset/tender-lions-arrive.md
@@ -1,0 +1,6 @@
+---
+'@graphql-tools/executor-graphql-ws': patch
+---
+
+changed the order how the configuration is given into the graphql-wsclient and prevent the
+overwriting of the parameters

--- a/packages/executors/graphql-ws/src/index.ts
+++ b/packages/executors/graphql-ws/src/index.ts
@@ -25,6 +25,7 @@ export function buildGraphQLWSExecutor(
     graphqlWSClient = clientOptionsOrClient;
   } else {
     graphqlWSClient = createClient({
+      ...clientOptionsOrClient,
       webSocketImpl: WebSocket,
       lazy: true,
       connectionParams: () => {
@@ -34,7 +35,6 @@ export function buildGraphQLWSExecutor(
             : clientOptionsOrClient.connectionParams) || {};
         return Object.assign(optionsConnectionParams, executorConnectionParams);
       },
-      ...clientOptionsOrClient,
     });
     if (clientOptionsOrClient.onClient) {
       clientOptionsOrClient.onClient(graphqlWSClient);


### PR DESCRIPTION
## Description

- simply changed the order how the configuration is given into the `graphql-ws`client and prevent the overwriting of the parameters
 
This should fix https://github.com/Urigo/graphql-mesh/issues/5774  and https://github.com/ardatan/graphql-tools/issues/5665
Related # (5774)

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

In the .meshrc of `graphql-mesh` with the `graphql`-handler I set

```
...
subscriptionsProtocol: WS
connectionParams:
     user: "{context.headers['x-user']}"
...
```

where `"{context.headers['x-user']}"` now gets resolved.
**Test Environment**:

- OS: macOS: 13.6
- `@graphql-tools/executor-graphql-ws`: 1.1.0
- NodeJS: 18.8.0

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

