### PR TITLE
Exposing the delegation plan for debugging purposes

### DIFF
--- a/.changeset/ten-eggs-run.md
+++ b/.changeset/ten-eggs-run.md
@@ -1,0 +1,22 @@
+---
+"@graphql-tools/delegate": patch
+"@graphql-tools/stitch": patch
+---
+
+Debugging the delegation plan;
+
+After you enable the environment variable, `EXPOSE_DELEGATION_PLAN`, you can see the delegation plan in the console. This can be useful for debugging and understanding how the delegation works.
+
+Also you can pass a different logger to it by using `logFnForContext` map from `@graphql-tools/delegate` package.
+
+```ts
+import { logFnForContext } from '@graphql-tools/delegate';
+logFnForContext.set(MyGraphQLContext, console.log);
+```
+
+You can also add a `contextId` for that specific gateway request by using `contextIdMap` map from `@graphql-tools/delegate` package.
+
+```ts
+import { contextIdMap } from '@graphql-tools/delegate';
+contextIdMap.set(MyGraphQLContext, 'my-request-id');
+```

--- a/.changeset/ten-eggs-run.md
+++ b/.changeset/ten-eggs-run.md
@@ -20,3 +20,11 @@ You can also add a `contextId` for that specific gateway request by using `conte
 import { contextIdMap } from '@graphql-tools/delegate';
 contextIdMap.set(MyGraphQLContext, 'my-request-id');
 ```
+
+If you want to use those information instead of logging, you can get them by using the `context` object like below;
+
+```ts
+import { delegationPlanInfosByContext } from '@graphql-tools/delegate';
+const delegationPlanInfos = delegationPlanInfosByContext.get(context);
+```
+

--- a/packages/delegate/src/debugging.ts
+++ b/packages/delegate/src/debugging.ts
@@ -1,0 +1,35 @@
+import { SelectionSetNode } from 'graphql';
+import { Subschema } from './Subschema.js';
+
+export interface DelegationPlanInfo {
+  contextId?: string;
+  operationName?: string;
+  planId: string;
+  source?: string;
+  type?: string;
+  path: (string | number)[];
+  fieldNodes?: string[];
+  fragments: string[];
+  stages: {
+    stageId: string;
+    delegations: {
+      target?: string;
+      selectionSet: string;
+    }[];
+  }[];
+}
+
+export const delegationPlanIdMap = new WeakMap<
+  Map<Subschema<any, any, any, Record<string, any>>, SelectionSetNode>[],
+  string
+>();
+export const delegationStageIdMap = new WeakMap<
+  Map<Subschema<any, any, any, Record<string, any>>, SelectionSetNode>,
+  string
+>();
+export const logFnForContext = new WeakMap<any, (data: any) => void>();
+export const delegationPlanInfosByContext = new WeakMap<any, Set<DelegationPlanInfo>>();
+export const contextIdMap = new WeakMap<any, string>();
+export function isDelegationDebugging() {
+  return globalThis.process?.env['EXPOSE_DELEGATION_PLAN'];
+}

--- a/packages/delegate/src/debugging.ts
+++ b/packages/delegate/src/debugging.ts
@@ -1,5 +1,5 @@
 import { GraphQLResolveInfo, print, responsePathAsArray, SelectionSetNode } from 'graphql';
-import { memoize2of5, memoize5 } from '@graphql-tools/utils';
+import { memoize2of5 } from '@graphql-tools/utils';
 import { Subschema } from './Subschema.js';
 import { MergedTypeInfo } from './types.js';
 

--- a/packages/delegate/src/index.ts
+++ b/packages/delegate/src/index.ts
@@ -8,3 +8,4 @@ export * from './mergeFields.js';
 export * from './resolveExternalValue.js';
 export * from './subschemaConfig.js';
 export * from './types.js';
+export * from './debugging.js';

--- a/packages/federation/test/__snapshots__/debug-logging.test.ts.snap
+++ b/packages/federation/test/__snapshots__/debug-logging.test.ts.snap
@@ -1,0 +1,301 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Debug Logging should expose delegation plan correctly by context: delegationInfos 1`] = `
+Set {
+  {
+    "contextId": undefined,
+    "fieldNodes": [
+      "users {
+  ...User
+  reviews {
+    ...Review
+    product {
+      ...Product
+      reviews {
+        ...Review
+        author {
+          ...User
+          reviews {
+            ...Review
+            product {
+              ...Product
+            }
+          }
+        }
+      }
+    }
+  }
+}",
+    ],
+    "fragments": [
+      "fragment User on User {
+  id
+  username
+  name
+}",
+      "fragment Review on Review {
+  id
+  body
+}",
+      "fragment Product on Product {
+  inStock
+  name
+  price
+  shippingEstimate
+  upc
+  weight
+}",
+    ],
+    "operationName": "TestQuery",
+    "path": [
+      "users",
+    ],
+    "planId": "4g00coussmu",
+    "source": "accounts",
+    "stages": [
+      {
+        "delegations": [
+          {
+            "selectionSet": "{
+  reviews {
+    ...Review
+    product {
+      ...Product
+      reviews {
+        ...Review
+        author {
+          ...User
+          reviews {
+            ...Review
+            product {
+              ...Product
+            }
+          }
+        }
+      }
+    }
+  }
+}",
+            "target": "reviews",
+          },
+        ],
+        "stageId": "4fzyo82mvyq",
+      },
+    ],
+    "type": "User",
+  },
+  {
+    "contextId": undefined,
+    "fieldNodes": [
+      "product {
+  ...Product
+  reviews {
+    ...Review
+    author {
+      ...User
+      reviews {
+        ...Review
+        product {
+          ...Product
+        }
+      }
+    }
+  }
+}",
+    ],
+    "fragments": [
+      "fragment User on User {
+  id
+  username
+  name
+}",
+      "fragment Review on Review {
+  id
+  body
+}",
+      "fragment Product on Product {
+  inStock
+  name
+  price
+  shippingEstimate
+  upc
+  weight
+}",
+    ],
+    "operationName": "TestQuery",
+    "path": [
+      "users",
+      "reviews",
+      "product",
+    ],
+    "planId": "4g05e37ain",
+    "source": "reviews",
+    "stages": [
+      {
+        "delegations": [
+          {
+            "selectionSet": "{
+  inStock
+}",
+            "target": "inventory",
+          },
+          {
+            "selectionSet": "{
+  name
+  price
+  price
+  weight
+  weight
+}",
+            "target": "products",
+          },
+        ],
+        "stageId": "4g0215mypav",
+      },
+      {
+        "delegations": [
+          {
+            "selectionSet": "{
+  shippingEstimate
+}",
+            "target": "inventory",
+          },
+        ],
+        "stageId": "4g03pmf4lz",
+      },
+    ],
+    "type": "Product",
+  },
+  {
+    "contextId": undefined,
+    "fieldNodes": [
+      "author {
+  ...User
+  reviews {
+    ...Review
+    product {
+      ...Product
+    }
+  }
+}",
+    ],
+    "fragments": [
+      "fragment User on User {
+  id
+  username
+  name
+}",
+      "fragment Review on Review {
+  id
+  body
+}",
+      "fragment Product on Product {
+  inStock
+  name
+  price
+  shippingEstimate
+  upc
+  weight
+}",
+    ],
+    "operationName": "TestQuery",
+    "path": [
+      "users",
+      "reviews",
+      "product",
+      "reviews",
+      "author",
+    ],
+    "planId": "4g08r0rmbz6",
+    "source": "reviews",
+    "stages": [
+      {
+        "delegations": [
+          {
+            "selectionSet": "{
+  name
+}",
+            "target": "accounts",
+          },
+        ],
+        "stageId": "4g072jzgfb2",
+      },
+    ],
+    "type": "User",
+  },
+  {
+    "contextId": undefined,
+    "fieldNodes": [
+      "product {
+  ...Product
+}",
+    ],
+    "fragments": [
+      "fragment User on User {
+  id
+  username
+  name
+}",
+      "fragment Review on Review {
+  id
+  body
+}",
+      "fragment Product on Product {
+  inStock
+  name
+  price
+  shippingEstimate
+  upc
+  weight
+}",
+    ],
+    "operationName": "TestQuery",
+    "path": [
+      "users",
+      "reviews",
+      "product",
+      "reviews",
+      "author",
+      "reviews",
+      "product",
+    ],
+    "planId": "4g0dsf441za",
+    "source": "reviews",
+    "stages": [
+      {
+        "delegations": [
+          {
+            "selectionSet": "{
+  inStock
+}",
+            "target": "inventory",
+          },
+          {
+            "selectionSet": "{
+  name
+  price
+  price
+  weight
+  weight
+}",
+            "target": "products",
+          },
+        ],
+        "stageId": "4g0afhjs8n8",
+      },
+      {
+        "delegations": [
+          {
+            "selectionSet": "{
+  shippingEstimate
+}",
+            "target": "inventory",
+          },
+        ],
+        "stageId": "4g0c3yby5b9",
+      },
+    ],
+    "type": "Product",
+  },
+}
+`;

--- a/packages/federation/test/debug-logging.test.ts
+++ b/packages/federation/test/debug-logging.test.ts
@@ -1,9 +1,9 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { parse } from 'graphql';
-import { buildSubgraphSchema } from '@apollo/subgraph';
 import { createDefaultExecutor, delegationPlanInfosByContext } from '@graphql-tools/delegate';
 import { normalizedExecutor } from '@graphql-tools/executor';
+import { buildSubgraphSchema } from '../src/subgraph';
 import { getStitchedSchemaFromSupergraphSdl } from '../src/supergraph';
 import * as accounts from './fixtures/gateway/accounts';
 import * as discount from './fixtures/gateway/discount';
@@ -11,15 +11,14 @@ import * as inventory from './fixtures/gateway/inventory';
 import * as products from './fixtures/gateway/products';
 import * as reviews from './fixtures/gateway/reviews';
 
-const services: Record<string, { typeDefs: string; resolvers: any }> = {
-  accounts,
-  inventory,
-  products,
-  reviews,
-  discount,
-};
-
 describe('Debug Logging', () => {
+  const services: Record<string, { typeDefs: string; resolvers: any }> = {
+    accounts,
+    inventory,
+    products,
+    reviews,
+    discount,
+  };
   const existingFlag = process.env['EXPOSE_DELEGATION_PLAN'];
   const existingMathRandom = Math.random;
   beforeEach(() => {

--- a/packages/federation/test/debug-logging.test.ts
+++ b/packages/federation/test/debug-logging.test.ts
@@ -1,0 +1,104 @@
+import { readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { parse } from 'graphql';
+import { buildSubgraphSchema } from '@apollo/subgraph';
+import { createDefaultExecutor, delegationPlanInfosByContext } from '@graphql-tools/delegate';
+import { normalizedExecutor } from '@graphql-tools/executor';
+import { getStitchedSchemaFromSupergraphSdl } from '../src/supergraph';
+import * as accounts from './fixtures/gateway/accounts';
+import * as discount from './fixtures/gateway/discount';
+import * as inventory from './fixtures/gateway/inventory';
+import * as products from './fixtures/gateway/products';
+import * as reviews from './fixtures/gateway/reviews';
+
+const services: Record<string, { typeDefs: string; resolvers: any }> = {
+  accounts,
+  inventory,
+  products,
+  reviews,
+  discount,
+};
+
+describe('Debug Logging', () => {
+  const existingFlag = process.env['EXPOSE_DELEGATION_PLAN'];
+  const existingMathRandom = Math.random;
+  beforeEach(() => {
+    process.env['EXPOSE_DELEGATION_PLAN'] = 'true';
+    let counter = 0;
+    Math.random = () => 0.123456 + counter++ * 0.000001;
+  });
+  afterEach(() => {
+    process.env['EXPOSE_DELEGATION_PLAN'] = existingFlag;
+    Math.random = existingMathRandom;
+  });
+  const exampleQuery = /* GraphQL */ `
+    fragment User on User {
+      id
+      username
+      name
+    }
+
+    fragment Review on Review {
+      id
+      body
+    }
+
+    fragment Product on Product {
+      inStock
+      name
+      price
+      shippingEstimate
+      upc
+      weight
+    }
+
+    query TestQuery {
+      users {
+        ...User
+        reviews {
+          ...Review
+          product {
+            ...Product
+            reviews {
+              ...Review
+              author {
+                ...User
+                reviews {
+                  ...Review
+                  product {
+                    ...Product
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+  const supergraphSdl = readFileSync(
+    join(__dirname, './fixtures/gateway/supergraph.graphql'),
+    'utf8',
+  );
+  const stitchedSchema = getStitchedSchemaFromSupergraphSdl({
+    supergraphSdl,
+    onExecutor({ subgraphName }) {
+      const schema = buildSubgraphSchema({
+        typeDefs: parse(services[subgraphName].typeDefs),
+        resolvers: services[subgraphName].resolvers,
+      });
+      return createDefaultExecutor(schema);
+    },
+  });
+  it('should expose delegation plan correctly by context', async () => {
+    const contextValue = {};
+    await normalizedExecutor({
+      schema: stitchedSchema,
+      document: parse(exampleQuery),
+      contextValue,
+    });
+    const delegationInfos = delegationPlanInfosByContext.get(contextValue);
+    expect(delegationInfos).toBeDefined();
+    expect(delegationInfos).toMatchSnapshot('delegationInfos');
+  });
+});

--- a/packages/federation/test/debug-logging.test.ts
+++ b/packages/federation/test/debug-logging.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from 'fs';
+import { readFileSync } from 'fs';
 import { join } from 'path';
 import { parse } from 'graphql';
 import { buildSubgraphSchema } from '@apollo/subgraph';

--- a/packages/stitch/src/createDelegationPlanBuilder.ts
+++ b/packages/stitch/src/createDelegationPlanBuilder.ts
@@ -10,6 +10,9 @@ import {
 } from 'graphql';
 import {
   DelegationPlanBuilder,
+  delegationPlanIdMap,
+  delegationStageIdMap,
+  isDelegationDebugging,
   MergedTypeInfo,
   StitchingInfo,
   Subschema,
@@ -246,6 +249,10 @@ export function createDelegationPlanBuilder(mergedTypeInfo: MergedTypeInfo): Del
     );
     let { delegationMap } = delegationStage;
     while (delegationMap.size) {
+      if (isDelegationDebugging()) {
+        const delegationStageId = Math.random().toString(36).slice(2);
+        delegationStageIdMap.set(delegationMap, delegationStageId);
+      }
       delegationMaps.push(delegationMap);
 
       const { proxiableSubschemas, nonProxiableSubschemas, unproxiableFieldNodes } =
@@ -260,6 +267,10 @@ export function createDelegationPlanBuilder(mergedTypeInfo: MergedTypeInfo): Del
         unproxiableFieldNodes,
       );
       delegationMap = delegationStage.delegationMap;
+    }
+    if (isDelegationDebugging()) {
+      const delegationPlanId = Math.random().toString(36).slice(2);
+      delegationPlanIdMap.set(delegationMaps, delegationPlanId);
     }
     return delegationMaps;
   });


### PR DESCRIPTION
Exposing the delegation plan;

When you enable the environment variable, `EXPOSE_DELEGATION_PLAN`, you can see the delegation plan in the console. This can be useful for debugging and understanding how the delegation works.

Also you can pass a different logger to it by using `logFnForContext` map from `@graphql-tools/delegate` package.

```ts
import { logFnForContext } from '@graphql-tools/delegate';
logFnForContext.set(MyGraphQLContext, console.log);
```

You can also add a `contextId` for that specific gateway request by using `contextIdMap` map from `@graphql-tools/delegate` package.

```ts
import { contextIdMap } from '@graphql-tools/delegate';
contextIdMap.set(MyGraphQLContext, 'my-request-id');
```

If you want to use those information instead of logging, you can get them by using the `context` object like below;

```ts
import { delegationPlanInfosByContext } from '@graphql-tools/delegate';
const delegationPlanInfos = delegationPlanInfosByContext.get(context);
```
The idea of exposing it via the context is to get the information to be used in other other places. Maybe putting it under extensions here;
https://github.com/ardatan/graphql-mesh/pull/6940/files#diff-5e5874cf986f5d1deeda6bec95633e4d1f45d2b59a022fec7e9cfbf878698042R165


You can find a full exposed plan example here below;
https://github.com/ardatan/graphql-tools/pull/6145/files#diff-9fe42f557cff42c58e7076d60567a7b9fce3798fd0c5882148b8e2bb398332df

The structure of each plan is like;
```json
  {
    "operationName": "TestQuery", # Main operation name
    "contextId": "MY_CONTEXT_IDENTIFIER", # This can be from `x-request-id` header
    "planId": "AAAA",  # Identifier for the plan
    "source": "reviews", # Source subgraph
    "type": "Product", # Return type
    "path": [ # Path of this delegation
      "users",
      "reviews",
      "product",
      "reviews",
      "author",
      "reviews",
      "product"
    ],
    "fieldNodes": [ # Expected final selection set
      "product {\n  ...Product\n}"
    ],
    "fragments": [
      "fragment User on User {\n  id\n  username\n  name\n}",
      "fragment Review on Review {\n  id\n  body\n}",
      "fragment Product on Product {\n  inStock\n  name\n  price\n  shippingEstimate\n  upc\n  weight\n}"
    ],
    # Called sequentially
    "stages": [
      {
        "stageId": "BBBBB",
        "delegations": [ # Called in parallel then merged
          {
            "target": "inventory",
            "selectionSet": "{\n  inStock\n}"
          },
          {
            "target": "products",
            "selectionSet": "{\n  name\n  price\n  price\n  weight\n  weight\n}"
          }
        ]
      },
      {
        "stageId": "CCCC",
        "delegations": [
          {
            "target": "inventory",
            "selectionSet": "{\n  shippingEstimate\n}"
          }
        ]
      }
    ]
  }
```