### PR TITLE
Disallow new lines in paths when checking with `isValidPath`

### DIFF
--- a/.changeset/spotty-kiwis-crash.md
+++ b/.changeset/spotty-kiwis-crash.md
@@ -1,0 +1,10 @@
+---
+"@graphql-tools/utils": patch
+---
+
+Disallow new lines in paths when checking with `isValidPath`
+
+A string may sometimes look like a path but is not (like an SDL of a simple
+GraphQL schema). To make sure we don't yield false-positives in such cases,
+we disallow new lines in paths (even thouhg most Unix systems support new
+lines in file names).

--- a/.changeset/spotty-kiwis-crash.md
+++ b/.changeset/spotty-kiwis-crash.md
@@ -6,5 +6,5 @@ Disallow new lines in paths when checking with `isValidPath`
 
 A string may sometimes look like a path but is not (like an SDL of a simple
 GraphQL schema). To make sure we don't yield false-positives in such cases,
-we disallow new lines in paths (even thouhg most Unix systems support new
+we disallow new lines in paths (even though most Unix systems support new
 lines in file names).

--- a/packages/utils/src/helpers.ts
+++ b/packages/utils/src/helpers.ts
@@ -31,7 +31,7 @@ const invalidPathRegex = /[‘“!%^<>`\n]/;
  *
  * A string may sometimes look like a path but is not (like an SDL of a simple
  * GraphQL schema). To make sure we don't yield false-positives in such cases,
- * we disallow new lines in paths (even thouhg most Unix systems support new
+ * we disallow new lines in paths (even though most Unix systems support new
  * lines in file names).
  */
 export function isValidPath(str: any): boolean {

--- a/packages/utils/src/helpers.ts
+++ b/packages/utils/src/helpers.ts
@@ -25,7 +25,15 @@ export function isDocumentString(str: any): boolean {
   return false;
 }
 
-const invalidPathRegex = /[‘“!%^<>`]/;
+const invalidPathRegex = /[‘“!%^<>`\n]/;
+/**
+ * Checkes whether the `str` contains any path illegal characters.
+ *
+ * A string may sometimes look like a path but is not (like an SDL of a simple
+ * GraphQL schema). To make sure we don't yield false-positives in such cases,
+ * we disallow new lines in paths (even thouhg most Unix systems support new
+ * lines in file names).
+ */
 export function isValidPath(str: any): boolean {
   return typeof str === 'string' && !invalidPathRegex.test(str);
 }

--- a/packages/utils/tests/helpers.test.ts
+++ b/packages/utils/tests/helpers.test.ts
@@ -1,0 +1,20 @@
+import { isValidPath } from '../src/helpers';
+
+describe('helpers', () => {
+  it.each([
+    `schema @transport(subgraph: "API", kind: "rest", location: "http://0.0.0.0:4001", headers: "{\"Content-Type\":\"application/json\"}") {
+      query: Query
+      mutation: Mutation
+      subscription: Subscription
+    }`,
+  ])('should detect "%s" as NOT a valid path', str => {
+    expect(isValidPath(str)).toBeFalsy();
+  });
+
+  it.each(['file', 'file.tsx', 'some/where/file.tsx', '/some/where/file.tsx'])(
+    'should detect "%s" as a valid path',
+    str => {
+      expect(isValidPath(str)).toBeTruthy();
+    },
+  );
+});


### PR DESCRIPTION
A string may sometimes look like a path but is not (like an SDL of a simple GraphQL schema). To make sure we don't yield false-positives in such cases, we disallow new lines in paths (even though most Unix systems support new lines in file names).

An example of a false-positive:

```graphql
schema @transport(subgraph: "API", kind: "rest", location: "http://0.0.0.0:4001", headers: "{\"Content-Type\":\"application/json\"}") {
  query: Query
  mutation: Mutation
  subscription: Subscription
}
```

