### PR TITLE
fix(utils): prevent race conditions when validating documents

### DIFF
--- a/.changeset/twenty-walls-sleep.md
+++ b/.changeset/twenty-walls-sleep.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/utils': patch
+---
+
+prevent race conditions when validating documents

--- a/packages/utils/src/validate-documents.ts
+++ b/packages/utils/src/validate-documents.ts
@@ -17,19 +17,20 @@ export function validateGraphQlDocuments(
   documents: DocumentNode[],
   rules: ValidationRule[] = createDefaultRules(),
 ) {
-  const definitionMap = new Map<string, DefinitionNode>();
+  const definitions = new Set<DefinitionNode>();
+  const fragmentsDefinitionsMap = new Map<string, DefinitionNode>();
   for (const document of documents) {
     for (const docDefinition of document.definitions) {
-      if ('name' in docDefinition && docDefinition.name) {
-        definitionMap.set(`${docDefinition.kind}_${docDefinition.name.value}`, docDefinition);
+      if (docDefinition.kind === Kind.FRAGMENT_DEFINITION) {
+        fragmentsDefinitionsMap.set(docDefinition.name.value, docDefinition);
       } else {
-        definitionMap.set(Date.now().toString(), docDefinition);
+        definitions.add(docDefinition);
       }
     }
   }
   const fullAST: DocumentNode = {
     kind: Kind.DOCUMENT,
-    definitions: Array.from(definitionMap.values()),
+    definitions: Array.from([...definitions, ...fragmentsDefinitionsMap.values()]),
   };
   const errors = validate(schema, fullAST, rules);
   for (const error of errors) {

--- a/packages/utils/tests/validate-documents.spec.ts
+++ b/packages/utils/tests/validate-documents.spec.ts
@@ -59,6 +59,62 @@ describe('validateGraphQlDocuments', () => {
     at packages/client/src/pages/search/searchPage.query.graphql:6:15`);
   });
 
+  it('Should throw a validation error when multiple anonymous queries are present', async () => {
+    const schema = buildSchema(/* GraphQL */ `
+      type OtherStuff {
+        foo: String
+      }
+
+      type Pizzeria {
+        id: Int
+        name: String
+        location: String
+      }
+
+      type Query {
+        otherStuff: OtherStuff
+        pizzeria: Pizzeria
+      }
+    `);
+
+    const result = validateGraphQlDocuments(schema, [
+      parse(
+        new Source(
+          /* GraphQL */ `
+            query {
+              pizzeria {
+                id
+                name
+              }
+            }
+          `,
+          'packages/client/src/pages/products/productPage.query.graphql',
+        ),
+      ),
+      parse(
+        new Source(
+          /* GraphQL */ `
+            query {
+              otherStuff {
+                foo
+              }
+            }
+          `,
+          'packages/client/src/pages/search/searchPage.query.graphql',
+        ),
+      ),
+    ]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].source?.name).toBe(
+      'packages/client/src/pages/products/productPage.query.graphql',
+    );
+    expect(result[0] instanceof GraphQLError).toBeTruthy();
+    expect(result[0].message).toBe('This anonymous operation must be the only defined operation.');
+    expect(result[0].stack).toBe(`This anonymous operation must be the only defined operation.
+    at packages/client/src/pages/products/productPage.query.graphql:2:13`);
+  });
+
   it('Should not swallow fragments on operation/fragment name conflict', async () => {
     const schema = buildSchema(/* GraphQL */ `
       type Query {


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

## Description

Make `validateGqlDocuments()` validation results more deterministic for cases when documents may include multiple anonymous definition nodes, where previously [validateGraphQLDocuments()](https://github.com/ardatan/graphql-tools/blob/000e93b47e437baa0a3d076ec09ff89a18a4b364/packages/utils/src/validate-documents.ts#L26) util would merge definitions in a way that created a risk for a race condition to take place depending on how fast the anonymous nodes get processed (definitions are keyed off `Date.now().toString()`), and blocked off certain validation rules.

This change essentially merges all definitions into one document as-is, with the exception of `FRAGMENT_DEFINITION` nodes, which get deduplicated based off their name. In turn this enables certain GraphQL rules, such as `lone-anonymous-operation` ([spec](https://spec.graphql.org/draft/#sec-Lone-Anonymous-Operation)), `unique-operation-names` ([spec](https://spec.graphql.org/draft/#sec-Operation-Name-Uniqueness)).

> Note that there's no validation whether fragment nodes are the same, so there may be room for improvement to unblock `unique-fragment-names` ([spec](https://spec.graphql.org/draft/#sec-Fragment-Name-Uniqueness)).

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
  - Potentially breaking change, since it will now throw an error if multiple definitions share the same name

## Screenshots/Sandbox (if appropriate/relevant):

N/A

## How Has This Been Tested?

Verified that a validation error is returned when multiple documents include an anonymous query.

**Test Environment**:

N/A

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A