### PR TITLE
Update doc to catch up with supported extensions for graphql-tag-pluck

### DIFF
--- a/website/src/pages/docs/graphql-tag-pluck.mdx
+++ b/website/src/pages/docs/graphql-tag-pluck.mdx
@@ -76,16 +76,19 @@ const MessageType = /* GraphQL */ `
 Supported file extensions are:
 
 - `.js`
+- `.mjs`
+- `.cjs`
 - `.jsx`
 - `.ts`
+- `.mts`
+- `.cts`
 - `.tsx`
 - `.flow`
 - `.flow.js`
 - `.flow.jsx`
-- `.graphqls`
-- `.graphql`
-- `.gqls`
-- `.gql`
+- `.vue`
+- `.svelte`
+- `.astro`
 
 ## Options
 


### PR DESCRIPTION
## Description
Supported extensions stated in the document may be outdated.
I have updated the docs to follow the current implementation. 
https://github.com/ardatan/graphql-tools/blob/2c6c1d688741ef024b407e45f4040a667f7969e0/packages/graphql-tag-pluck/src/index.ts#L131-L146

## Type of change

- [x] This is a documentation only update

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules