### PR TITLE
perf: only clone schema once in `addMocksToSchema`

### DIFF
--- a/.changeset/four-items-live.md
+++ b/.changeset/four-items-live.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/mock': patch
+---
+
+perf: only clone schema once in `addMocksToSchema`

--- a/packages/mock/src/addMocksToSchema.ts
+++ b/packages/mock/src/addMocksToSchema.ts
@@ -249,6 +249,8 @@ export function addMocksToSchema<TResolvers = IResolvers>({
     ? addResolversToSchema({
         schema: schemaWithMocks,
         resolvers: resolvers as any,
+        // This option ensures that schemas are not cloned multiple times, which can be very expensive
+        updateResolversInPlace: true,
       })
     : schemaWithMocks;
 }

--- a/packages/mock/tests/addMocksToSchema.spec.ts
+++ b/packages/mock/tests/addMocksToSchema.spec.ts
@@ -388,4 +388,25 @@ describe('addMocksToSchema', () => {
 
     expect(viewer.name).toEqual('custom mock for String');
   });
+
+  it('creates a new schema whether or not resolvers are passed in', () => {
+    expect(
+      Object.is(
+        addMocksToSchema({
+          schema,
+          resolvers: {},
+        }),
+        schema,
+      ),
+    ).toBe(false);
+
+    expect(
+      Object.is(
+        addMocksToSchema({
+          schema,
+        }),
+        schema,
+      ),
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

This PR adds `updateResolversInPlace: true` to the call to `addResolversToSchema` in `addMocksToSchema`, to prevent large schemas from being cloned twice.

Related https://github.com/ardatan/graphql-tools/issues/6198

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

N/A

## How Has This Been Tested?

- Added a test that ensures that a new schema is always created by calls to `addMocksToSchema`, whether or not the `resolvers` argument is passed.

**Test Environment**:

- OS: MacOS
- `@graphql-tools/mock`: 9.0.2
- NodeJS: v20.10.0

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

See https://github.com/ardatan/graphql-tools/issues/6198 for alternatives considered.
