### PR TITLE
make globalGqlIdentifierName case sensitive

### DIFF
--- a/packages/graphql-tag-pluck/src/visitor.ts
+++ b/packages/graphql-tag-pluck/src/visitor.ts
@@ -225,7 +225,7 @@ export default (code: string, out: any, options: GraphQLTagPluckOptions = {}) =>
   // Check if identifier is defined and imported from registered packages
   function isValidIdentifier(name: string) {
     return (
-      definedIdentifierNames.some(id => id === name) || globalGqlIdentifierName!.includes(name)
+      definedIdentifierNames.some(id => id === name) || globalGqlIdentifierName!.includes(name.toLowerCase())
     );
   }
 

--- a/packages/graphql-tag-pluck/src/visitor.ts
+++ b/packages/graphql-tag-pluck/src/visitor.ts
@@ -225,7 +225,8 @@ export default (code: string, out: any, options: GraphQLTagPluckOptions = {}) =>
   // Check if identifier is defined and imported from registered packages
   function isValidIdentifier(name: string) {
     return (
-      definedIdentifierNames.some(id => id === name) || globalGqlIdentifierName!.includes(name.toLowerCase())
+      definedIdentifierNames.some(id => id === name) ||
+      globalGqlIdentifierName!.includes(name.toLowerCase())
     );
   }
 

--- a/packages/graphql-tag-pluck/src/visitor.ts
+++ b/packages/graphql-tag-pluck/src/visitor.ts
@@ -203,7 +203,7 @@ export default (code: string, out: any, options: GraphQLTagPluckOptions = {}) =>
       identifier: mod.identifier && mod.identifier.toLowerCase(),
     };
   });
-  globalGqlIdentifierName = asArray(globalGqlIdentifierName).map(s => s!.toLowerCase());
+  globalGqlIdentifierName = asArray(globalGqlIdentifierName ?? '');
 
   const hooksOptions = { skipIndent, gqlMagicComment, modules, globalGqlIdentifierName };
 
@@ -225,8 +225,7 @@ export default (code: string, out: any, options: GraphQLTagPluckOptions = {}) =>
   // Check if identifier is defined and imported from registered packages
   function isValidIdentifier(name: string) {
     return (
-      definedIdentifierNames.some(id => id === name) ||
-      globalGqlIdentifierName!.includes(name.toLowerCase())
+      definedIdentifierNames.some(id => id === name) || globalGqlIdentifierName!.includes(name)
     );
   }
 

--- a/packages/graphql-tag-pluck/tests/graphql-tag-pluck.test.ts
+++ b/packages/graphql-tag-pluck/tests/graphql-tag-pluck.test.ts
@@ -268,7 +268,7 @@ describe('graphql-tag-pluck', () => {
       );
     });
 
-    it.only("should pluck graphql-tag template literals from .ts that use 'using' keyword", async () => {
+    it("should pluck graphql-tag template literals from .ts that use 'using' keyword", async () => {
       const sources = await pluck(
         'tmp-XXXXXX.ts',
         freeText(`
@@ -1930,6 +1930,45 @@ describe('graphql-tag-pluck', () => {
         \`)
 
         const doc = anothergql\`
+          query foo {
+            foo {
+              ...Foo
+            }
+          }
+
+          \${fragment}
+        \`
+      `),
+        {
+          globalGqlIdentifierName: 'anothergql',
+        },
+      );
+      expect(sources.map(source => source.body).join('\n\n')).toEqual(
+        freeText(`
+        fragment Foo on FooType {
+          id
+        }
+
+        query foo {
+          foo {
+            ...Foo
+          }
+        }
+      `),
+      );
+    });
+
+    it('should be able to specify the global GraphQL identifier name case insensitively', async () => {
+      const sources = await pluck(
+        'tmp-XXXXXX.js',
+        freeText(`
+        const fragment = anotherGql(\`
+          fragment Foo on FooType {
+            id
+          }
+        \`)
+
+        const doc = AnotherGql\`
           query foo {
             foo {
               ...Foo

--- a/packages/graphql-tag-pluck/tests/graphql-tag-pluck.test.ts
+++ b/packages/graphql-tag-pluck/tests/graphql-tag-pluck.test.ts
@@ -1958,7 +1958,7 @@ describe('graphql-tag-pluck', () => {
       );
     });
 
-    it('should be able to specify the global GraphQL identifier name case insensitively', async () => {
+    it('should be able to specify the global GraphQL identifier name case sensitively', async () => {
       const sources = await pluck(
         'tmp-XXXXXX.js',
         freeText(`
@@ -1979,7 +1979,7 @@ describe('graphql-tag-pluck', () => {
         \`
       `),
         {
-          globalGqlIdentifierName: 'anothergql',
+          globalGqlIdentifierName: 'anotherGql',
         },
       );
 
@@ -1987,14 +1987,7 @@ describe('graphql-tag-pluck', () => {
         freeText(`
         fragment Foo on FooType {
           id
-        }
-
-        query foo {
-          foo {
-            ...Foo
-          }
-        }
-      `),
+        }`),
       );
     });
 

--- a/website/src/pages/docs/graphql-tag-pluck.mdx
+++ b/website/src/pages/docs/graphql-tag-pluck.mdx
@@ -103,7 +103,7 @@ be translated into `/* GraphQL */` in code.
 
 ### `globalGqlIdentifierName`
 
-Allows using a global identifier instead of a module import. Identifiers are case insensitive.
+Allows using a global identifier instead of a module import. Identifiers are case sensitive.
 
 ```js
 // `graphql` is a global function

--- a/website/src/pages/docs/graphql-tag-pluck.mdx
+++ b/website/src/pages/docs/graphql-tag-pluck.mdx
@@ -103,7 +103,7 @@ be translated into `/* GraphQL */` in code.
 
 ### `globalGqlIdentifierName`
 
-Allows using a global identifier instead of a module import.
+Allows using a global identifier instead of a module import. Identifiers are case insensitive.
 
 ```js
 // `graphql` is a global function


### PR DESCRIPTION
## Description

Currently globalGqlIdentifierNames are converted to lower case before being used for matching. This patch removes this conversion so they match in the file if the identifier in the code source is not all lower case. Previously if you had a mixed case globalGqlIdentifierName in the source code it would not match.

Eg: `const x = testGql(` could not be plucked using globalGqlIdentifierName as it is mixed case.

It also re-enables tests

Related # 5944

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [x] unit test
- [x] used in own project

**Test Environment**:

- OS: MacOS
- `@graphql-tools/...`: master
- NodeJS: 18

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

