### PR TITLE
fix(documents): do not order mutations

### DIFF
--- a/.changeset/tough-flowers-listen.md
+++ b/.changeset/tough-flowers-listen.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/documents': patch
+---
+
+Do not sort mutations when using `printExecutableGraphQLDocument`

--- a/packages/documents/src/sort-executable-document.ts
+++ b/packages/documents/src/sort-executable-document.ts
@@ -1,4 +1,4 @@
-import { visit, type DocumentNode } from 'graphql';
+import { OperationTypeNode, visit, type DocumentNode } from 'graphql';
 import { sortExecutableNodes } from './sort-executable-nodes.js';
 
 /**
@@ -13,6 +13,10 @@ export function sortExecutableDocument(document: DocumentNode): DocumentNode {
       };
     },
     OperationDefinition(node) {
+      if (node.operation === ('mutation' as OperationTypeNode)) {
+        return false;
+      }
+
       return {
         ...node,
         variableDefinitions: sortExecutableNodes(node.variableDefinitions),

--- a/packages/documents/src/sort-executable-document.ts
+++ b/packages/documents/src/sort-executable-document.ts
@@ -1,10 +1,13 @@
-import { OperationTypeNode, visit, type DocumentNode } from 'graphql';
+import { SelectionNode, SelectionSetNode, visit, type DocumentNode } from 'graphql';
 import { sortExecutableNodes } from './sort-executable-nodes.js';
 
 /**
  * Sort an executable GraphQL document.
  */
 export function sortExecutableDocument(document: DocumentNode): DocumentNode {
+  const ignoredNodes = new WeakSet<SelectionSetNode>();
+  const ignoredSelectionsArr = new Set<readonly SelectionNode[]>();
+  const ignoredFragments = new Set<string>();
   return visit(document, {
     Document(node) {
       return {
@@ -13,34 +16,49 @@ export function sortExecutableDocument(document: DocumentNode): DocumentNode {
       };
     },
     OperationDefinition(node) {
-      if (node.operation === ('mutation' as OperationTypeNode)) {
-        return false;
+      if (node.operation === 'mutation') {
+        ignoredNodes.add(node.selectionSet);
+        ignoredSelectionsArr.add(node.selectionSet.selections);
       }
-
       return {
         ...node,
         variableDefinitions: sortExecutableNodes(node.variableDefinitions),
       };
     },
     SelectionSet(node) {
+      if (ignoredNodes.has(node)) {
+        ignoredSelectionsArr.add(node.selections);
+        return node;
+      }
       return {
         ...node,
         selections: sortExecutableNodes(node.selections),
       };
     },
-    FragmentSpread(node) {
+    FragmentSpread(node, _key, parent) {
+      if (Array.isArray(parent) && ignoredSelectionsArr.has(parent)) {
+        ignoredFragments.add(node.name.value);
+      }
       return {
         ...node,
         directives: sortExecutableNodes(node.directives),
       };
     },
-    InlineFragment(node) {
+    InlineFragment(node, _key, parent) {
+      if (Array.isArray(parent) && ignoredSelectionsArr.has(parent)) {
+        ignoredNodes.add(node.selectionSet);
+        ignoredSelectionsArr.add(node.selectionSet.selections);
+        return node;
+      }
       return {
         ...node,
         directives: sortExecutableNodes(node.directives),
       };
     },
     FragmentDefinition(node) {
+      if (ignoredFragments.has(node.name.value)) {
+        return node;
+      }
       return {
         ...node,
         directives: sortExecutableNodes(node.directives),

--- a/packages/documents/tests/print-executable-graphql-document.spec.ts
+++ b/packages/documents/tests/print-executable-graphql-document.spec.ts
@@ -83,4 +83,20 @@ describe('printExecutableGraphQLDocument', () => {
       `"fragment B on Query { c } query A { ... on Query { a { a ...B } } ... on Query { a { b ...B } } }"`,
     );
   });
+
+  test('should not sort a mutation as mutations run in series and order matters', () => {
+    const inputDocument = parse(/* GraphQL */ `
+      mutation A {
+        c {
+          f
+          e
+          d
+        }
+        b
+        a
+      }
+    `);
+    const outputStr = printExecutableGraphQLDocument(inputDocument);
+    expect(outputStr).toMatchInlineSnapshot(`"mutation A { c { f e d } b a }"`);
+  });
 });

--- a/packages/documents/tests/print-executable-graphql-document.spec.ts
+++ b/packages/documents/tests/print-executable-graphql-document.spec.ts
@@ -87,16 +87,26 @@ describe('printExecutableGraphQLDocument', () => {
   test('should not sort a mutation as mutations run in series and order matters', () => {
     const inputDocument = parse(/* GraphQL */ `
       mutation A {
-        c {
-          f
-          e
+        ... on Mutation {
+          c
+          b
           d
+        }
+        c {
+          d
+          e {
+            b
+            a
+          }
+          f
         }
         b
         a
       }
     `);
     const outputStr = printExecutableGraphQLDocument(inputDocument);
-    expect(outputStr).toMatchInlineSnapshot(`"mutation A { c { f e d } b a }"`);
+    expect(outputStr).toMatchInlineSnapshot(
+      `"mutation A { ... on Mutation { c b d } c { d e { a b } f } b a }"`,
+    );
   });
 });


### PR DESCRIPTION
🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

printExecutableGraphQLDocument sorts mutations by name whereas from the GraphQL spec the order of mutation matters, they do not run in parallel like queries, but in series. See: [graphql.org/learn/queries/#multiple-fields-in-mutations](https://graphql.org/learn/queries/#multiple-fields-in-mutations).

This PR makes sure that mutations are not sorted and thus if you have a mutation where order matters they will run as 
you expect them to. 

Related #6195 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

I was in doubt if it is a breaking change, but I think that anyone using the package currently without it breaking their workflow should be fine with this bugfix.

## Screenshots/Sandbox (if appropriate/relevant):

N/A

## How Has This Been Tested?

- Added a unit tests which describes the behavior I'd like to see

Linked locally to our project and tested if the fix worked.


**Test Environment**:

OS: MacOS
"@graphql-tools/documents@^1.0.0"::
NodeJS: LTS Iron (v20) - Now using node v20.12.2 (npm v10.5.0)

## Checklist:

- [X] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests and linter rules pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

## Further comments

Linked issue in graphql-code-generator: https://github.com/dotansimha/graphql-code-generator/issues/9925
PR I made to graphql-code-generator to provide an alternative: https://github.com/dotansimha/graphql-code-generator/pull/9926 - here I was asked to create a PR here ;)

Open to any comments, remarks as I'm very well aware I did not discuss the solution before proceeding to create a PR. Let me know :)
