### PR TITLE
fix: revert subscription event source stream handling

### DIFF
--- a/.changeset/spotty-ways-give.md
+++ b/.changeset/spotty-ways-give.md
@@ -1,0 +1,5 @@
+---
+"@graphql-tools/executor": patch
+---
+
+revert subscription event source error handling to graphql-js behaviour

--- a/packages/executor/src/execution/__tests__/subscribe-test.ts
+++ b/packages/executor/src/execution/__tests__/subscribe-test.ts
@@ -1287,11 +1287,10 @@ describe('Subscription Publish Phase', () => {
       },
     });
 
-    try {
-      await iterator.next();
-    } catch (error: unknown) {
-      expect(error).toMatchObject({ message: 'test error', locations: [{ line: 2, column: 9 }] });
-    }
+    await expect(iterator.next()).rejects.toMatchObject({
+      message: 'test error',
+      locations: [{ line: 2, column: 9 }],
+    });
 
     const endResult = await iterator.next();
 

--- a/packages/executor/src/execution/__tests__/subscribe-test.ts
+++ b/packages/executor/src/execution/__tests__/subscribe-test.ts
@@ -1287,19 +1287,11 @@ describe('Subscription Publish Phase', () => {
       },
     });
 
-    const resultThree = await iterator.next();
-
-    expect(JSON.parse(JSON.stringify(resultThree))).toEqual({
-      done: false,
-      value: {
-        errors: [
-          {
-            message: 'test error',
-            locations: [{ line: 2, column: 9 }],
-          },
-        ],
-      },
-    });
+    try {
+      await iterator.next();
+    } catch (error: unknown) {
+      expect(error).toMatchObject({ message: 'test error' });
+    }
 
     const endResult = await iterator.next();
 

--- a/packages/executor/src/execution/__tests__/subscribe-test.ts
+++ b/packages/executor/src/execution/__tests__/subscribe-test.ts
@@ -1290,7 +1290,7 @@ describe('Subscription Publish Phase', () => {
     try {
       await iterator.next();
     } catch (error: unknown) {
-      expect(error).toMatchObject({ message: 'test error' });
+      expect(error).toMatchObject({ message: 'test error', locations: [{ line: 2, column: 9 }] });
     }
 
     const endResult = await iterator.next();

--- a/packages/executor/src/execution/execute.ts
+++ b/packages/executor/src/execution/execute.ts
@@ -1624,24 +1624,66 @@ function mapSourceToResponse(
   // "ExecuteSubscriptionEvent" algorithm, as it is nearly identical to the
   // "ExecuteQuery" algorithm, for which `execute` is also used.
   return flattenAsyncIterable(
-    mapAsyncIterator(
-      resultOrStream[Symbol.asyncIterator](),
-      async (payload: unknown) =>
-        ensureAsyncIterable(
-          await executeImpl(buildPerEventExecutionContext(exeContext, payload)),
-          exeContext.signal,
-        ),
-      async function* (error: Error) {
-        const wrappedError = createGraphQLError(error.message, {
-          originalError: error,
-          nodes: [exeContext.operation],
-        });
-        yield {
-          errors: [wrappedError],
-        };
-      },
+    mapAsyncIterator(resultOrStream[Symbol.asyncIterator](), async (payload: unknown) =>
+      ensureAsyncIterable(await executeImpl(buildPerEventExecutionContext(exeContext, payload))),
     ),
   );
+}
+
+/**
+ * Implements the "CreateSourceEventStream" algorithm described in the
+ * GraphQL specification, resolving the subscription source event stream.
+ *
+ * Returns a Promise which resolves to either an AsyncIterable (if successful)
+ * or an ExecutionResult (error). The promise will be rejected if the schema or
+ * other arguments to this function are invalid, or if the resolved event stream
+ * is not an async iterable.
+ *
+ * If the client-provided arguments to this function do not result in a
+ * compliant subscription, a GraphQL Response (ExecutionResult) with
+ * descriptive errors and no data will be returned.
+ *
+ * If the the source stream could not be created due to faulty subscription
+ * resolver logic or underlying systems, the promise will resolve to a single
+ * ExecutionResult containing `errors` and no `data`.
+ *
+ * If the operation succeeded, the promise resolves to the AsyncIterable for the
+ * event stream returned by the resolver.
+ *
+ * A Source Event Stream represents a sequence of events, each of which triggers
+ * a GraphQL execution for that event.
+ *
+ * This may be useful when hosting the stateful subscription service in a
+ * different process or machine than the stateless GraphQL execution engine,
+ * or otherwise separating these two steps. For more on this, see the
+ * "Supporting Subscriptions at Scale" information in the GraphQL specification.
+ */
+export function createSourceEventStream(
+  args: ExecutionArgs,
+): MaybePromise<AsyncIterable<unknown> | SingularExecutionResult> {
+  // If a valid execution context cannot be created due to incorrect arguments,
+  // a "Response" with only errors is returned.
+  const exeContext = buildExecutionContext(args);
+
+  // Return early errors if execution context failed.
+  if (!('schema' in exeContext)) {
+    return {
+      errors: exeContext.map(e => {
+        Object.defineProperty(e, 'extensions', {
+          value: {
+            ...e.extensions,
+            http: {
+              ...e.extensions?.['http'],
+              status: 400,
+            },
+          },
+        });
+        return e;
+      }),
+    };
+  }
+
+  return createSourceEventStreamImpl(exeContext);
 }
 
 function createSourceEventStreamImpl(


### PR DESCRIPTION
## Description

This reverts the changes for the executor introduced in https://github.com/ardatan/graphql-tools/pull/5187

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
