### PR TITLE
Pass fieldArgs to value function

### DIFF
--- a/.changeset/twenty-cats-drop.md
+++ b/.changeset/twenty-cats-drop.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/mock': patch
+---
+
+Pass fieldArgs to value function

--- a/packages/mock/src/addMocksToSchema.ts
+++ b/packages/mock/src/addMocksToSchema.ts
@@ -148,7 +148,7 @@ export function addMocksToSchema<TResolvers = IResolvers>({
 
     if (defaultResolvedValue === undefined) {
       // any is used here because generateFieldValue is a private method at time of writing
-      return (store as any).generateFieldValue(info.parentType.name, info.fieldName);
+      return (store as any).generateFieldValue(info.parentType.name, info.fieldName, args);
     }
 
     return undefined;

--- a/packages/mock/tests/store.spec.ts
+++ b/packages/mock/tests/store.spec.ts
@@ -131,7 +131,7 @@ describe('MockStore', () => {
     expect(user1.$ref).toEqual(user1Bis.$ref);
   });
 
-  it('sould return a different value if called with different field args', () => {
+  it('should return a different value if called with different field args', () => {
     const store = createMockStore({ schema });
     const user1 = store.get({
       typeName: 'Query',
@@ -608,5 +608,22 @@ describe('MockStore', () => {
     store.set(makeRef('User', 'me'), 'name', 'Alexandre');
     store.reset();
     expect(store.get('User', 'me', 'name')).not.toEqual('Alexandre');
+  });
+
+  it('should pass field args to value getter function', () => {
+    const store = createMockStore({
+      schema,
+      mocks: {
+        User: () => {
+          return {
+            name: ({ format }: { format: string }) =>
+              format === 'fullName' ? 'Alexandre the Great' : 'Alex',
+          };
+        },
+      },
+    });
+
+    expect(store.get('User', '123', 'name', { format: 'fullName' })).toEqual('Alexandre the Great');
+    expect(store.get('User', '123', 'name', { format: 'shortName' })).toEqual('Alex');
   });
 });


### PR DESCRIPTION
## Description

Fix https://github.com/ardatan/graphql-tools/discussions/4497. This allows for finer-grained mocking with mocked data depending on field arguments.

```typescript
const store = createMockStore({
    schema,
    mocks: {
      User: () => {
        return {
          name: ({ format }: { format: string }) =>
            format === 'fullName' ? 'Alexandre the Great' : 'Alex',
        };
      },
    },
  });

store.get('User', '123', 'name', { format: 'fullName' }))
// Alexandre the Great
store.get('User', '123', 'name', { format: 'shortName ' }))
// Alex
```

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] store.spec.ts: should pass field args to value getter function

## Checklist:

- [x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes

