### PR TITLE
fix(filterSchema): provide actual type name for root field

### DIFF
--- a/.changeset/warm-ducks-smash.md
+++ b/.changeset/warm-ducks-smash.md
@@ -1,0 +1,5 @@
+---
+"@graphql-tools/utils": patch
+---
+
+fix filterSchema argument filter for schema with non-default root types

--- a/packages/utils/src/filterSchema.ts
+++ b/packages/utils/src/filterSchema.ts
@@ -94,7 +94,7 @@ function filterRootFields(
         delete config.fields[fieldName];
       } else if (argumentFilter && field.args) {
         for (const argName in field.args) {
-          if (!argumentFilter(operation, fieldName, argName, field.args[argName])) {
+          if (!argumentFilter(type.name, fieldName, argName, field.args[argName])) {
             delete field.args[argName];
           }
         }

--- a/packages/utils/tests/filterSchema.test.ts
+++ b/packages/utils/tests/filterSchema.test.ts
@@ -236,4 +236,33 @@ describe('filterSchema', () => {
         ['field'].args.map(arg => arg.name),
     ).toEqual(['keep']);
   });
+
+  it('filters root field arguments for non-default query type', () => {
+    const schema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        schema {
+          query: Root
+        }
+        type Root {
+          field(keep: String, omit: String): String
+        }
+      `,
+    });
+
+    const filtered = filterSchema({
+      schema,
+      argumentFilter(typeName, fieldName, argName) {
+        if (typeName === 'Root' && fieldName === 'field' && argName === 'omit') {
+          return false;
+        }
+        return true;
+      },
+    });
+
+    expect(
+      (filtered.getType('Root') as GraphQLObjectType)
+        .getFields()
+        ['field'].args.map(arg => arg.name),
+    ).toEqual(['keep']);
+  });
 });


### PR DESCRIPTION
## Description

We are using `filterSchema()` on a schema that does not use the default `Query` type. We noticed that the `argumentsFilter()` does not work as expected and is provided with an inaccurate `typeName` argument.

I personally think that `rootFieldFilter()` should also pass the actual field name but I can see that is a breaking change. 

Related https://github.com/ardatan/graphql-tools/issues/5930

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

Added a unit test

**Test Environment**:

- OS: Sonoma
- `@graphql-tools/utils`: 10.1.0
- NodeJS: v18.18.0

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
