### PR TITLE
fix: handle overlapping fields correctly across subschemas

### DIFF
--- a/.changeset/fresh-kangaroos-exist.md
+++ b/.changeset/fresh-kangaroos-exist.md
@@ -1,0 +1,34 @@
+---
+"@graphql-tools/stitch": minor
+---
+
+New option `useNonNullableFieldOnConflict` in `typeMergingOptions` of `stitchSchemas`
+
+When you have two schemas like below, you will get a warning about the conflicting fields because `name` field is defined as non-null in one schema and nullable in the other schema, and non-nullable field can exist in the stitched schema because of the order or any other reasons, and this might actually cause an unexpected behavior when you fetch `User.name` from the one who has it as non-nullable.
+This option supresses the warning, and takes the field from the schema that has it as non-nullable.
+
+```graphql
+  type Query {
+    user: User
+  }
+
+  type User {
+    id: ID!
+    name: String
+    email: String
+  }
+```
+And;
+
+```graphql
+  type Query {
+    user: User
+  }
+
+  type User {
+    id: ID!
+    name: String!
+  }
+```
+
+

--- a/.changeset/many-ads-run.md
+++ b/.changeset/many-ads-run.md
@@ -1,0 +1,97 @@
+---
+"@graphql-tools/federation": patch
+"@graphql-tools/delegate": patch
+"@graphql-tools/stitch": patch
+---
+
+If the gateway receives a query with an overlapping fields for the subschema, it uses aliases to resolve it correctly.
+
+Let's say subschema A has the following schema;
+
+```graphql
+  type Query {
+    user: User
+  }
+
+  interface User {
+    id: ID!
+    name: String!
+  }
+
+  type Admin implements User {
+    id: ID!
+    name: String!
+    role: String!
+  }
+
+  type Customer implements User {
+    id: ID!
+    name: String
+    email: String
+  }
+```
+
+And let's say the gateway has the following schema instead;
+
+```graphql
+  type Query {
+    user: User
+  }
+
+  interface User {
+    id: ID!
+    name: String!
+  }
+
+  type Admin implements User {
+    id: ID!
+    name: String!
+    role: String!
+  }
+
+  type Customer implements User {
+    id: ID!
+    name: String!
+    email: String!
+  }
+```
+
+In this case, the following query is fine for the gateway but for the subschema, it's not;
+
+```graphql
+  query {
+    user {
+      ... on Admin {
+        id
+        name # This is nullable in the subschema
+        role
+      }
+      ... on Customer {
+        id
+        name # This is non-nullable in the subschema
+        email
+      }
+    }
+  }
+```
+
+So the subgraph will throw based on this rule [OverlappingFieldsCanBeMerged](https://github.com/graphql/graphql-js/blob/main/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts)
+
+To avoid this, the gateway will use aliases to resolve the query correctly. The query will be transformed to the following;
+
+```graphql
+  query {
+    user {
+      ... on Admin {
+        id
+        name # This is nullable in the subschema
+        role
+      }
+      ... on Customer {
+        id
+        name: _nullable_name # This is non-nullable in the subschema
+        email
+      }
+    }
+  }
+```

--- a/packages/delegate/src/OverlappingAliasesTransform.ts
+++ b/packages/delegate/src/OverlappingAliasesTransform.ts
@@ -1,0 +1,101 @@
+import { ExecutionRequest, ExecutionResult } from "@graphql-tools/utils";
+import { DelegationContext, Transform } from "./types.js";
+import { Kind, isNullableType, visit } from "graphql";
+
+const OverlappingAliases = Symbol('OverlappingAliases');
+
+interface OverlappingAliasesContext {
+  [OverlappingAliases]: boolean;
+}
+
+export class OverlappingAliasesTransform<TContext> implements Transform<OverlappingAliasesContext, TContext> {
+  transformRequest(request: ExecutionRequest, delegationContext: DelegationContext<TContext>, transformationContext: OverlappingAliasesContext) {
+    const newDocument = visit(request.document, {
+      [Kind.SELECTION_SET]: (node) => {
+        const seenNonNullable = new Set<string>();
+        const seenNullable = new Set<string>();
+        return {
+          ...node,
+          selections: node.selections.map(selection => {
+            if (selection.kind === Kind.INLINE_FRAGMENT) {
+              const selectionTypeName = selection.typeCondition?.name.value;
+              if (selectionTypeName) {
+                const selectionType = delegationContext.transformedSchema.getType(selectionTypeName);
+                if (selectionType && 'getFields' in selectionType) {
+                  const selectionTypeFields = selectionType.getFields();
+                  return {
+                    ...selection,
+                    selectionSet: {
+                      ...selection.selectionSet,
+                      selections: selection.selectionSet.selections.map(subSelection => {
+                        if (subSelection.kind === Kind.FIELD) {
+                          const fieldName = subSelection.name.value;
+                          if (!subSelection.alias) {
+                            const field = selectionTypeFields[fieldName];
+                            if (field) {
+                              let currentNullable: boolean;
+                              if (isNullableType(field.type)) {
+                                seenNullable.add(fieldName);
+                                currentNullable = true;
+                              } else {
+                                seenNonNullable.add(fieldName);
+                                currentNullable = false;
+                              }
+                              if (seenNullable.size  && seenNonNullable.size ) {
+                                transformationContext[OverlappingAliases] = true;
+                                return {
+                                  ...subSelection,
+                                  alias: {
+                                    kind: Kind.NAME,
+                                    value: currentNullable ? `_nullable_${fieldName}` : `_nonNullable_${fieldName}`,
+                                  },
+                                }
+                              }
+                            }
+                          }
+                        }
+                        return subSelection;
+                      })
+                    }
+                  }
+                }
+              }
+            }
+            return selection;
+          }),
+        }
+      }
+    })
+    return {
+      ...request,
+      document: newDocument,
+    };
+  }
+
+  transformResult(result: ExecutionResult, _delegationContext: DelegationContext<TContext>, transformationContext: OverlappingAliasesContext) {
+    if (transformationContext[OverlappingAliases]) {
+      return removeOverlappingAliases(result);
+    }
+    return result;
+  }
+}
+
+function removeOverlappingAliases(result: any): any {
+  if (result != null) {
+    if (Array.isArray(result)) {
+      return result.map(removeOverlappingAliases);
+    } else if (typeof result === 'object') {
+      const newResult: Record<string, any> = {};
+      for (const key in result) {
+        if (key.startsWith('_nullable_') || key.startsWith('_nonNullable_')) {
+          const newKey = key.replace(/^_nullable_/, '').replace(/^_nonNullable_/, '');
+          newResult[newKey] = removeOverlappingAliases(result[key]);
+        } else {
+          newResult[key] = removeOverlappingAliases(result[key]);
+        }
+      }
+      return newResult;
+    }
+  }
+  return result;
+}

--- a/packages/federation/src/supergraph.ts
+++ b/packages/federation/src/supergraph.ts
@@ -13,6 +13,7 @@ import {
   ObjectTypeDefinitionNode,
   ObjectTypeExtensionNode,
   parse,
+  parseType,
   print,
   ScalarTypeDefinitionNode,
   TypeDefinitionNode,
@@ -159,8 +160,16 @@ export function getSubschemasFromSupergraphSdl({
                     argumentNode.value.value === true,
                 );
                 if (!isExternal) {
+                  const typeArg = joinFieldDirectiveNode.arguments?.find(
+                    argumentNode => argumentNode.name.value === 'type',
+                  );
+                  const typeNode =
+                    typeArg?.value.kind === Kind.STRING
+                      ? parseType(typeArg.value.value)
+                      : fieldNode.type;
                   fieldDefinitionNodesOfSubgraph.push({
                     ...fieldNode,
+                    type: typeNode,
                     directives: fieldNode.directives?.filter(
                       directiveNode => directiveNode.name.value !== 'join__field',
                     ),

--- a/packages/federation/src/supergraph.ts
+++ b/packages/federation/src/supergraph.ts
@@ -717,6 +717,9 @@ export function getStitchedSchemaFromSupergraphSdl(opts: GetSubschemasFromSuperg
     subschemas: [...subschemaMap.values()],
     assumeValid: true,
     assumeValidSDL: true,
+    typeMergingOptions: {
+      useNonNullableFieldOnConflict: true,
+    },
   });
   return filterInternalFieldsAndTypes(supergraphSchema);
 }

--- a/packages/federation/test/federation-compatibility.test.ts
+++ b/packages/federation/test/federation-compatibility.test.ts
@@ -43,7 +43,7 @@ describe('Federation Compatibility', () => {
           } else {
             if ('errors' in result && result.errors) {
               for (const error of result.errors) {
-                console.error(error.message);
+                console.error(error.stack);
               }
             }
             expect(result).toMatchObject({

--- a/packages/stitch/src/mergeCandidates.ts
+++ b/packages/stitch/src/mergeCandidates.ts
@@ -1,6 +1,7 @@
 import {
   EnumTypeDefinitionNode,
   EnumTypeExtensionNode,
+  getNullableType,
   GraphQLEnumType,
   GraphQLEnumValueConfigMap,
   GraphQLFieldConfig,
@@ -23,6 +24,7 @@ import {
   isEnumType,
   isInputObjectType,
   isInterfaceType,
+  isNullableType,
   isObjectType,
   isScalarType,
   isUnionType,
@@ -527,6 +529,8 @@ function mergeFieldConfigs<TContext = Record<string, any>>(
 function defaultFieldConfigMerger<TContext = Record<string, any>>(
   candidates: Array<MergeFieldConfigCandidate<TContext>>,
 ) {
+  const nullables: Array<GraphQLFieldConfig<any, any>> = [];
+  const nonNullables: Array<GraphQLFieldConfig<any, any>> = [];
   const canonicalByField: Array<GraphQLFieldConfig<any, any>> = [];
   const canonicalByType: Array<GraphQLFieldConfig<any, any>> = [];
 
@@ -537,19 +541,47 @@ function defaultFieldConfigMerger<TContext = Record<string, any>>(
     } else if (transformedSubschema.merge?.[type.name]?.canonical) {
       canonicalByType.push(fieldConfig);
     }
+    if (isNullableType(fieldConfig.type)) {
+      nullables.push(fieldConfig);
+    } else {
+      nonNullables.push(fieldConfig);
+    }
   }
+
+  const nonNullableFinalField = nonNullables.length > 0 && nullables.length > 0;
 
   if (canonicalByField.length > 1) {
     throw new Error(
       `Multiple canonical definitions for "${candidates[0].type.name}.${candidates[0].fieldName}"`,
     );
   } else if (canonicalByField.length) {
-    return canonicalByField[0];
+    const finalField = canonicalByField[0];
+    if (nonNullableFinalField) {
+      return {
+        ...finalField,
+        type: getNullableType(finalField.type),
+      };
+    }
+    return finalField;
   } else if (canonicalByType.length) {
-    return canonicalByType[0];
+    const finalField = canonicalByType[0];
+    if (nonNullableFinalField) {
+      return {
+        ...finalField,
+        type: getNullableType(finalField.type),
+      };
+    }
+    return finalField;
   }
 
-  return candidates[candidates.length - 1].fieldConfig;
+  const finalField = candidates[candidates.length - 1].fieldConfig;
+  if (nonNullableFinalField) {
+    return {
+      ...finalField,
+      type: getNullableType(finalField.type),
+    };
+  }
+  return finalField;
 }
 
 function inputFieldConfigMapFromTypeCandidates<TContext = Record<string, any>>(

--- a/packages/stitch/src/mergeCandidates.ts
+++ b/packages/stitch/src/mergeCandidates.ts
@@ -520,42 +520,65 @@ function mergeFieldConfigs<TContext = Record<string, any>>(
   candidates: Array<MergeFieldConfigCandidate<TContext>>,
   typeMergingOptions?: TypeMergingOptions<TContext>,
 ) {
-  const fieldConfigMerger = typeMergingOptions?.fieldConfigMerger ?? defaultFieldConfigMerger;
+  const fieldConfigMerger =
+    typeMergingOptions?.fieldConfigMerger ??
+    getDefaultFieldConfigMerger(typeMergingOptions?.useNonNullableFieldOnConflict);
   const finalFieldConfig = fieldConfigMerger(candidates);
   validateFieldConsistency(finalFieldConfig, candidates, typeMergingOptions);
   return finalFieldConfig;
 }
 
-function defaultFieldConfigMerger<TContext = Record<string, any>>(
-  candidates: Array<MergeFieldConfigCandidate<TContext>>,
-) {
-  const nullables: Array<GraphQLFieldConfig<any, any>> = [];
-  const nonNullables: Array<GraphQLFieldConfig<any, any>> = [];
-  const canonicalByField: Array<GraphQLFieldConfig<any, any>> = [];
-  const canonicalByType: Array<GraphQLFieldConfig<any, any>> = [];
+export function getDefaultFieldConfigMerger(useNonNullableFieldOnConflict = false) {
+  return function defaultFieldConfigMerger<TContext = Record<string, any>>(
+    candidates: Array<MergeFieldConfigCandidate<TContext>>,
+  ) {
+    const nullables: Array<GraphQLFieldConfig<any, any>> = [];
+    const nonNullables: Array<GraphQLFieldConfig<any, any>> = [];
+    const canonicalByField: Array<GraphQLFieldConfig<any, any>> = [];
+    const canonicalByType: Array<GraphQLFieldConfig<any, any>> = [];
 
-  for (const { type, fieldName, fieldConfig, transformedSubschema } of candidates) {
-    if (!isSubschemaConfig(transformedSubschema)) continue;
-    if (transformedSubschema.merge?.[type.name]?.fields?.[fieldName]?.canonical) {
-      canonicalByField.push(fieldConfig);
-    } else if (transformedSubschema.merge?.[type.name]?.canonical) {
-      canonicalByType.push(fieldConfig);
+    for (const { type, fieldName, fieldConfig, transformedSubschema } of candidates) {
+      if (!isSubschemaConfig(transformedSubschema)) continue;
+      if (transformedSubschema.merge?.[type.name]?.fields?.[fieldName]?.canonical) {
+        canonicalByField.push(fieldConfig);
+      } else if (transformedSubschema.merge?.[type.name]?.canonical) {
+        canonicalByType.push(fieldConfig);
+      }
+      if (isNullableType(fieldConfig.type)) {
+        nullables.push(fieldConfig);
+      } else {
+        nonNullables.push(fieldConfig);
+      }
     }
-    if (isNullableType(fieldConfig.type)) {
-      nullables.push(fieldConfig);
-    } else {
-      nonNullables.push(fieldConfig);
+
+    const nonNullableFinalField =
+      nonNullables.length > 0 && nullables.length > 0 && useNonNullableFieldOnConflict;
+
+    if (canonicalByField.length > 1) {
+      throw new Error(
+        `Multiple canonical definitions for "${candidates[0].type.name}.${candidates[0].fieldName}"`,
+      );
+    } else if (canonicalByField.length) {
+      const finalField = canonicalByField[0];
+      if (nonNullableFinalField) {
+        return {
+          ...finalField,
+          type: getNullableType(finalField.type),
+        };
+      }
+      return finalField;
+    } else if (canonicalByType.length) {
+      const finalField = canonicalByType[0];
+      if (nonNullableFinalField) {
+        return {
+          ...finalField,
+          type: getNullableType(finalField.type),
+        };
+      }
+      return finalField;
     }
-  }
 
-  const nonNullableFinalField = nonNullables.length > 0 && nullables.length > 0;
-
-  if (canonicalByField.length > 1) {
-    throw new Error(
-      `Multiple canonical definitions for "${candidates[0].type.name}.${candidates[0].fieldName}"`,
-    );
-  } else if (canonicalByField.length) {
-    const finalField = canonicalByField[0];
+    const finalField = candidates[candidates.length - 1].fieldConfig;
     if (nonNullableFinalField) {
       return {
         ...finalField,
@@ -563,25 +586,7 @@ function defaultFieldConfigMerger<TContext = Record<string, any>>(
       };
     }
     return finalField;
-  } else if (canonicalByType.length) {
-    const finalField = canonicalByType[0];
-    if (nonNullableFinalField) {
-      return {
-        ...finalField,
-        type: getNullableType(finalField.type),
-      };
-    }
-    return finalField;
-  }
-
-  const finalField = candidates[candidates.length - 1].fieldConfig;
-  if (nonNullableFinalField) {
-    return {
-      ...finalField,
-      type: getNullableType(finalField.type),
-    };
-  }
-  return finalField;
+  };
 }
 
 function inputFieldConfigMapFromTypeCandidates<TContext = Record<string, any>>(

--- a/packages/stitch/src/mergeValidations.ts
+++ b/packages/stitch/src/mergeValidations.ts
@@ -274,7 +274,7 @@ function validationMessage<TContext = Record<string, any>>(
   }
 }
 
-function getValidationSettings<TContext = Record<string, any>>(
+export function getValidationSettings<TContext = Record<string, any>>(
   settingNamespace: string,
   typeMergingOptions?: TypeMergingOptions<TContext>,
 ): ValidationSettings {

--- a/packages/stitch/src/types.ts
+++ b/packages/stitch/src/types.ts
@@ -82,6 +82,7 @@ export interface TypeMergingOptions<TContext = Record<string, any>> {
   enumValueConfigMerger?: (
     candidates: Array<MergeEnumValueConfigCandidate<TContext>>,
   ) => GraphQLEnumValueConfig;
+  useNonNullableFieldOnConflict?: boolean;
 }
 
 export enum ValidationLevel {

--- a/packages/stitch/tests/mergeValidations.test.ts
+++ b/packages/stitch/tests/mergeValidations.test.ts
@@ -88,7 +88,7 @@ describe('Field validations', () => {
   });
 
   describe('fieldNullConsistency', () => {
-    it.skip('raises stricter nullability in canonical definition', () => {
+    it('raises stricter nullability in canonical definition', () => {
       expect(() => {
         stitchSchemas({
           typeMergingOptions: {

--- a/packages/stitch/tests/mergeValidations.test.ts
+++ b/packages/stitch/tests/mergeValidations.test.ts
@@ -88,7 +88,7 @@ describe('Field validations', () => {
   });
 
   describe('fieldNullConsistency', () => {
-    it('raises stricter nullability in canonical definition', () => {
+    it.skip('raises stricter nullability in canonical definition', () => {
       expect(() => {
         stitchSchemas({
           typeMergingOptions: {


### PR DESCRIPTION
Read the changeset for the description.
This PR fixes the validation issues within `no-entity` Federation example