### PR TITLE
fix: incremental delivery cancelation unhandled rejection

### DIFF
--- a/.changeset/pink-fishes-punch.md
+++ b/.changeset/pink-fishes-punch.md
@@ -1,0 +1,5 @@
+---
+"@graphql-tools/executor": patch
+---
+
+fix rejecting when canceling async iterable returned from normalized executor

--- a/packages/executor/src/execution/__tests__/defer-test.ts
+++ b/packages/executor/src/execution/__tests__/defer-test.ts
@@ -107,7 +107,7 @@ async function complete(document: DocumentNode) {
 
 describe('Execute: defer directive', () => {
   it('Can defer fragments containing scalar types', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query HeroNameQuery {
         hero {
           id
@@ -119,6 +119,7 @@ describe('Execute: defer directive', () => {
         name
       }
     `);
+
     const result = await complete(document);
 
     expect(result).toEqual([
@@ -146,7 +147,7 @@ describe('Execute: defer directive', () => {
   });
 
   it('Can disable defer using if argument', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query HeroNameQuery {
         hero {
           id
@@ -157,6 +158,7 @@ describe('Execute: defer directive', () => {
         name
       }
     `);
+
     const result = await complete(document);
 
     expectJSON(result).toDeepEqual({
@@ -170,7 +172,7 @@ describe('Execute: defer directive', () => {
   });
 
   it('Does not disable defer with null if argument', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query HeroNameQuery($shouldDefer: Boolean) {
         hero {
           id
@@ -181,6 +183,7 @@ describe('Execute: defer directive', () => {
         name
       }
     `);
+
     const result = await complete(document);
     expectJSON(result).toDeepEqual([
       {
@@ -200,7 +203,7 @@ describe('Execute: defer directive', () => {
   });
 
   it('Can defer fragments on the top level Query field', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query HeroNameQuery {
         ...QueryFragment @defer(label: "DeferQuery")
       }
@@ -210,6 +213,7 @@ describe('Execute: defer directive', () => {
         }
       }
     `);
+
     const result = await complete(document);
 
     expectJSON(result).toDeepEqual([
@@ -235,7 +239,7 @@ describe('Execute: defer directive', () => {
   });
 
   it('Can defer fragments with errors on the top level Query field', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query HeroNameQuery {
         ...QueryFragment @defer(label: "DeferQuery")
       }
@@ -245,6 +249,7 @@ describe('Execute: defer directive', () => {
         }
       }
     `);
+
     const result = await complete(document);
 
     expectJSON(result).toDeepEqual([
@@ -277,7 +282,7 @@ describe('Execute: defer directive', () => {
   });
 
   it('Can defer a fragment within an already deferred fragment', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query HeroNameQuery {
         hero {
           id
@@ -294,6 +299,7 @@ describe('Execute: defer directive', () => {
         }
       }
     `);
+
     const result = await complete(document);
 
     expectJSON(result).toDeepEqual([
@@ -328,7 +334,7 @@ describe('Execute: defer directive', () => {
   });
 
   it('Can defer a fragment that is also not deferred, deferred fragment is first', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query HeroNameQuery {
         hero {
           id
@@ -340,6 +346,7 @@ describe('Execute: defer directive', () => {
         name
       }
     `);
+
     const result = await complete(document);
     expectJSON(result).toDeepEqual([
       {
@@ -367,7 +374,7 @@ describe('Execute: defer directive', () => {
   });
 
   it('Can defer a fragment that is also not deferred, non-deferred fragment is first', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query HeroNameQuery {
         hero {
           id
@@ -379,6 +386,7 @@ describe('Execute: defer directive', () => {
         name
       }
     `);
+
     const result = await complete(document);
     expectJSON(result).toDeepEqual([
       {
@@ -406,7 +414,7 @@ describe('Execute: defer directive', () => {
   });
 
   it('Can defer an inline fragment', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query HeroNameQuery {
         hero {
           id
@@ -416,6 +424,7 @@ describe('Execute: defer directive', () => {
         }
       }
     `);
+
     const result = await complete(document);
 
     expectJSON(result).toDeepEqual([
@@ -431,7 +440,7 @@ describe('Execute: defer directive', () => {
   });
 
   it('Handles errors thrown in deferred fragments', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query HeroNameQuery {
         hero {
           id
@@ -442,6 +451,7 @@ describe('Execute: defer directive', () => {
         errorField
       }
     `);
+
     const result = await complete(document);
     expectJSON(result).toDeepEqual([
       {
@@ -468,7 +478,7 @@ describe('Execute: defer directive', () => {
   });
 
   it('Handles non-nullable errors thrown in deferred fragments', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query HeroNameQuery {
         hero {
           id
@@ -479,6 +489,7 @@ describe('Execute: defer directive', () => {
         nonNullErrorField
       }
     `);
+
     const result = await complete(document);
     expectJSON(result).toDeepEqual([
       {
@@ -505,7 +516,7 @@ describe('Execute: defer directive', () => {
   });
 
   it('Handles non-nullable errors thrown outside deferred fragments', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query HeroNameQuery {
         hero {
           nonNullErrorField
@@ -516,6 +527,7 @@ describe('Execute: defer directive', () => {
         id
       }
     `);
+
     const result = await complete(document);
     expectJSON(result).toDeepEqual({
       errors: [
@@ -537,7 +549,7 @@ describe('Execute: defer directive', () => {
   });
 
   it('Handles async non-nullable errors thrown in deferred fragments', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query HeroNameQuery {
         hero {
           id
@@ -548,6 +560,7 @@ describe('Execute: defer directive', () => {
         promiseNonNullErrorField
       }
     `);
+
     const result = await complete(document);
     expectJSON(result).toDeepEqual([
       {
@@ -574,7 +587,7 @@ describe('Execute: defer directive', () => {
   });
 
   it('Returns payloads in correct order', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query HeroNameQuery {
         hero {
           id
@@ -620,23 +633,24 @@ describe('Execute: defer directive', () => {
   });
 
   it('Returns payloads from synchronous data in correct order', async () => {
-    const document = parse(`
-    query HeroNameQuery {
-      hero {
-        id
-        ...NameFragment @defer
+    const document = parse(/* GraphQL */ `
+      query HeroNameQuery {
+        hero {
+          id
+          ...NameFragment @defer
+        }
       }
-    }
-    fragment NameFragment on Hero {
-      name
-      friends {
-        ...NestedFragment @defer
+      fragment NameFragment on Hero {
+        name
+        friends {
+          ...NestedFragment @defer
+        }
       }
-    }
-    fragment NestedFragment on Friend {
-      name
-    }
-  `);
+      fragment NestedFragment on Friend {
+        name
+      }
+    `);
+
     const result = await complete(document);
     expectJSON(result).toDeepEqual([
       {
@@ -669,19 +683,20 @@ describe('Execute: defer directive', () => {
   });
 
   it('Filters deferred payloads when a list item returned by an async iterable is nulled', async () => {
-    const document = parse(`
-    query {
-      hero {
-        asyncFriends {
-          promiseNonNullErrorField
-          ...NameFragment @defer
+    const document = parse(/* GraphQL */ `
+      query {
+        hero {
+          asyncFriends {
+            promiseNonNullErrorField
+            ...NameFragment @defer
+          }
         }
       }
-    }
-    fragment NameFragment on Friend {
-      name
-    }
-  `);
+      fragment NameFragment on Friend {
+        name
+      }
+    `);
+
     const result = await complete(document);
     expectJSON(result).toDeepEqual({
       data: {
@@ -692,7 +707,7 @@ describe('Execute: defer directive', () => {
       errors: [
         {
           message: 'Cannot return null for non-nullable field Friend.promiseNonNullErrorField.',
-          locations: [{ line: 5, column: 11 }],
+          locations: [{ line: 5, column: 13 }],
           path: ['hero', 'asyncFriends', 0, 'promiseNonNullErrorField'],
         },
       ],

--- a/packages/executor/src/execution/__tests__/stream-test.ts
+++ b/packages/executor/src/execution/__tests__/stream-test.ts
@@ -302,7 +302,7 @@ describe('Execute: stream directive', () => {
   });
 
   it('Can stream a field that returns a list of promises', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query {
         friendList @stream(initialCount: 2) {
           name
@@ -347,7 +347,7 @@ describe('Execute: stream directive', () => {
   });
 
   it('Can stream in correct order with lists of promises', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query {
         friendList @stream(initialCount: 0) {
           name
@@ -396,7 +396,7 @@ describe('Execute: stream directive', () => {
   });
 
   it('Handles rejections in a field that returns a list of promises before initialCount is reached', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query {
         friendList @stream(initialCount: 2) {
           name
@@ -440,7 +440,7 @@ describe('Execute: stream directive', () => {
   });
 
   it('Handles rejections in a field that returns a list of promises after initialCount is reached', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query {
         friendList @stream(initialCount: 1) {
           name
@@ -488,7 +488,7 @@ describe('Execute: stream directive', () => {
   });
 
   it('Can stream a field that returns an async iterable', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query {
         friendList @stream {
           name
@@ -544,7 +544,7 @@ describe('Execute: stream directive', () => {
   });
 
   it('Can stream a field that returns an async iterable, using a non-zero initialCount', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query {
         friendList @stream(initialCount: 2) {
           name
@@ -582,7 +582,7 @@ describe('Execute: stream directive', () => {
   });
 
   it('Negative values of initialCount throw field errors on a field that returns an async iterable', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query {
         friendList @stream(initialCount: -2) {
           name
@@ -608,7 +608,7 @@ describe('Execute: stream directive', () => {
   });
 
   it('Can handle concurrent calls to .next() without waiting', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query {
         friendList @stream(initialCount: 2) {
           name
@@ -654,7 +654,7 @@ describe('Execute: stream directive', () => {
   });
 
   it('Handles error thrown in async iterable before initialCount is reached', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query {
         friendList @stream(initialCount: 2) {
           name
@@ -683,7 +683,7 @@ describe('Execute: stream directive', () => {
   });
 
   it('Handles error thrown in async iterable after initialCount is reached', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query {
         friendList @stream(initialCount: 1) {
           name
@@ -724,7 +724,7 @@ describe('Execute: stream directive', () => {
   });
 
   it('Handles null returned in non-null list items after initialCount is reached', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query {
         nonNullFriendList @stream(initialCount: 1) {
           name
@@ -762,7 +762,7 @@ describe('Execute: stream directive', () => {
   });
 
   it('Handles null returned in non-null async iterable list items after initialCount is reached', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query {
         nonNullFriendList @stream(initialCount: 1) {
           name
@@ -809,7 +809,7 @@ describe('Execute: stream directive', () => {
   });
 
   it('Handles errors thrown by completeValue after initialCount is reached', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query {
         scalarList @stream(initialCount: 1)
       }
@@ -844,7 +844,7 @@ describe('Execute: stream directive', () => {
   });
 
   it('Handles async errors thrown by completeValue after initialCount is reached', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query {
         friendList @stream(initialCount: 1) {
           nonNullName
@@ -896,7 +896,7 @@ describe('Execute: stream directive', () => {
   });
 
   it('Handles async errors thrown by completeValue after initialCount is reached for a non-nullable list', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query {
         nonNullFriendList @stream(initialCount: 1) {
           nonNullName
@@ -939,7 +939,7 @@ describe('Execute: stream directive', () => {
   });
 
   it('Handles async errors thrown by completeValue after initialCount is reached from async iterable', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query {
         friendList @stream(initialCount: 1) {
           nonNullName
@@ -994,7 +994,7 @@ describe('Execute: stream directive', () => {
   });
 
   it('Handles async errors thrown by completeValue after initialCount is reached from async iterable for a non-nullable list', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query {
         nonNullFriendList @stream(initialCount: 1) {
           nonNullName
@@ -1039,7 +1039,7 @@ describe('Execute: stream directive', () => {
   });
 
   it('Filters payloads that are nulled', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query {
         nestedObject {
           nonNullScalarField
@@ -1072,7 +1072,7 @@ describe('Execute: stream directive', () => {
   });
 
   it('Filters payloads that are nulled by a later synchronous error', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query {
         nestedObject {
           nestedFriendList @stream(initialCount: 0) {
@@ -1105,7 +1105,7 @@ describe('Execute: stream directive', () => {
   });
 
   it('Does not filter payloads when null error is in a different path', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query {
         otherNestedObject: nestedObject {
           ... @defer {
@@ -1159,7 +1159,7 @@ describe('Execute: stream directive', () => {
   });
 
   it('Filters stream payloads that are nulled in a deferred payload', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query {
         nestedObject {
           ... @defer {
@@ -1213,16 +1213,16 @@ describe('Execute: stream directive', () => {
   });
 
   it('Filters defer payloads that are nulled in a stream response', async () => {
-    const document = parse(`
-    query {
-      friendList @stream(initialCount: 0) {
-        nonNullName
-        ... @defer {
-          name
+    const document = parse(/* GraphQL */ `
+      query {
+        friendList @stream(initialCount: 0) {
+          nonNullName
+          ... @defer {
+            name
+          }
         }
       }
-    }
-  `);
+    `);
     const result = await complete(document, {
       async *friendList() {
         yield await Promise.resolve({
@@ -1246,7 +1246,7 @@ describe('Execute: stream directive', () => {
             errors: [
               {
                 message: 'Cannot return null for non-nullable field Friend.nonNullName.',
-                locations: [{ line: 4, column: 9 }],
+                locations: [{ line: 4, column: 11 }],
                 path: ['friendList', 0, 'nonNullName'],
               },
             ],
@@ -1288,7 +1288,7 @@ describe('Execute: stream directive', () => {
       }),
     };
 
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query {
         nestedObject {
           ... @defer {
@@ -1359,7 +1359,7 @@ describe('Execute: stream directive', () => {
   });
 
   it('Handles promises returned by completeValue after initialCount is reached', async () => {
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query {
         friendList @stream(initialCount: 1) {
           id
@@ -1410,10 +1410,10 @@ describe('Execute: stream directive', () => {
 
   it('Returns payloads in correct order when parent deferred fragment resolves slower than stream', async () => {
     const [slowFieldPromise, resolveSlowField] = createResolvablePromise();
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query {
         nestedObject {
-          ... DeferFragment @defer
+          ...DeferFragment @defer
         }
       }
       fragment DeferFragment on NestedObject {
@@ -1506,17 +1506,17 @@ describe('Execute: stream directive', () => {
     const [slowFieldPromise, resolveSlowField] = createResolvablePromise();
     const [iterableCompletionPromise, resolveIterableCompletion] = createResolvablePromise();
 
-    const document = parse(`
-    query {
-      friendList @stream(initialCount: 1, label:"stream-label") {
-        ...NameFragment @defer(label: "DeferName") @defer(label: "DeferName")
-        id
+    const document = parse(/* GraphQL */ `
+      query {
+        friendList @stream(initialCount: 1, label: "stream-label") {
+          ...NameFragment @defer(label: "DeferName") @defer(label: "DeferName")
+          id
+        }
       }
-    }
-    fragment NameFragment on Friend {
-      name
-    }
-  `);
+      fragment NameFragment on Friend {
+        name
+      }
+    `);
 
     const executeResult = await execute({
       schema,
@@ -1594,17 +1594,17 @@ describe('Execute: stream directive', () => {
     const [slowFieldPromise, resolveSlowField] = createResolvablePromise();
     const [iterableCompletionPromise, resolveIterableCompletion] = createResolvablePromise();
 
-    const document = parse(`
-    query {
-      friendList @stream(initialCount: 1, label:"stream-label") {
-        ...NameFragment @defer(label: "DeferName") @defer(label: "DeferName")
-        id
+    const document = parse(/* GraphQL */ `
+      query {
+        friendList @stream(initialCount: 1, label: "stream-label") {
+          ...NameFragment @defer(label: "DeferName") @defer(label: "DeferName")
+          id
+        }
       }
-    }
-    fragment NameFragment on Friend {
-      name
-    }
-  `);
+      fragment NameFragment on Friend {
+        name
+      }
+    `);
 
     const executeResult = await execute({
       schema,
@@ -1702,7 +1702,7 @@ describe('Execute: stream directive', () => {
       }),
     };
 
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query {
         friendList @stream(initialCount: 1) {
           id
@@ -1760,7 +1760,7 @@ describe('Execute: stream directive', () => {
       }),
     };
 
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query {
         friendList @stream(initialCount: 1) {
           name
@@ -1820,7 +1820,7 @@ describe('Execute: stream directive', () => {
         },
       }),
     };
-    const document = parse(`
+    const document = parse(/* GraphQL */ `
       query {
         friendList @stream(initialCount: 1) {
           ... @defer {


### PR DESCRIPTION
This change properly handles the cancelation of defer/stream results returned from `normalizedExecutor`.