### PR TITLE
Fix hasNextPage logic in relayStylePaginationMock

### DIFF
--- a/packages/mock/src/pagination.ts
+++ b/packages/mock/src/pagination.ts
@@ -158,7 +158,7 @@ export const relayStylePaginationMock = <
     const pageInfo: RelayPageInfo = {
       startCursor: edges.length > 0 ? edges[0].cursor : '',
       endCursor: edges.length > 0 ? edges[edges.length - 1].cursor : '',
-      hasNextPage: end < allEdges.length - 1,
+      hasNextPage: end < allEdges.length,
       hasPreviousPage: start > 0,
     };
 

--- a/packages/mock/tests/pagination.spec.ts
+++ b/packages/mock/tests/pagination.spec.ts
@@ -100,6 +100,7 @@ describe('relayStylePaginationMock', () => {
         });
 
         const page2Items = page2.data?.['items'] as any;
+        expect(page2Items.pageInfo.hasNextPage).toBeTruthy();
         expect(page2Items.edges.map((e: any) => e.node.index)).toEqual([2, 3]);
 
         const page3 = await graphql({


### PR DESCRIPTION
## Description

Fixes an issue where `hasNextPage` is erroneously `false` in some cases.

Related #5890 

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

**Test Environment**:

- `@graphql-tools/mock`: 9.0.0
- NodeJS: 18.15.0

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
