### PR TITLE
fix __typename not selected if already selected with alias

### DIFF
--- a/.changeset/twelve-buckets-bow.md
+++ b/.changeset/twelve-buckets-bow.md
@@ -1,0 +1,5 @@
+---
+"@graphql-tools/wrap": patch
+---
+
+Fix missing `__typename` field when it is already present but aliased.

--- a/packages/wrap/tests/transformTransformCompositeFields.test.ts
+++ b/packages/wrap/tests/transformTransformCompositeFields.test.ts
@@ -126,9 +126,6 @@ describe('TransformCompositeFields', () => {
       expect.objectContaining({
         selections: [
           expect.objectContaining({
-            name: expect.objectContaining({ kind: 'Name', value: '__typename' }),
-          }),
-          expect.objectContaining({
             name: expect.objectContaining({ kind: 'Name', value: 'product' }),
             selectionSet: expect.objectContaining({
               selections: [
@@ -140,6 +137,9 @@ describe('TransformCompositeFields', () => {
                 }),
               ],
             }),
+          }),
+          expect.objectContaining({
+            name: expect.objectContaining({ kind: 'Name', value: '__typename' }),
           }),
         ],
       }),


### PR DESCRIPTION
## Description

The `TransformCompositeFields` allows to transform fields, which automatically adds `__typename` to the selection set.

Problem is that to avoid duplicating the selection of this field, we check if it's already selected. This check is flawed because it doesn't take in account the possible alias, which leads to `__typename` not being selected if already present in the query with an alias.

This causes incompatibility with the response-cache plugin which rely on selecting `__typename`, but with a `__responseCacheType` alias.

Related https://github.com/ardatan/graphql-mesh/issues/6272

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

A better fix would have been to do exactly what response-cache plugin is doing, always adding typename but with a uniq identifiable alias. This would simplify code and allow for result clean up. But since the usage of this transform is already spreaded and used as is, changing the assumption that a `__typename` is always present would break a lot of other transforms.