### PR TITLE
Prettier ignore changesets

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -29,5 +29,7 @@ website/src/pages/docs/api
 website/src/pages/docs/migration/migration-from-tools.mdx
 website/src/pages/docs/schema-stitching/stitch-schema-extensions.mdx
 
-.changeset/*-dependencies.md
+.changeset/*
+!.changeset/README.md
+!.changeset/config.json
 .husky


### PR DESCRIPTION
Adjust the prettierignore file to ignore changesets, but not the `README.md` and the `config.json`.