### PR TITLE
allow toString directive  (check isNode on merge if inherited from prototype)

### DIFF
--- a/packages/merge/src/typedefs-mergers/merge-nodes.ts
+++ b/packages/merge/src/typedefs-mergers/merge-nodes.ts
@@ -5,6 +5,7 @@ import {
   SchemaDefinitionNode,
   SchemaExtensionNode,
 } from 'graphql';
+import { isNode } from 'graphql/language/ast.js';
 import { collectComment, NamedDefinitionNode } from '@graphql-tools/utils';
 import { mergeDirective } from './directives.js';
 import { mergeEnum } from './enum.js';
@@ -104,6 +105,14 @@ export function mergeGraphQLNodes(
             );
             break;
           case Kind.DIRECTIVE_DEFINITION:
+            if (mergedResultMap[name]) {
+              const isInheritedFromPrototype = name in {};
+              if (isInheritedFromPrototype) {
+                if (!isNode(mergedResultMap[name])) {
+                  mergedResultMap[name] = undefined as any;
+                }
+              }
+            }
             mergedResultMap[name] = mergeDirective(nodeDefinition, mergedResultMap[name] as any);
             break;
         }

--- a/packages/merge/tests/merge-nodes.spec.ts
+++ b/packages/merge/tests/merge-nodes.spec.ts
@@ -280,6 +280,27 @@ describe('Merge Nodes', () => {
         'Unable to merge GraphQL type "A": Field "f1" already defined with a different type. Declared as "String", but you tried to override with "Int"',
       );
     });
+
+    it('Should merge GraphQL Types and merge directives (when the directive is inherited from the Object prototype)', () => {
+      const type1 = parse(/* GraphQL */ `
+        type A @toString {
+          f1: String
+        }
+      `);
+      const type2 = parse(/* GraphQL */ `
+        type A @test2 {
+          f2: Int
+        }
+      `);
+      const merged = mergeGraphQLNodes([...type1.definitions, ...type2.definitions]);
+      const type = merged['A'];
+      assertObjectTypeDefinitionNode(type);
+      assertSome(type.directives);
+
+      expect(type.directives.length).toBe(2);
+      expect(type.directives[0].name.value).toBe('toString');
+      expect(type.directives[1].name.value).toBe('test2');
+    });
   });
 
   describe('enum', () => {


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

I was trying to make a toString directive and makeExecutableSchema was failing. 

It wasn't working because it creates an object (mergedResultMap in function mergeGraphQLNodes) and objects have an inherited toString method. So it was finding that toString exists in the map because it was the inherited object function, not a directive. (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty#direct_vs._inherited_properties)

 So I thought maybe when merging the directive it could check if it exists and if it's an inherited property and not a node, then set to undefined so it can proceed to create the directive node instead of the inherited object function.

Related #5967

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Screenshots/Sandbox (if appropriate/relevant):

Codesandbox to show the error https://codesandbox.io/p/devbox/brave-visvesvaraya-49xx8m

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [x] Unit test
- [x] Patched into my project

**Test Environment**:

- OS:
- `@graphql-tools/...`:
- NodeJS:

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
