### PR TITLE
Add explicitResourceManagement to the list of parser plugins in graphql-tag-pluck

### DIFF
--- a/.changeset/short-paws-provide.md
+++ b/.changeset/short-paws-provide.md
@@ -1,0 +1,5 @@
+---
+"@graphql-tools/graphql-tag-pluck": minor
+---
+
+Adds support for tc39/proposal-explicit-resource-management ('using' keyword)

--- a/packages/graphql-tag-pluck/src/config.ts
+++ b/packages/graphql-tag-pluck/src/config.ts
@@ -16,6 +16,7 @@ export default function generateConfig(
     'decorators-legacy',
     'doExpressions',
     'dynamicImport',
+    'explicitResourceManagement',
     'exportDefaultFrom',
     'exportNamespaceFrom',
     'functionBind',

--- a/packages/graphql-tag-pluck/tests/graphql-tag-pluck.test.ts
+++ b/packages/graphql-tag-pluck/tests/graphql-tag-pluck.test.ts
@@ -268,6 +268,47 @@ describe('graphql-tag-pluck', () => {
       );
     });
 
+    it.only("should pluck graphql-tag template literals from .ts that use 'using' keyword", async () => {
+      const sources = await pluck(
+        'tmp-XXXXXX.ts',
+        freeText(`
+        import { graphql } from '../somewhere'
+        import { Document } from 'graphql'
+        import createManagedResource from 'managed-resource'
+
+        using managedResource = createManagedResource()
+
+        const fragment: Document = graphql(\`
+            fragment Foo on FooType {
+              id
+            }
+          \`)
+
+          const doc: Document = graphql(\`
+            query foo {
+              foo {
+                ...Foo
+              }
+            }
+            \`)
+      `),
+      );
+
+      expect(sources.map(source => source.body).join('\n\n')).toEqual(
+        freeText(`
+        fragment Foo on FooType {
+          id
+        }
+
+        query foo {
+          foo {
+            ...Foo
+          }
+        }
+      `),
+      );
+    });
+
     it('should pluck graphql-tag template literals from .ts file', async () => {
       const sources = await pluck(
         'tmp-XXXXXX.ts',


### PR DESCRIPTION
A related issue #5869 has been open for several weeks.

This would be a simpler short-term solution to allow for the new syntax.

## Description

Adds the `explicitResourceManagement` parser plugin for babel. This allows using the stage 3 `using` keyword for resource management.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

This has been tested by adding a test case to the `graphql-tg-pluck` package using the new syntax.

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
