### PR TITLE
fix: buildSubgraphSchema when there are no entity keys

### DIFF
--- a/.changeset/perfect-files-bake.md
+++ b/.changeset/perfect-files-bake.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/federation': patch
+---
+
+fix: buildSubgraphSchema with no entity keys

--- a/packages/federation/src/subgraph.ts
+++ b/packages/federation/src/subgraph.ts
@@ -89,7 +89,8 @@ export function buildSubgraphSchema<TContext = any>(
       };
     },
   });
-  const entityTypeDefinition = `union _Entity = ${entityTypeNames.join(' | ')}`;
+
+  const entityTypeDefinition = `union _Entity ${entityTypeNames.length > 0 ? '=' : ''} ${entityTypeNames.join(' | ')}`;
   const givenResolvers: any = mergeResolvers(opts.resolvers);
   const subgraphResolvers = {
     _Entity: {

--- a/packages/federation/test/__snapshots__/subgraph.test.ts.snap
+++ b/packages/federation/test/__snapshots__/subgraph.test.ts.snap
@@ -1,5 +1,61 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`allows a subgraph without any keys 1`] = `
+"schema {
+  query: Query
+}
+
+directive @external on FIELD_DEFINITION | OBJECT
+
+directive @requires(fields: _FieldSet!) on FIELD_DEFINITION
+
+directive @provides(fields: _FieldSet!) on FIELD_DEFINITION
+
+directive @key(fields: _FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+directive @link(url: String!, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @shareable repeatable on OBJECT | FIELD_DEFINITION
+
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @override(from: String!) on FIELD_DEFINITION
+
+directive @composeDirective(name: String!) repeatable on SCHEMA
+
+directive @extends on OBJECT | INTERFACE
+
+union _Entity
+
+scalar _Any
+
+scalar _FieldSet
+
+scalar link__Import
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+type _Service {
+  sdl: String!
+}
+
+type Query {
+  _entities(representations: [_Any!]!): [_Entity]!
+  _service: _Service!
+  users: [User!]!
+}
+
+type User @extends {
+  id: ID!
+  name: String!
+}"
+`;
+
 exports[`converts extensions in the subgraph SDL 1`] = `
 "schema {
   query: Query

--- a/packages/federation/test/subgraph.test.ts
+++ b/packages/federation/test/subgraph.test.ts
@@ -15,3 +15,18 @@ it('converts extensions in the subgraph SDL', () => {
   });
   expect(printSchemaWithDirectives(subgraphSchema).trim()).toMatchSnapshot();
 });
+
+it('allows a subgraph without any keys', () => {
+  const subgraphSchema = buildSubgraphSchema({
+    typeDefs: /* GraphQL */ `
+      extend type Query {
+        users: [User!]!
+      }
+      extend type User {
+        id: ID!
+        name: String!
+      }
+    `,
+  });
+  expect(printSchemaWithDirectives(subgraphSchema).trim()).toMatchSnapshot();
+});


### PR DESCRIPTION
### Summary 
The federation package fails to create a valid schema in the case where no key directives are specified. This PR fixes this adding an empty `_Entity` union in this case.