### PR TITLE
fix: Node subschema pattern

### DIFF
--- a/.changeset/healthy-news-enjoy.md
+++ b/.changeset/healthy-news-enjoy.md
@@ -1,0 +1,68 @@
+---
+"@graphql-tools/federation": patch
+"@graphql-tools/delegate": patch
+"@graphql-tools/stitch": patch
+---
+
+When there is a Node subschema, and others to resolve the rest of the entities by using a union resolver as in Federation like below, it was failing. This version fixes that issue.
+
+```graphql
+query {
+  node(id: "1") {
+    id # Fetches from Node
+    ... on User {
+      name # Fetches from User
+    }
+  }
+}
+```
+
+```graphql
+type Query {
+  node(id: ID!): Node
+}
+
+interface Node {
+  id: ID!
+}
+
+type User implements Node {
+  id: ID!
+}
+
+type Post implements Node {
+  id: ID!
+}
+```
+
+```graphql
+# User subschema
+scalar _Any
+type Query {
+  _entities(representations: [_Any!]!): [_Entity]!
+}
+union _Entity = User
+interface Node {
+  id: ID!
+}
+type User implements Node {
+  id: ID!
+  name: String!
+}
+```
+
+```graphql
+# Post subschema
+scalar _Any
+union _Entity = Post
+type Query {
+  _entities(representations: [_Any!]!): [_Entity]!
+}
+interface Node {
+  id: ID!
+}
+type Post implements Node {
+  id: ID!
+  title: String!
+}
+```

--- a/packages/delegate/src/delegateToSchema.ts
+++ b/packages/delegate/src/delegateToSchema.ts
@@ -66,7 +66,6 @@ export function delegateToSchema<
     context,
     info,
   });
-
   return delegateRequest({
     ...options,
     request,

--- a/packages/stitch/tests/node.test.ts
+++ b/packages/stitch/tests/node.test.ts
@@ -1,0 +1,166 @@
+import { parse } from 'graphql';
+import { normalizedExecutor } from '@graphql-tools/executor';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { stitchSchemas } from '../src/stitchSchemas';
+
+describe('Node', () => {
+  interface Node {
+    __typename: string;
+    id: string;
+    [key: string]: any;
+  }
+  const nodes: Node[] = [
+    {
+      __typename: 'User',
+      id: '1',
+      name: 'Alice',
+    },
+    {
+      __typename: 'User',
+      id: '2',
+      name: 'Bob',
+    },
+    {
+      __typename: 'Post',
+      id: '3',
+      title: 'Hello, World!',
+    },
+  ];
+  const nodeSchema = makeExecutableSchema({
+    typeDefs: /* GraphQL */ `
+      type Query {
+        node(id: ID!): Node
+      }
+
+      interface Node {
+        id: ID!
+      }
+
+      type User implements Node {
+        id: ID!
+      }
+
+      type Post implements Node {
+        id: ID!
+      }
+    `,
+    resolvers: {
+      Query: {
+        node: (_, { id }) => nodes.find(node => node.id.toString() === id.toString()),
+      },
+      Node: {
+        __resolveType: () => 'User',
+      },
+    },
+  });
+  const userSchema = makeExecutableSchema({
+    typeDefs: /* GraphQL */ `
+      scalar _Any
+      type Query {
+        _entities(representations: [_Any!]!): [_Entity]!
+      }
+      union _Entity = User
+      interface Node {
+        id: ID!
+      }
+      type User implements Node {
+        id: ID!
+        name: String!
+      }
+    `,
+    resolvers: {
+      Query: {
+        _entities: (_, { representations }) =>
+          representations.map(({ __typename, id }: Node) =>
+            nodes.find(
+              node => node.__typename === __typename && node.id.toString() === id.toString(),
+            ),
+          ),
+      },
+      User: {
+        __isTypeOf: (obj: Node) => obj.__typename === 'User',
+      },
+    },
+  });
+  const postSchema = makeExecutableSchema({
+    typeDefs: /* GraphQL */ `
+      scalar _Any
+      union _Entity = Post
+      type Query {
+        _entities(representations: [_Any!]!): [_Entity]!
+      }
+      interface Node {
+        id: ID!
+      }
+      type Post implements Node {
+        id: ID!
+        title: String!
+      }
+    `,
+    resolvers: {
+      Query: {
+        _entities: (_, { representations }) =>
+          representations.map(({ __typename, id }: Node) =>
+            nodes.find(
+              node => node.__typename === __typename && node.id.toString() === id.toString(),
+            ),
+          ),
+      },
+      Post: {
+        __isTypeOf: (obj: Node) => obj.__typename === 'Post',
+      },
+    },
+  });
+  const gatewaySchema = stitchSchemas({
+    subschemas: [
+      { name: 'Node', schema: nodeSchema },
+      {
+        name: 'User',
+        schema: userSchema,
+        merge: {
+          User: {
+            selectionSet: '{ id }',
+            fieldName: '_entities',
+            key: root => root,
+            argsFromKeys: representations => ({ representations }),
+          },
+        },
+      },
+      {
+        name: 'Post',
+        schema: postSchema,
+        merge: {
+          Post: {
+            selectionSet: '{ id }',
+            fieldName: '_entities',
+            key: root => root,
+            argsFromKeys: representations => ({ representations }),
+          },
+        },
+      },
+    ],
+  });
+  it('should work', async () => {
+    const result = await normalizedExecutor({
+      schema: gatewaySchema,
+      document: parse(/* GraphQL */ `
+        query {
+          node(id: "1") {
+            id
+            ... on User {
+              name
+            }
+          }
+        }
+      `),
+    });
+    expect(result).toEqual({
+      data: {
+        node: {
+          id: '1',
+          name: 'Alice',
+        },
+      },
+    });
+  });
+});


### PR DESCRIPTION

When there is a Node subschema, and others to resolve the rest of the entities by using a union resolver as in Federation like below, it was failing. This version fixes that issue.

```graphql
query {
  node(id: "1") {
    id # Fetches from Node
    ... on User {
      name # Fetches from User
    }
  }
}
```

```graphql
type Query {
  node(id: ID!): Node
}

interface Node {
  id: ID!
}

type User implements Node {
  id: ID!
}

type Post implements Node {
  id: ID!
}
```

```graphql
# User subschema
scalar _Any
type Query {
  _entities(representations: [_Any!]!): [_Entity]!
}
union _Entity = User
interface Node {
  id: ID!
}
type User implements Node {
  id: ID!
  name: String!
}
```

```graphql
# Post subschema
scalar _Any
union _Entity = Post
type Query {
  _entities(representations: [_Any!]!): [_Entity]!
}
interface Node {
  id: ID!
}
type Post implements Node {
  id: ID!
  title: String!
}
```
