### PR TITLE
fix(stitch): handle nested dependencies in computed fields

### DIFF
--- a/.changeset/rare-grapes-drive.md
+++ b/.changeset/rare-grapes-drive.md
@@ -1,0 +1,24 @@
+---
+"@graphql-tools/stitch": patch
+---
+
+Handle nested dependencies in the computed fields
+```ts
+{
+  merge: {
+    Product: {
+      selectionSet: '{ id }',
+      fields: {
+        isExpensive: {
+          selectionSet: '{ price }',
+          computed: true,
+        },
+        canAfford: {
+          selectionSet: '{ isExpensive }',
+          computed: true,
+        },
+      }
+    }
+  }
+}
+```

--- a/packages/federation/test/fixtures/federation-compatibility/requires-requires/supergraph.graphql
+++ b/packages/federation/test/fixtures/federation-compatibility/requires-requires/supergraph.graphql
@@ -1,0 +1,67 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY)
+{
+  query: Query
+}
+
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  A @join__graph(name: "a", url: "https://federation-compatibility.the-guild.dev/requires-requires/a")
+  B @join__graph(name: "b", url: "https://federation-compatibility.the-guild.dev/requires-requires/b")
+  C @join__graph(name: "c", url: "https://federation-compatibility.the-guild.dev/requires-requires/c")
+  D @join__graph(name: "d", url: "https://federation-compatibility.the-guild.dev/requires-requires/d")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Product
+  @join__type(graph: A, key: "id")
+  @join__type(graph: B, key: "id")
+  @join__type(graph: C, key: "id")
+  @join__type(graph: D, key: "id")
+{
+  id: ID!
+  price: Float! @inaccessible @join__field(graph: A) @join__field(graph: C, external: true)
+  isExpensive: Boolean! @join__field(graph: C, requires: "price") @join__field(graph: D, external: true)
+  canAfford: Boolean! @join__field(graph: D, requires: "isExpensive")
+}
+
+type Query
+  @join__type(graph: A)
+  @join__type(graph: B)
+  @join__type(graph: C)
+  @join__type(graph: D)
+{
+  product: Product @join__field(graph: B)
+}

--- a/packages/federation/test/fixtures/federation-compatibility/requires-requires/tests.json
+++ b/packages/federation/test/fixtures/federation-compatibility/requires-requires/tests.json
@@ -1,0 +1,33 @@
+[
+  {
+    "query": "\n      query {\n        product {\n          canAfford\n        }\n      }\n    ",
+    "expected": {
+      "data": {
+        "product": {
+          "canAfford": false
+        }
+      }
+    }
+  },
+  {
+    "query": "\n      query {\n        product {\n          isExpensive\n        }\n      }\n    ",
+    "expected": {
+      "data": {
+        "product": {
+          "isExpensive": true
+        }
+      }
+    }
+  },
+  {
+    "query": "\n      query {\n        product {\n          isExpensive\n          canAfford\n        }\n      }\n    ",
+    "expected": {
+      "data": {
+        "product": {
+          "isExpensive": true,
+          "canAfford": false
+        }
+      }
+    }
+  }
+]


### PR DESCRIPTION

Handle nested dependencies in the computed fields
```ts
{
  merge: {
    Product: {
      selectionSet: '{ id }',
      fields: {
        isExpensive: {
          selectionSet: '{ price }',
          computed: true,
        },
        canAfford: {
          selectionSet: '{ isExpensive }',
          computed: true,
        },
      }
    }
  }
}
```