### PR TITLE
fix: remove headers from extensions

### DIFF
--- a/packages/executors/http/src/index.ts
+++ b/packages/executors/http/src/index.ts
@@ -126,15 +126,19 @@ export function buildHTTPExecutor(
     }
 
     const endpoint = request.extensions?.endpoint || options?.endpoint || '/graphql';
-    const headers = Object.assign(
-      {
-        accept,
-      },
-      (typeof options?.headers === 'function' ? options.headers(request) : options?.headers) || {},
-      request.extensions?.headers || {},
-    );
+    const headers = { accept };
 
-    delete request.extensions?.headers;
+    if (options?.headers) {
+      Object.assign(
+        headers,
+        typeof options?.headers === 'function' ? options.headers(request) : options?.headers,
+      );
+    }
+
+    if (request.extensions?.headers) {
+      Object.assign(headers, request.extensions.headers);
+      delete request.extensions.headers;
+    }
 
     const query = print(request.document);
 

--- a/packages/executors/http/src/index.ts
+++ b/packages/executors/http/src/index.ts
@@ -134,6 +134,8 @@ export function buildHTTPExecutor(
       request.extensions?.headers || {},
     );
 
+    delete request.extensions?.headers;
+
     const query = print(request.document);
 
     let timeoutId: any;

--- a/packages/executors/http/tests/buildHTTPExecutor.test.ts
+++ b/packages/executors/http/tests/buildHTTPExecutor.test.ts
@@ -114,4 +114,34 @@ describe('buildHTTPExecutor', () => {
     });
     expect(method).toBe('POST');
   });
+
+  it('should not encode headers from extensions', async () => {
+    const executor = buildHTTPExecutor({
+      useGETForQueries: true,
+      fetch(url) {
+        expect(url).not.toMatch(/(Authorization|headers)/i);
+        return new Response(JSON.stringify({ data: { hello: 'world!' } }), {
+          headers: { 'Content-Type': 'application/json' },
+        });
+      },
+    });
+    const result = (await executor({
+      document: parse(/* GraphQL */ `
+        query {
+          hello
+        }
+      `),
+      extensions: {
+        headers: {
+          Authorization: 'Token',
+        },
+      },
+    })) as ExecutionResult;
+
+    expect(result.data).toMatchInlineSnapshot(`
+      {
+        "hello": "world!",
+      }
+    `);
+  });
 });


### PR DESCRIPTION
## Description

This fix removes the headers from the extensions avoiding them being leaked in query parameters.

This happens if using the GraphiQL bundled in Yoga, this should fix the issue for Yoga if updated.

Related # ([5753](https://github.com/ardatan/graphql-tools/issues/5753))

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

I have written a unit test and confirmed the original ones work.

**Test Environment**:

- OS:
- `@graphql-tools/...`:
- NodeJS: all

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


