### PR TITLE
Ignore unmerged fields

### DIFF
--- a/.changeset/olive-shirts-buy.md
+++ b/.changeset/olive-shirts-buy.md
@@ -1,0 +1,49 @@
+---
+"@graphql-tools/delegate": patch
+"@graphql-tools/stitch": patch
+---
+
+Ignore unmerged fields
+
+Let's say you have a gateway schema like nelow, and `id` is added to the query, only if the `age` is requested;
+
+```graphql
+# This will be sent as-is
+{
+  user {
+    name
+  }
+}
+```
+
+But the following will be transformed;
+```graphql
+{
+  user {
+    name
+    age
+  }
+}
+```
+Into
+```graphql
+{
+  user {
+    id
+    name
+    age
+  }
+}
+
+
+```graphql
+type Query {
+  user: User
+}
+
+type User {
+  id: ID! # is the key for all services
+  name: String!
+  age: Int! # This comes from another service
+}
+```

--- a/.changeset/olive-shirts-buy.md
+++ b/.changeset/olive-shirts-buy.md
@@ -5,7 +5,7 @@
 
 Ignore unmerged fields
 
-Let's say you have a gateway schema like nelow, and `id` is added to the query, only if the `age` is requested;
+Let's say you have a gateway schema like in the bottom, and `id` is added to the query, only if the `age` is requested;
 
 ```graphql
 # This will be sent as-is

--- a/packages/delegate/src/extractUnavailableFields.ts
+++ b/packages/delegate/src/extractUnavailableFields.ts
@@ -1,0 +1,138 @@
+import {
+  FieldNode,
+  getNamedType,
+  GraphQLField,
+  GraphQLInterfaceType,
+  GraphQLNamedOutputType,
+  GraphQLNamedType,
+  GraphQLObjectType,
+  GraphQLSchema,
+  isAbstractType,
+  isInterfaceType,
+  isLeafType,
+  isObjectType,
+  isUnionType,
+  Kind,
+  SelectionNode,
+  SelectionSetNode,
+} from 'graphql';
+import { Maybe, memoize4 } from '@graphql-tools/utils';
+
+export const extractUnavailableFieldsFromSelectionSet = memoize4(
+  function extractUnavailableFieldsFromSelectionSet(
+    schema: GraphQLSchema,
+    fieldType: GraphQLNamedOutputType,
+    fieldSelectionSet: SelectionSetNode,
+    shouldAdd: (
+      fieldType: GraphQLObjectType | GraphQLInterfaceType,
+      selection: FieldNode,
+    ) => boolean,
+  ) {
+    if (isLeafType(fieldType)) {
+      return [];
+    }
+    if (isUnionType(fieldType)) {
+      const unavailableSelections: SelectionNode[] = [];
+      for (const type of fieldType.getTypes()) {
+        // Exclude other inline fragments
+        const fieldSelectionExcluded: SelectionSetNode = {
+          ...fieldSelectionSet,
+          selections: fieldSelectionSet.selections.filter(selection =>
+            selection.kind === Kind.INLINE_FRAGMENT
+              ? selection.typeCondition
+                ? selection.typeCondition.name.value === type.name
+                : false
+              : true,
+          ),
+        };
+        unavailableSelections.push(
+          ...extractUnavailableFieldsFromSelectionSet(
+            schema,
+            type,
+            fieldSelectionExcluded,
+            shouldAdd,
+          ),
+        );
+      }
+      return unavailableSelections;
+    }
+    const subFields = fieldType.getFields();
+    const unavailableSelections: SelectionNode[] = [];
+    for (const selection of fieldSelectionSet.selections) {
+      if (selection.kind === Kind.FIELD) {
+        if (selection.name.value === '__typename') {
+          continue;
+        }
+        const fieldName = selection.name.value;
+        const selectionField = subFields[fieldName];
+        if (!selectionField) {
+          if (shouldAdd(fieldType, selection)) {
+            unavailableSelections.push(selection);
+          }
+        } else {
+          const unavailableSubFields = extractUnavailableFields(
+            schema,
+            selectionField,
+            selection,
+            shouldAdd,
+          );
+          if (unavailableSubFields.length) {
+            unavailableSelections.push({
+              ...selection,
+              selectionSet: {
+                kind: Kind.SELECTION_SET,
+                selections: unavailableSubFields,
+              },
+            });
+          }
+        }
+      } else if (selection.kind === Kind.INLINE_FRAGMENT) {
+        const subFieldType: Maybe<GraphQLNamedType> = selection.typeCondition
+          ? schema.getType(selection.typeCondition.name.value)
+          : fieldType;
+        if (
+          (isObjectType(subFieldType) || isInterfaceType(subFieldType)) &&
+          isAbstractType(fieldType) &&
+          schema.isSubType(fieldType, subFieldType)
+        ) {
+          const unavailableFields = extractUnavailableFieldsFromSelectionSet(
+            schema,
+            subFieldType,
+            selection.selectionSet,
+            shouldAdd,
+          );
+          if (unavailableFields.length) {
+            unavailableSelections.push({
+              ...selection,
+              selectionSet: {
+                kind: Kind.SELECTION_SET,
+                selections: unavailableFields,
+              },
+            });
+          }
+        } else {
+          unavailableSelections.push(selection);
+        }
+      }
+    }
+    return unavailableSelections;
+  },
+);
+
+export const extractUnavailableFields = memoize4(function extractUnavailableFields(
+  schema: GraphQLSchema,
+  field: GraphQLField<any, any>,
+  fieldNode: FieldNode,
+  shouldAdd: (fieldType: GraphQLObjectType | GraphQLInterfaceType, selection: FieldNode) => boolean,
+) {
+  if (fieldNode.selectionSet) {
+    const fieldType = getNamedType(field.type);
+    return extractUnavailableFieldsFromSelectionSet(
+      schema,
+      fieldType,
+      fieldNode.selectionSet,
+      shouldAdd,
+    );
+  }
+  return [];
+});

--- a/packages/delegate/src/index.ts
+++ b/packages/delegate/src/index.ts
@@ -8,3 +8,4 @@ export * from './mergeFields.js';
 export * from './resolveExternalValue.js';
 export * from './subschemaConfig.js';
 export * from './types.js';
+export * from './extractUnavailableFields.js';

--- a/packages/delegate/src/prepareGatewayDocument.ts
+++ b/packages/delegate/src/prepareGatewayDocument.ts
@@ -10,6 +10,7 @@ import {
   isAbstractType,
   isInterfaceType,
   isLeafType,
+  isObjectType,
   Kind,
   SelectionNode,
   SelectionSetNode,
@@ -121,7 +122,6 @@ function visitSelectionSet(
 ): SelectionSetNode {
   const newSelections = new Set<SelectionNode>();
   const maybeType = typeInfo.getParentType();
-
   if (maybeType != null) {
     const parentType: GraphQLNamedType = getNamedType(maybeType);
     const parentTypeName = parentType.name;
@@ -185,7 +185,7 @@ function visitSelectionSet(
         const fieldName = selection.name.value;
         let skipAddingDependencyNodes = false;
         // TODO: Optimization to prevent extra fields to the subgraph
-        if ('getFields' in parentType) {
+        if (isObjectType(parentType) || isInterfaceType(parentType)) {
           const fieldMap = parentType.getFields();
           const field = fieldMap[fieldName];
           if (field) {

--- a/packages/delegate/tests/extractUnavailableFields.test.ts
+++ b/packages/delegate/tests/extractUnavailableFields.test.ts
@@ -1,7 +1,7 @@
 import { getOperationAST, isObjectType, Kind, parse, print, SelectionSetNode } from 'graphql';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { stripWhitespaces } from '../../merge/tests/utils';
-import { extractUnavailableFields } from '../src/getFieldsNotInSubschema';
+import { extractUnavailableFields } from '../src/extractUnavailableFields';
 
 describe('extractUnavailableFields', () => {
   it('should extract correct fields', () => {

--- a/packages/delegate/tests/prepareGatewayDocument.test.ts
+++ b/packages/delegate/tests/prepareGatewayDocument.test.ts
@@ -1,0 +1,248 @@
+import { parse, print } from 'graphql';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { stitchSchemas } from '@graphql-tools/stitch';
+import { prepareGatewayDocument } from '../src/prepareGatewayDocument';
+import '../../testing/to-be-similar-gql-doc';
+
+describe('prepareGatewayDocument', () => {
+  const posts = [
+    { id: '1', title: 'The Post1', user: { id: '1' } },
+    { id: '2', title: 'The Post2', user: { id: '2' } },
+  ];
+  const users = [
+    { id: '1', name: 'The User1', posts: [posts[0]] },
+    { id: '2', name: 'The User2', posts: [posts[1]] },
+  ];
+  const userSchema = makeExecutableSchema({
+    typeDefs: /* GraphQL */ `
+      type User {
+        id: ID!
+        name: String!
+      }
+      type Query {
+        userById(id: ID!): User
+      }
+    `,
+    resolvers: {
+      Query: {
+        userById: (_root, { id }) => {
+          const foundUser = users.find(user => user.id === id);
+          if (!foundUser) {
+            return null;
+          }
+          return {
+            id: foundUser.id,
+            name: foundUser.name,
+          };
+        },
+      },
+    },
+  });
+  const postSchema = makeExecutableSchema({
+    typeDefs: /* GraphQL */ `
+      type Post {
+        id: ID!
+        title: String!
+        user: User
+      }
+      type User {
+        id: ID!
+        posts: [Post]
+      }
+      type Query {
+        postById(id: ID!): Post
+        userByIdWithPosts(id: ID!): User
+      }
+    `,
+    resolvers: {
+      Query: {
+        postById: (_root, { id }) => posts.find(post => post.id === id),
+        userByIdWithPosts: (_root, { id }) => {
+          const foundUser = users.find(user => user.id === id);
+          if (!foundUser) {
+            return null;
+          }
+          return {
+            id: foundUser.id,
+            posts: foundUser.posts,
+          };
+        },
+      },
+    },
+  });
+  const gatewaySchema = stitchSchemas({
+    subschemas: [
+      {
+        schema: userSchema,
+        merge: {
+          User: {
+            selectionSet: '{ id }',
+            fieldName: 'userById',
+            args: ({ id }: (typeof users)[0]) => ({ id }),
+          },
+        },
+      },
+      {
+        schema: userSchema,
+        merge: {
+          User: {
+            selectionSet: '{ id }',
+            fieldName: 'userByIdWithPosts',
+            args: ({ id }: (typeof users)[0]) => ({ id }),
+          },
+        },
+      },
+    ],
+  });
+  it('adds required selection sets if it is a merged field', () => {
+    const posts = [
+      { id: '1', title: 'The Post1', user: { id: '1' } },
+      { id: '2', title: 'The Post2', user: { id: '2' } },
+    ];
+    const users = [
+      { id: '1', name: 'The User1', posts: [posts[0]] },
+      { id: '2', name: 'The User2', posts: [posts[1]] },
+    ];
+    const userSchema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        type User {
+          id: ID!
+          name: String!
+        }
+        type Query {
+          userById(id: ID!): User
+        }
+      `,
+      resolvers: {
+        Query: {
+          userById: (_root, { id }) => {
+            const foundUser = users.find(user => user.id === id);
+            if (!foundUser) {
+              return null;
+            }
+            return {
+              id: foundUser.id,
+              name: foundUser.name,
+            };
+          },
+        },
+      },
+    });
+    const postSchema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        type Post {
+          id: ID!
+          title: String!
+          user: User
+        }
+        type User {
+          id: ID!
+          posts: [Post]
+        }
+        type Query {
+          postById(id: ID!): Post
+          userByIdWithPosts(id: ID!): User
+        }
+      `,
+      resolvers: {
+        Query: {
+          postById: (_root, { id }) => posts.find(post => post.id === id),
+          userByIdWithPosts: (_root, { id }) => {
+            const foundUser = users.find(user => user.id === id);
+            if (!foundUser) {
+              return null;
+            }
+            return {
+              id: foundUser.id,
+              posts: foundUser.posts,
+            };
+          },
+        },
+      },
+    });
+    const gatewaySchema = stitchSchemas({
+      subschemas: [
+        {
+          schema: userSchema,
+          merge: {
+            User: {
+              selectionSet: '{ id }',
+              fieldName: 'userById',
+              args: ({ id }: (typeof users)[0]) => ({ id }),
+            },
+          },
+        },
+        {
+          schema: userSchema,
+          merge: {
+            User: {
+              selectionSet: '{ id }',
+              fieldName: 'userByIdWithPosts',
+              args: ({ id }: (typeof users)[0]) => ({ id }),
+            },
+          },
+        },
+      ],
+    });
+    const originalDocument = parse(/* GraphQL */ `
+      query {
+        userByIdWithPosts(id: "1") {
+          name
+          posts {
+            id
+            title
+          }
+        }
+      }
+    `);
+    const preparedDocument = prepareGatewayDocument(
+      originalDocument,
+      postSchema,
+      postSchema.getQueryType()!,
+      gatewaySchema,
+    );
+    expect(print(preparedDocument)).toBeSimilarGqlDoc(/* GraphQL */ `
+      query {
+        __typename
+        userByIdWithPosts(id: "1") {
+          __typename
+          id
+          name
+          posts {
+            id
+            title
+          }
+        }
+      }
+    `);
+  });
+  it('does not add required selection sets if it is not a merged field', () => {
+    const originalDocument = parse(/* GraphQL */ `
+      query {
+        userByIdWithPosts(id: "1") {
+          posts {
+            id
+            title
+          }
+        }
+      }
+    `);
+    const preparedDocument = prepareGatewayDocument(
+      originalDocument,
+      postSchema,
+      postSchema.getQueryType()!,
+      gatewaySchema,
+    );
+    expect(print(preparedDocument)).toBeSimilarGqlDoc(/* GraphQL */ `
+      query {
+        __typename
+        userByIdWithPosts(id: "1") {
+          posts {
+            id
+            title
+          }
+        }
+      }
+    `);
+  });
+});

--- a/packages/stitch/src/createDelegationPlanBuilder.ts
+++ b/packages/stitch/src/createDelegationPlanBuilder.ts
@@ -10,12 +10,13 @@ import {
 } from 'graphql';
 import {
   DelegationPlanBuilder,
+  extractUnavailableFields,
   MergedTypeInfo,
   StitchingInfo,
   Subschema,
 } from '@graphql-tools/delegate';
 import { memoize1, memoize2, memoize3, memoize5 } from '@graphql-tools/utils';
-import { extractUnavailableFields, getFieldsNotInSubschema } from './getFieldsNotInSubschema.js';
+import { getFieldsNotInSubschema } from './getFieldsNotInSubschema.js';
 
 function calculateDelegationStage(
   mergedTypeInfo: MergedTypeInfo,

--- a/packages/stitch/src/getFieldsNotInSubschema.ts
+++ b/packages/stitch/src/getFieldsNotInSubschema.ts
@@ -1,24 +1,13 @@
 import {
   FieldNode,
   FragmentDefinitionNode,
-  getNamedType,
-  GraphQLField,
-  GraphQLInterfaceType,
   GraphQLNamedOutputType,
-  GraphQLNamedType,
   GraphQLObjectType,
   GraphQLSchema,
-  isAbstractType,
-  isInterfaceType,
-  isLeafType,
-  isObjectType,
-  isUnionType,
   Kind,
-  SelectionNode,
-  SelectionSetNode,
 } from 'graphql';
-import { StitchingInfo } from '@graphql-tools/delegate';
-import { collectSubFields, Maybe } from '@graphql-tools/utils';
+import { extractUnavailableFields, StitchingInfo } from '@graphql-tools/delegate';
+import { collectSubFields } from '@graphql-tools/utils';
 
 export function getFieldsNotInSubschema(
   schema: GraphQLSchema,
@@ -39,6 +28,8 @@ export function getFieldsNotInSubschema(
 
   // TODO: Verify whether it is safe that extensions always exists.
   const fieldNodesByField = stitchingInfo?.fieldNodesByField;
+  const shouldAdd = (fieldType: GraphQLNamedOutputType, selection: FieldNode) =>
+    !fieldNodesByField?.[fieldType.name]?.[selection.name.value];
 
   const fields = subschemaType.getFields();
 
@@ -52,12 +43,7 @@ export function getFieldsNotInSubschema(
     } else {
       const field = fields[fieldName];
       for (const subFieldNode of subFieldNodes) {
-        const unavailableFields = extractUnavailableFields(
-          schema,
-          field,
-          subFieldNode,
-          (fieldType, selection) => !fieldNodesByField?.[fieldType.name]?.[selection.name.value],
-        );
+        const unavailableFields = extractUnavailableFields(schema, field, subFieldNode, shouldAdd);
         if (unavailableFields.length) {
           fieldsNotInSchema.add({
             ...subFieldNode,
@@ -84,118 +70,4 @@ export function getFieldsNotInSubschema(
   }
 
   return Array.from(fieldsNotInSchema);
-}
-
-export function extractUnavailableFieldsFromSelectionSet(
-  schema: GraphQLSchema,
-  fieldType: GraphQLNamedOutputType,
-  fieldSelectionSet: SelectionSetNode,
-  shouldAdd: (fieldType: GraphQLObjectType | GraphQLInterfaceType, selection: FieldNode) => boolean,
-) {
-  if (isLeafType(fieldType)) {
-    return [];
-  }
-  if (isUnionType(fieldType)) {
-    const unavailableSelections: SelectionNode[] = [];
-    for (const type of fieldType.getTypes()) {
-      // Exclude other inline fragments
-      const fieldSelectionExcluded: SelectionSetNode = {
-        ...fieldSelectionSet,
-        selections: fieldSelectionSet.selections.filter(selection =>
-          selection.kind === Kind.INLINE_FRAGMENT
-            ? selection.typeCondition
-              ? selection.typeCondition.name.value === type.name
-              : false
-            : true,
-        ),
-      };
-      unavailableSelections.push(
-        ...extractUnavailableFieldsFromSelectionSet(
-          schema,
-          type,
-          fieldSelectionExcluded,
-          shouldAdd,
-        ),
-      );
-    }
-    return unavailableSelections;
-  }
-  const subFields = fieldType.getFields();
-  const unavailableSelections: SelectionNode[] = [];
-  for (const selection of fieldSelectionSet.selections) {
-    if (selection.kind === Kind.FIELD) {
-      if (selection.name.value === '__typename') {
-        continue;
-      }
-      const fieldName = selection.name.value;
-      const selectionField = subFields[fieldName];
-      if (!selectionField) {
-        if (shouldAdd(fieldType, selection)) {
-          unavailableSelections.push(selection);
-        }
-      } else {
-        const unavailableSubFields = extractUnavailableFields(
-          schema,
-          selectionField,
-          selection,
-          shouldAdd,
-        );
-        if (unavailableSubFields.length) {
-          unavailableSelections.push({
-            ...selection,
-            selectionSet: {
-              kind: Kind.SELECTION_SET,
-              selections: unavailableSubFields,
-            },
-          });
-        }
-      }
-    } else if (selection.kind === Kind.INLINE_FRAGMENT) {
-      const subFieldType: Maybe<GraphQLNamedType> = selection.typeCondition
-        ? schema.getType(selection.typeCondition.name.value)
-        : fieldType;
-      if (
-        (isObjectType(subFieldType) || isInterfaceType(subFieldType)) &&
-        isAbstractType(fieldType) &&
-        schema.isSubType(fieldType, subFieldType)
-      ) {
-        const unavailableFields = extractUnavailableFieldsFromSelectionSet(
-          schema,
-          subFieldType,
-          selection.selectionSet,
-          shouldAdd,
-        );
-        if (unavailableFields.length) {
-          unavailableSelections.push({
-            ...selection,
-            selectionSet: {
-              kind: Kind.SELECTION_SET,
-              selections: unavailableFields,
-            },
-          });
-        }
-      } else {
-        unavailableSelections.push(selection);
-      }
-    }
-  }
-  return unavailableSelections;
-}
-
-export function extractUnavailableFields(
-  schema: GraphQLSchema,
-  field: GraphQLField<any, any>,
-  fieldNode: FieldNode,
-  shouldAdd: (fieldType: GraphQLObjectType | GraphQLInterfaceType, selection: FieldNode) => boolean,
-) {
-  if (fieldNode.selectionSet) {
-    const fieldType = getNamedType(field.type);
-    return extractUnavailableFieldsFromSelectionSet(
-      schema,
-      fieldType,
-      fieldNode.selectionSet,
-      shouldAdd,
-    );
-  }
-  return [];
 }

--- a/packages/stitch/tests/mergeFailures.test.ts
+++ b/packages/stitch/tests/mergeFailures.test.ts
@@ -229,7 +229,7 @@ describe('merge failures', () => {
 
     const expectedResult: ExecutionResult = {
       data: { thing: null },
-      errors: [createGraphQLError('Cannot return null for non-nullable field Thing.id.')],
+      errors: [createGraphQLError('Cannot return null for non-nullable field Thing.description.')],
     };
 
     expect(result).toEqual(expectedResult);


### PR DESCRIPTION
If a field is not going to be used for type merging in the following calls, do not add it to the final query to the subgraph.

See the changeset for the example