### PR TITLE
fix(federation/stitch/delegate): handle complex nested keys

### DIFF
--- a/.changeset/orange-balloons-grin.md
+++ b/.changeset/orange-balloons-grin.md
@@ -1,0 +1,9 @@
+---
+"@graphql-tools/delegate": patch
+"@graphql-tools/stitch": patch
+---
+
+If there are some fields depending on a nested type resolution, wait until it gets resolved then resolve the rest.
+
+See packages/federation/test/fixtures/complex-entity-call example for more details.
+You can see `ProductList` needs some fields from `Product` to resolve `first`

--- a/packages/delegate/src/defaultMergedResolver.ts
+++ b/packages/delegate/src/defaultMergedResolver.ts
@@ -15,11 +15,7 @@ import {
 } from './mergeFields.js';
 import { resolveExternalValue } from './resolveExternalValue.js';
 import { Subschema } from './Subschema.js';
-import {
-  FIELD_SUBSCHEMA_MAP_SYMBOL,
-  OBJECT_SUBSCHEMA_SYMBOL,
-  UNPATHED_ERRORS_SYMBOL,
-} from './symbols.js';
+import { FIELD_SUBSCHEMA_MAP_SYMBOL, UNPATHED_ERRORS_SYMBOL } from './symbols.js';
 import { ExternalObject, StitchingInfo } from './types.js';
 
 /**

--- a/packages/delegate/src/defaultMergedResolver.ts
+++ b/packages/delegate/src/defaultMergedResolver.ts
@@ -1,8 +1,26 @@
-import { defaultFieldResolver, GraphQLResolveInfo } from 'graphql';
-import { getResponseKeyFromInfo } from '@graphql-tools/utils';
-import { getSubschema, getUnpathedErrors, isExternalObject } from './mergeFields.js';
+import {
+  defaultFieldResolver,
+  GraphQLResolveInfo,
+  Kind,
+  responsePathAsArray,
+  SelectionSetNode,
+} from 'graphql';
+import { getResponseKeyFromInfo, isPromise } from '@graphql-tools/utils';
+import { getPlanLeftOverFromParent } from './leftOver.js';
+import {
+  getSubschema,
+  getUnpathedErrors,
+  handleResolverResult,
+  isExternalObject,
+} from './mergeFields.js';
 import { resolveExternalValue } from './resolveExternalValue.js';
-import { ExternalObject } from './types.js';
+import { Subschema } from './Subschema.js';
+import {
+  FIELD_SUBSCHEMA_MAP_SYMBOL,
+  OBJECT_SUBSCHEMA_SYMBOL,
+  UNPATHED_ERRORS_SYMBOL,
+} from './symbols.js';
+import { ExternalObject, StitchingInfo } from './types.js';
 
 /**
  * Resolver that knows how to:
@@ -28,9 +46,155 @@ export function defaultMergedResolver(
     return defaultFieldResolver(parent, args, context, info);
   }
 
+  if (parent[responseKey] === undefined) {
+    const leftOver = getPlanLeftOverFromParent(parent);
+    const missingFieldName = info.fieldNodes[0].name.value;
+    if (
+      leftOver?.unproxiableFieldNodes?.some(fieldNode => fieldNode.name.value === missingFieldName)
+    ) {
+      const stitchingInfo = info.schema.extensions?.['stitchingInfo'] as StitchingInfo;
+      if (stitchingInfo) {
+        const satisfiedSubschema = new Promise<Subschema | undefined>(resolve => {
+          // TODO: Find a better solution than polling
+          const interval = setInterval(() => {
+            if (parent[responseKey] != null) {
+              clearInterval(interval);
+              resolve(undefined);
+            }
+            for (const possibleSubschema of leftOver.nonProxiableSubschemas) {
+              const selectionSet =
+                stitchingInfo.mergedTypes[info.parentType.name].selectionSets.get(
+                  possibleSubschema,
+                );
+              if (selectionSet && parentSatisfiedSelectionSet(parent, selectionSet)) {
+                clearInterval(interval);
+                resolve(possibleSubschema);
+              }
+            }
+          }, 100);
+        });
+        return satisfiedSubschema.then(satisfiedSubschema => {
+          if (satisfiedSubschema) {
+            const resolver =
+              stitchingInfo.mergedTypes[info.parentType.name].resolvers.get(satisfiedSubschema);
+            if (resolver) {
+              const selectionSet: SelectionSetNode = {
+                kind: Kind.SELECTION_SET,
+                selections: info.fieldNodes,
+              };
+              const resolverResult$ = resolver(
+                parent,
+                context,
+                info,
+                satisfiedSubschema,
+                selectionSet,
+                info.parentType,
+                info.parentType,
+              );
+              if (isPromise(resolverResult$)) {
+                return resolverResult$
+                  .then(resolverResult =>
+                    handleResolverResult(
+                      resolverResult,
+                      satisfiedSubschema,
+                      selectionSet,
+                      parent,
+                      parent[FIELD_SUBSCHEMA_MAP_SYMBOL],
+                      info,
+                      responsePathAsArray(info.path),
+                      parent[UNPATHED_ERRORS_SYMBOL],
+                    ),
+                  )
+                  .then(() => handleResult(parent, responseKey, context, info));
+              } else {
+                handleResolverResult(
+                  resolverResult$,
+                  satisfiedSubschema,
+                  selectionSet,
+                  parent,
+                  parent[FIELD_SUBSCHEMA_MAP_SYMBOL],
+                  info,
+                  responsePathAsArray(info.path),
+                  parent[UNPATHED_ERRORS_SYMBOL],
+                );
+              }
+            }
+          }
+        });
+      }
+    }
+  }
+  return handleResult(parent, responseKey, context, info);
+}
+
+function handleResult(
+  parent: ExternalObject,
+  responseKey: string,
+  context: Record<string, any>,
+  info: GraphQLResolveInfo,
+) {
+  const subschema = getSubschema(parent, responseKey);
   const data = parent[responseKey];
   const unpathedErrors = getUnpathedErrors(parent);
-  const subschema = getSubschema(parent, responseKey);
 
   return resolveExternalValue(data, unpathedErrors, subschema, context, info);
+}
+
+function parentSatisfiedSelectionSet(
+  parent: any,
+  selectionSet: SelectionSetNode,
+): Set<Subschema> | undefined {
+  if (Array.isArray(parent)) {
+    const subschemas = new Set<Subschema>();
+    for (const item of parent) {
+      const satisfied = parentSatisfiedSelectionSet(item, selectionSet);
+      if (satisfied === undefined) {
+        return undefined;
+      }
+      for (const subschema of satisfied) {
+        subschemas.add(subschema);
+      }
+    }
+    return subschemas;
+  }
+  if (parent === null) {
+    return parent[OBJECT_SUBSCHEMA_SYMBOL];
+  }
+  if (parent === undefined) {
+    return undefined;
+  }
+  const subschemas = new Set<Subschema>();
+  for (const selection of selectionSet.selections) {
+    if (selection.kind === Kind.FIELD) {
+      const responseKey = selection.alias?.value ?? selection.name.value;
+      if (parent[responseKey] === undefined) {
+        return undefined;
+      }
+      const subschema = getSubschema(parent, responseKey) as Subschema;
+      if (subschema) {
+        subschemas.add(subschema);
+      }
+      if (parent[responseKey] === null) {
+        continue;
+      }
+      if (selection.selectionSet != null) {
+        const satisfied = parentSatisfiedSelectionSet(parent[responseKey], selection.selectionSet);
+        if (satisfied === undefined) {
+          return undefined;
+        }
+        for (const subschema of satisfied) {
+          subschemas.add(subschema);
+        }
+      }
+    } else if (selection.kind === Kind.INLINE_FRAGMENT) {
+      const inlineSatisfied = parentSatisfiedSelectionSet(parent, selection.selectionSet);
+      if (inlineSatisfied === undefined) {
+        return undefined;
+      }
+      for (const subschema of inlineSatisfied) {
+        subschemas.add(subschema);
+      }
+    }
+  }
+  return subschemas;
 }

--- a/packages/delegate/src/defaultMergedResolver.ts
+++ b/packages/delegate/src/defaultMergedResolver.ts
@@ -192,7 +192,7 @@ function handleFlattenedParent(
 }
 
 function parentSatisfiedSelectionSet(
-  parent: ExternalObject,
+  parent: unknown,
   selectionSet: SelectionSetNode,
 ): Set<Subschema> | undefined {
   if (Array.isArray(parent)) {
@@ -209,7 +209,7 @@ function parentSatisfiedSelectionSet(
     return subschemas;
   }
   if (parent === null) {
-    return parent[OBJECT_SUBSCHEMA_SYMBOL];
+    return new Set<Subschema>();
   }
   if (parent === undefined) {
     return undefined;
@@ -221,9 +221,11 @@ function parentSatisfiedSelectionSet(
       if (parent[responseKey] === undefined) {
         return undefined;
       }
-      const subschema = getSubschema(parent, responseKey) as Subschema;
-      if (subschema) {
-        subschemas.add(subschema);
+      if (isExternalObject(parent)) {
+        const subschema = getSubschema(parent, responseKey) as Subschema;
+        if (subschema) {
+          subschemas.add(subschema);
+        }
       }
       if (parent[responseKey] === null) {
         continue;

--- a/packages/delegate/src/defaultMergedResolver.ts
+++ b/packages/delegate/src/defaultMergedResolver.ts
@@ -16,7 +16,7 @@ import {
 import { resolveExternalValue } from './resolveExternalValue.js';
 import { Subschema } from './Subschema.js';
 import { FIELD_SUBSCHEMA_MAP_SYMBOL, UNPATHED_ERRORS_SYMBOL } from './symbols.js';
-import { ExternalObject, StitchingInfo } from './types.js';
+import { ExternalObject, MergedTypeResolver, StitchingInfo } from './types.js';
 
 /**
  * Resolver that knows how to:
@@ -73,10 +73,10 @@ export function defaultMergedResolver(
   return handleResult(parent, responseKey, context, info);
 }
 
-function handleResult(
+function handleResult<TContext extends Record<string, any>>(
   parent: ExternalObject,
   responseKey: string,
-  context: Record<string, any>,
+  context: TContext,
   info: GraphQLResolveInfo,
 ) {
   const subschema = getSubschema(parent, responseKey);
@@ -211,13 +211,13 @@ function handleFlattenedParent(
   }
 }
 
-function handleDeferredResolverResult(
-  resolverResult: any,
+function handleDeferredResolverResult<TContext extends Record<string, any>>(
+  resolverResult: ReturnType<MergedTypeResolver>,
   possibleSubschema: Subschema,
   selectionSet: SelectionSetNode,
   leftOverParent: ExternalObject,
   leftOver: DelegationPlanLeftOver,
-  context: any,
+  context: TContext,
   info: GraphQLResolveInfo,
 ) {
   handleResolverResult(

--- a/packages/delegate/src/defaultMergedResolver.ts
+++ b/packages/delegate/src/defaultMergedResolver.ts
@@ -100,9 +100,9 @@ function handleResult<TContext extends Record<string, any>>(
   return resolvedData$;
 }
 
-function handleLeftOver(
+function handleLeftOver<TContext extends Record<string, any>>(
   parent: ExternalObject,
-  context: any,
+  context: TContext,
   info: GraphQLResolveInfo,
   leftOver: DelegationPlanLeftOver,
 ) {
@@ -146,14 +146,14 @@ function handleLeftOver(
   }
 }
 
-function handleFlattenedParent(
+function handleFlattenedParent<TContext extends Record<string, any>>(
   flattenedParent: ExternalObject,
   possibleSubschema: Subschema,
   selectionSet: SelectionSetNode,
   leftOver: DelegationPlanLeftOver,
   stitchingInfo: StitchingInfo,
   parentTypeName: string,
-  context: any,
+  context: TContext,
   info: GraphQLResolveInfo,
 ) {
   // If this subschema is satisfied now, try to resolve the deferred fields

--- a/packages/delegate/src/defaultMergedResolver.ts
+++ b/packages/delegate/src/defaultMergedResolver.ts
@@ -43,7 +43,7 @@ export function defaultMergedResolver(
   }
 
   // If the parent is satisfied for the left over after a nested delegation, try to resolve it
-  if (!parent.hasOwnProperty(responseKey)) {
+  if (!Object.prototype.hasOwnProperty.call(parent, responseKey)) {
     const leftOver = getPlanLeftOverFromParent(parent);
     // Add this field to the deferred fields
     if (leftOver) {
@@ -234,7 +234,7 @@ function handleDeferredResolverResult<TContext extends Record<string, any>>(
   if (deferredFields) {
     for (const [responseKey, deferred] of deferredFields) {
       // If the deferred field is resolved, resolve the deferred field
-      if (resolverResult.hasOwnProperty(responseKey)) {
+      if (Object.prototype.hasOwnProperty.call(resolverResult, responseKey)) {
         deferred.resolve(handleResult(leftOverParent, responseKey, context, info));
       }
     }

--- a/packages/delegate/src/index.ts
+++ b/packages/delegate/src/index.ts
@@ -9,3 +9,4 @@ export * from './resolveExternalValue.js';
 export * from './subschemaConfig.js';
 export * from './types.js';
 export * from './extractUnavailableFields.js';
+export * from './leftOver.js';

--- a/packages/delegate/src/leftOver.ts
+++ b/packages/delegate/src/leftOver.ts
@@ -2,13 +2,27 @@ import { FieldNode } from 'graphql';
 import { Subschema } from './Subschema.js';
 import { DelegationPlanBuilder, ExternalObject } from './types.js';
 
+export interface Deferred<T = unknown> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+}
+
+export function createDeferred<T>(): Deferred<T> {
+  let resolve: (value: T) => void;
+  let reject: (error: unknown) => void;
+  const promise = new Promise<T>((_resolve, _reject) => {
+    resolve = _resolve;
+    reject = _reject;
+  });
+  return { promise, resolve: resolve!, reject: reject! };
+}
+
 export interface DelegationPlanLeftOver {
   unproxiableFieldNodes: Array<FieldNode>;
   nonProxiableSubschemas: Array<Subschema>;
-  onResolveCallbacksByParent: WeakMap<
-    ExternalObject,
-    Set<(flattenedParent: any, subschema: Subschema) => void>
-  >;
+  missingFieldsParentMap: Map<ExternalObject, Array<FieldNode>>;
+  missingFieldsParentDeferredMap: Map<ExternalObject, Map<string, Deferred>>;
 }
 export const leftOverByDelegationPlan = new WeakMap<
   ReturnType<DelegationPlanBuilder>,

--- a/packages/delegate/src/leftOver.ts
+++ b/packages/delegate/src/leftOver.ts
@@ -1,10 +1,14 @@
 import { FieldNode } from 'graphql';
 import { Subschema } from './Subschema.js';
-import { DelegationPlanBuilder } from './types.js';
+import { DelegationPlanBuilder, ExternalObject } from './types.js';
 
 export interface DelegationPlanLeftOver {
   unproxiableFieldNodes: Array<FieldNode>;
   nonProxiableSubschemas: Array<Subschema>;
+  onResolveCallbacksByParent: WeakMap<
+    ExternalObject,
+    Set<(flattenedParent: any, subschema: Subschema) => void>
+  >;
 }
 export const leftOverByDelegationPlan = new WeakMap<
   ReturnType<DelegationPlanBuilder>,

--- a/packages/delegate/src/leftOver.ts
+++ b/packages/delegate/src/leftOver.ts
@@ -1,0 +1,18 @@
+import { FieldNode } from 'graphql';
+import { Subschema } from './Subschema.js';
+import { DelegationPlanBuilder } from './types.js';
+
+export interface DelegationPlanLeftOver {
+  unproxiableFieldNodes: Array<FieldNode>;
+  nonProxiableSubschemas: Array<Subschema>;
+}
+export const leftOverByDelegationPlan = new WeakMap<
+  ReturnType<DelegationPlanBuilder>,
+  DelegationPlanLeftOver
+>();
+export const PLAN_LEFT_OVER = Symbol('PLAN_LEFT_OVER');
+export function getPlanLeftOverFromParent(parent: unknown): DelegationPlanLeftOver | undefined {
+  if (parent != null && typeof parent === 'object') {
+    return parent[PLAN_LEFT_OVER];
+  }
+}

--- a/packages/delegate/src/mergeFields.ts
+++ b/packages/delegate/src/mergeFields.ts
@@ -166,7 +166,8 @@ export function handleResolverResult(
         object[responseKey] = sourcePropValue;
       }
     }
-    combinedFieldSubschemaMap[responseKey] = fieldSubschemaMap?.[responseKey] ?? objectSubschema;
+    combinedFieldSubschemaMap[responseKey] =
+      fieldSubschemaMap?.[responseKey] ?? objectSubschema ?? subschema;
   }
 }
 

--- a/packages/federation/test/fixtures/federation-compatibility/complex-entity-call/supergraph.graphql
+++ b/packages/federation/test/fixtures/federation-compatibility/complex-entity-call/supergraph.graphql
@@ -1,0 +1,90 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type Category
+  @join__type(graph: PRICE, key: "id tag")
+  @join__type(graph: PRODUCTS, key: "id")
+{
+  id: String!
+  tag: String
+  mainProduct: Product! @join__field(graph: PRODUCTS)
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  LINK @join__graph(name: "link", url: "https://federation-compatibility.the-guild.dev/complex-entity-call/link")
+  LIST @join__graph(name: "list", url: "https://federation-compatibility.the-guild.dev/complex-entity-call/list")
+  PRICE @join__graph(name: "price", url: "https://federation-compatibility.the-guild.dev/complex-entity-call/price")
+  PRODUCTS @join__graph(name: "products", url: "https://federation-compatibility.the-guild.dev/complex-entity-call/products")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Price
+  @join__type(graph: PRICE)
+{
+  price: Float!
+}
+
+type Product
+  @join__type(graph: LINK, key: "id")
+  @join__type(graph: LINK, key: "id pid")
+  @join__type(graph: LIST, key: "id pid")
+  @join__type(graph: PRICE, key: "id pid category{id tag}")
+  @join__type(graph: PRODUCTS, key: "id", extension: true)
+{
+  id: String!
+  pid: String @join__field(graph: LINK, type: "String!") @join__field(graph: LIST, type: "String") @join__field(graph: PRICE, type: "String")
+  price: Price @join__field(graph: PRICE)
+  category: Category @join__field(graph: PRICE) @join__field(graph: PRODUCTS)
+}
+
+type ProductList
+  @join__type(graph: LIST, key: "products{id pid}")
+  @join__type(graph: PRICE, key: "products{id pid category{id tag}} selected{id}")
+  @join__type(graph: PRODUCTS, key: "products{id}")
+{
+  products: [Product!]!
+  first: Product @join__field(graph: LIST) @join__field(graph: PRICE)
+  selected: Product @join__field(graph: LIST) @join__field(graph: PRICE)
+}
+
+type Query
+  @join__type(graph: LINK)
+  @join__type(graph: LIST)
+  @join__type(graph: PRICE)
+  @join__type(graph: PRODUCTS)
+{
+  topProducts: ProductList! @join__field(graph: PRODUCTS)
+}

--- a/packages/federation/test/fixtures/federation-compatibility/complex-entity-call/tests.json
+++ b/packages/federation/test/fixtures/federation-compatibility/complex-entity-call/tests.json
@@ -1,0 +1,47 @@
+[
+  {
+    "query": "\n      query {\n        topProducts {\n          products {\n            id\n            pid\n            price {\n              price\n            }\n            category {\n              mainProduct {\n                id\n              }\n              id\n              tag\n            }\n          }\n          selected {\n            id\n          }\n          first {\n            id\n          }\n        }\n      }\n    ",
+    "expected": {
+      "data": {
+        "topProducts": {
+          "products": [
+            {
+              "id": "1",
+              "pid": "p1",
+              "price": {
+                "price": 100
+              },
+              "category": {
+                "mainProduct": {
+                  "id": "1"
+                },
+                "id": "c1",
+                "tag": "t1"
+              }
+            },
+            {
+              "id": "2",
+              "pid": "p2",
+              "price": {
+                "price": 200
+              },
+              "category": {
+                "mainProduct": {
+                  "id": "2"
+                },
+                "id": "c2",
+                "tag": "t2"
+              }
+            }
+          ],
+          "selected": {
+            "id": "2"
+          },
+          "first": {
+            "id": "1"
+          }
+        }
+      }
+    }
+  }
+]

--- a/packages/stitch/src/createDelegationPlanBuilder.ts
+++ b/packages/stitch/src/createDelegationPlanBuilder.ts
@@ -270,7 +270,8 @@ export function createDelegationPlanBuilder(mergedTypeInfo: MergedTypeInfo): Del
       leftOverByDelegationPlan.set(delegationMaps, {
         unproxiableFieldNodes: delegationStage.unproxiableFieldNodes,
         nonProxiableSubschemas: delegationStage.nonProxiableSubschemas,
-        onResolveCallbacksByParent: new WeakMap(),
+        missingFieldsParentMap: new Map(),
+        missingFieldsParentDeferredMap: new Map(),
       });
     }
     return delegationMaps;

--- a/packages/stitch/src/createDelegationPlanBuilder.ts
+++ b/packages/stitch/src/createDelegationPlanBuilder.ts
@@ -270,6 +270,7 @@ export function createDelegationPlanBuilder(mergedTypeInfo: MergedTypeInfo): Del
       leftOverByDelegationPlan.set(delegationMaps, {
         unproxiableFieldNodes: delegationStage.unproxiableFieldNodes,
         nonProxiableSubschemas: delegationStage.nonProxiableSubschemas,
+        onResolveCallbacksByParent: new WeakMap(),
       });
     }
     return delegationMaps;

--- a/packages/stitch/src/createDelegationPlanBuilder.ts
+++ b/packages/stitch/src/createDelegationPlanBuilder.ts
@@ -11,6 +11,7 @@ import {
 import {
   DelegationPlanBuilder,
   extractUnavailableFields,
+  leftOverByDelegationPlan,
   MergedTypeInfo,
   StitchingInfo,
   Subschema,
@@ -261,6 +262,15 @@ export function createDelegationPlanBuilder(mergedTypeInfo: MergedTypeInfo): Del
         unproxiableFieldNodes,
       );
       delegationMap = delegationStage.delegationMap;
+    }
+    if (
+      delegationStage.unproxiableFieldNodes.length &&
+      delegationStage.nonProxiableSubschemas.length
+    ) {
+      leftOverByDelegationPlan.set(delegationMaps, {
+        unproxiableFieldNodes: delegationStage.unproxiableFieldNodes,
+        nonProxiableSubschemas: delegationStage.nonProxiableSubschemas,
+      });
     }
     return delegationMaps;
   });

--- a/packages/stitch/src/createMergedTypeResolver.ts
+++ b/packages/stitch/src/createMergedTypeResolver.ts
@@ -19,7 +19,7 @@ export function createMergedTypeResolver<TContext extends Record<string, any> = 
       subschema,
       selectionSet,
       key,
-      type = getNamedType(info?.returnType) as GraphQLOutputType,
+      type = getNamedType(info.returnType) as GraphQLOutputType,
     ) {
       return batchDelegateToSchema({
         schema: subschema,

--- a/packages/stitch/src/createMergedTypeResolver.ts
+++ b/packages/stitch/src/createMergedTypeResolver.ts
@@ -19,7 +19,7 @@ export function createMergedTypeResolver<TContext extends Record<string, any> = 
       subschema,
       selectionSet,
       key,
-      type = getNamedType(info.returnType) as GraphQLOutputType,
+      type = getNamedType(info?.returnType) as GraphQLOutputType,
     ) {
       return batchDelegateToSchema({
         schema: subschema,


### PR DESCRIPTION
If there are some fields depending on a nested type resolution, wait until it gets resolved then resolve the rest.

See packages/federation/test/fixtures/complex-entity-call example for more details.
You can see `ProductList` needs some fields from `Product` to resolve `first`

Closes https://github.com/ardatan/graphql-tools/pull/6076