### PR TITLE
feat(delegate): deduplicate upstream documents

### DIFF
--- a/.changeset/blue-camels-camp.md
+++ b/.changeset/blue-camels-camp.md
@@ -1,0 +1,5 @@
+---
+"@graphql-tools/delegate": patch
+---
+
+Deduplicate fields, inline fragment spreads and fragment spreads before sending the operation document to the subschema

--- a/packages/batch-execute/tests/batchExecute.test.ts
+++ b/packages/batch-execute/tests/batchExecute.test.ts
@@ -126,8 +126,7 @@ describe('batch execution', () => {
     ])) as ExecutionResult[];
 
     const squishedDoc = executorDocument?.replace(/\s+/g, ' ');
-    expect(squishedDoc).toMatch('... on Query { _0_field1: field1 }');
-    expect(squishedDoc).toMatch('... on Query { _1_field2: field2 }');
+    expect(squishedDoc).toMatch('... on Query { _0_field1: field1 _1_field2: field2 }');
     expect(first?.data).toEqual({ field1: '1' });
     expect(second?.data).toEqual({ field2: '2' });
     expect(executorCalls).toEqual(1);

--- a/packages/delegate/src/createRequest.ts
+++ b/packages/delegate/src/createRequest.ts
@@ -11,7 +11,6 @@ import {
   NameNode,
   OperationDefinitionNode,
   OperationTypeNode,
-  SelectionNode,
   SelectionSetNode,
   typeFromAST,
   VariableDefinitionNode,
@@ -19,6 +18,7 @@ import {
 import {
   createVariableNameGenerator,
   ExecutionRequest,
+  SelectionSetBuilder,
   serializeInputValue,
   updateArgument,
 } from '@graphql-tools/utils';
@@ -59,21 +59,16 @@ export function createRequest({
   if (selectionSet != null) {
     newSelectionSet = selectionSet;
   } else {
-    const selections: Array<SelectionNode> = [];
+    const selections = new SelectionSetBuilder();
     for (const fieldNode of fieldNodes || []) {
       if (fieldNode.selectionSet) {
         for (const selection of fieldNode.selectionSet.selections) {
-          selections.push(selection);
+          selections.addSelection(selection);
         }
       }
     }
 
-    newSelectionSet = selections.length
-      ? {
-          kind: Kind.SELECTION_SET,
-          selections,
-        }
-      : undefined;
+    newSelectionSet = selections.getSize() ? selections.getSelectionSet() : undefined;
 
     const args = fieldNodes?.[0]?.arguments;
     if (args) {

--- a/packages/delegate/src/finalizeGatewayRequest.ts
+++ b/packages/delegate/src/finalizeGatewayRequest.ts
@@ -28,6 +28,7 @@ import {
   getDefinedRootType,
   implementsAbstractType,
   inspect,
+  SelectionSetBuilder,
   serializeInputValue,
   updateArgument,
 } from '@graphql-tools/utils';
@@ -179,7 +180,7 @@ function addVariablesToRootFields(
 
     const type = getDefinedRootType(targetSchema, operation.operation);
 
-    const newSelections: Array<SelectionNode> = [];
+    const selectionSetBuilder = new SelectionSetBuilder();
 
     for (const selection of operation.selectionSet.selections) {
       if (selection.kind === Kind.FIELD) {
@@ -198,25 +199,19 @@ function addVariablesToRootFields(
         if (targetField != null) {
           updateArguments(targetField, argumentNodeMap, variableDefinitionMap, newVariables, args);
         }
-
-        newSelections.push({
+        selectionSetBuilder.addSelection({
           ...selection,
           arguments: Object.values(argumentNodeMap),
         });
       } else {
-        newSelections.push(selection);
+        selectionSetBuilder.addSelection(selection);
       }
     }
-
-    const newSelectionSet: SelectionSetNode = {
-      kind: Kind.SELECTION_SET,
-      selections: newSelections,
-    };
 
     return {
       ...operation,
       variableDefinitions: Object.values(variableDefinitionMap),
-      selectionSet: newSelectionSet,
+      selectionSet: selectionSetBuilder.getSelectionSet(),
     };
   });
 

--- a/packages/utils/src/SelectionSetBuilder.ts
+++ b/packages/utils/src/SelectionSetBuilder.ts
@@ -1,0 +1,101 @@
+import { FieldNode, Kind, SelectionNode, SelectionSetNode } from 'graphql';
+
+export class SelectionSetBuilder {
+  fieldNodeMap = new Map<string, FieldNode>();
+  fieldSelections = new Map<string, SelectionSetBuilder>();
+  fragmentSpreads = new Set<string>();
+  inlineFragments = new Map<string, SelectionSetBuilder>();
+  constructor() {}
+  addSelection(selection: SelectionNode) {
+    switch (selection.kind) {
+      case Kind.FRAGMENT_SPREAD: {
+        this.fragmentSpreads.add(selection.name.value);
+        break;
+      }
+      case Kind.INLINE_FRAGMENT: {
+        if (!selection.typeCondition) {
+          for (const subSelection of selection.selectionSet.selections) {
+            this.addSelection(subSelection);
+          }
+          break;
+        }
+        let inlineFragmentBuilder = this.inlineFragments.get(selection.typeCondition.name.value);
+        if (!inlineFragmentBuilder) {
+          inlineFragmentBuilder = new SelectionSetBuilder();
+          this.inlineFragments.set(selection.typeCondition.name.value, inlineFragmentBuilder);
+        }
+        for (const subSelection of selection.selectionSet.selections) {
+          if (subSelection.kind === Kind.FIELD && this.fieldNodeMap.has(subSelection.name.value)) {
+            if (subSelection.selectionSet) {
+              let fieldSelections = this.fieldSelections.get(subSelection.name.value);
+              if (!fieldSelections) {
+                fieldSelections = new SelectionSetBuilder();
+                this.fieldSelections.set(subSelection.name.value, fieldSelections);
+              }
+              for (const subSubSelection of subSelection.selectionSet.selections) {
+                fieldSelections.addSelection(subSubSelection);
+              }
+            }
+            continue;
+          }
+          inlineFragmentBuilder.addSelection(subSelection);
+        }
+        break;
+      }
+      case Kind.FIELD: {
+        const responseKey = selection.alias?.value || selection.name.value;
+        this.fieldNodeMap.set(responseKey, selection);
+        let fieldSelections = this.fieldSelections.get(responseKey);
+        if (!fieldSelections) {
+          fieldSelections = new SelectionSetBuilder();
+          this.fieldSelections.set(responseKey, fieldSelections);
+        }
+        if (selection.selectionSet) {
+          for (const subSelection of selection.selectionSet.selections) {
+            fieldSelections.addSelection(subSelection);
+          }
+        }
+        break;
+      }
+    }
+  }
+
+  getSelectionSet(): SelectionSetNode {
+    const selections: SelectionNode[] = [];
+    for (const fieldNode of this.fieldNodeMap.values()) {
+      selections.push(fieldNode);
+    }
+    for (const fragmentSpread of this.fragmentSpreads) {
+      selections.push({
+        kind: Kind.FRAGMENT_SPREAD,
+        name: {
+          kind: Kind.NAME,
+          value: fragmentSpread,
+        },
+      });
+    }
+    for (const [typeName, inlineFragmentBuilder] of this.inlineFragments) {
+      if (inlineFragmentBuilder.getSize() > 0) {
+        selections.push({
+          kind: Kind.INLINE_FRAGMENT,
+          typeCondition: {
+            kind: Kind.NAMED_TYPE,
+            name: {
+              kind: Kind.NAME,
+              value: typeName,
+            },
+          },
+          selectionSet: inlineFragmentBuilder.getSelectionSet(),
+        });
+      }
+    }
+    return {
+      kind: Kind.SELECTION_SET,
+      selections,
+    };
+  }
+
+  getSize() {
+    return this.fieldNodeMap.size + this.fragmentSpreads.size + this.inlineFragments.size;
+  }
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -54,3 +54,4 @@ export * from './jsutils.js';
 export * from './directives.js';
 export * from './mergeIncrementalResult.js';
 export * from './debugTimer.js';
+export * from './SelectionSetBuilder.js';

--- a/packages/utils/tests/SelectionSetBuilder.test.ts
+++ b/packages/utils/tests/SelectionSetBuilder.test.ts
@@ -1,0 +1,191 @@
+import { Kind, print } from 'graphql';
+import { SelectionSetBuilder } from '../src/SelectionSetBuilder';
+import '../../testing/to-be-similar-gql-doc';
+import { parseSelectionSet } from '../src/selectionSets';
+
+describe('SelectionSetBuilder', () => {
+  it('deduplicate fields', () => {
+    const selectionSetBuilder = new SelectionSetBuilder();
+    selectionSetBuilder.addSelection({
+      kind: Kind.FIELD,
+      name: {
+        kind: Kind.NAME,
+        value: 'a',
+      },
+    });
+    selectionSetBuilder.addSelection({
+      kind: Kind.FIELD,
+      name: {
+        kind: Kind.NAME,
+        value: 'b',
+      },
+    });
+    selectionSetBuilder.addSelection({
+      kind: Kind.FIELD,
+      name: {
+        kind: Kind.NAME,
+        value: 'a',
+      },
+    });
+    expect(selectionSetBuilder.getSelectionSet()).toMatchObject({
+      selections: [
+        { kind: 'Field', name: { value: 'a' } },
+        { kind: 'Field', name: { value: 'b' } },
+      ],
+    });
+  });
+  it('deduplicate fragment spreads', () => {
+    const selectionSetBuilder = new SelectionSetBuilder();
+    selectionSetBuilder.addSelection({
+      kind: Kind.FRAGMENT_SPREAD,
+      name: {
+        kind: Kind.NAME,
+        value: 'a',
+      },
+    });
+    selectionSetBuilder.addSelection({
+      kind: Kind.FRAGMENT_SPREAD,
+      name: {
+        kind: Kind.NAME,
+        value: 'b',
+      },
+    });
+    selectionSetBuilder.addSelection({
+      kind: Kind.FRAGMENT_SPREAD,
+      name: {
+        kind: Kind.NAME,
+        value: 'a',
+      },
+    });
+    expect(selectionSetBuilder.getSelectionSet()).toMatchObject({
+      selections: [
+        { kind: 'FragmentSpread', name: { value: 'a' } },
+        { kind: 'FragmentSpread', name: { value: 'b' } },
+      ],
+    });
+  });
+  it('deduplicate inline fragments', () => {
+    const selectionSetBuilder = new SelectionSetBuilder();
+    selectionSetBuilder.addSelection({
+      kind: Kind.INLINE_FRAGMENT,
+      typeCondition: {
+        kind: Kind.NAMED_TYPE,
+        name: {
+          kind: Kind.NAME,
+          value: 'a',
+        },
+      },
+      selectionSet: {
+        kind: Kind.SELECTION_SET,
+        selections: [
+          {
+            kind: Kind.FIELD,
+            name: {
+              kind: Kind.NAME,
+              value: 'a',
+            },
+          },
+        ],
+      },
+    });
+    selectionSetBuilder.addSelection({
+      kind: Kind.INLINE_FRAGMENT,
+      typeCondition: {
+        kind: Kind.NAMED_TYPE,
+        name: {
+          kind: Kind.NAME,
+          value: 'a',
+        },
+      },
+      selectionSet: {
+        kind: Kind.SELECTION_SET,
+        selections: [
+          {
+            kind: Kind.FIELD,
+            name: {
+              kind: Kind.NAME,
+              value: 'b',
+            },
+          },
+        ],
+      },
+    });
+    selectionSetBuilder.addSelection({
+      kind: Kind.INLINE_FRAGMENT,
+      typeCondition: {
+        kind: Kind.NAMED_TYPE,
+        name: {
+          kind: Kind.NAME,
+          value: 'a',
+        },
+      },
+      selectionSet: {
+        kind: Kind.SELECTION_SET,
+        selections: [
+          {
+            kind: Kind.FIELD,
+            name: {
+              kind: Kind.NAME,
+              value: 'a',
+            },
+          },
+        ],
+      },
+    });
+    expect(selectionSetBuilder.getSelectionSet()).toMatchObject({
+      selections: [
+        {
+          kind: 'InlineFragment',
+          typeCondition: { kind: 'NamedType', name: { value: 'a' } },
+          selectionSet: {
+            selections: [
+              { kind: 'Field', name: { value: 'a' } },
+              { kind: 'Field', name: { value: 'b' } },
+            ],
+          },
+        },
+      ],
+    });
+  });
+  it('deduplicate inline fragments and fields', () => {
+    const selectionSetBuilder = new SelectionSetBuilder();
+    const selectionSet = parseSelectionSet(
+      /* GraphQL */ `
+        {
+          __typename
+          id
+          ... on User {
+            __typename
+            id
+            name
+          }
+          ... on Post {
+            __typename
+            id
+            title
+          }
+          ... {
+            extensions
+          }
+        }
+      `,
+      { noLocation: true },
+    );
+    for (const selection of selectionSet.selections) {
+      selectionSetBuilder.addSelection(selection);
+    }
+    expect(print(selectionSetBuilder.getSelectionSet())).toBeSimilarGqlDoc(/* GraphQL */ `
+      {
+        __typename
+        id
+        extensions
+        ... on User {
+          name
+        }
+        ... on Post {
+          title
+        }
+      }
+    `);
+  });
+});


### PR DESCRIPTION
Deduplicate fields, inline fragment spreads and fragment spreads before sending the operation document to the subschema

See tests for the use cases