### PR TITLE
enhance(executor-http): details in extensions for errors

### DIFF
--- a/.changeset/hungry-spies-argue.md
+++ b/.changeset/hungry-spies-argue.md
@@ -1,0 +1,31 @@
+---
+'@graphql-tools/executor-http': patch
+---
+
+Details in the extensions when an error occurs;
+
+```json
+{
+  "request": {
+    "endpoint": "https://api.example.com/graphql",
+    "method": "POST",
+    "body": {
+      "query": "query { hello }"
+    }
+  },
+  "http": {
+    "status": 500,
+    "statusText": "Internal Server Error",
+    "headers": {
+      "content-type": "application/json"
+    }
+  },
+  "responseBody": {
+    "errors": [
+      {
+        "message": "Internal Server Error"
+      }
+    ]
+  }
+}
+```

--- a/packages/executors/http/tests/buildHTTPExecutor.test.ts
+++ b/packages/executors/http/tests/buildHTTPExecutor.test.ts
@@ -38,7 +38,10 @@ describe('buildHTTPExecutor', () => {
     expect(result).toMatchObject({
       errors: [
         {
-          message: 'Unexpected response: "NOT JSON"',
+          message: 'Unexpected response',
+          extensions: {
+            responseBody: 'NOT JSON',
+          },
         },
       ],
     });
@@ -69,7 +72,10 @@ describe('buildHTTPExecutor', () => {
     expect(result).toMatchObject({
       errors: [
         {
-          message: 'Unexpected empty "data" and "errors" fields',
+          message: 'Unexpected response',
+          extensions: {
+            responseBody: JSON.parse(body),
+          },
         },
       ],
     });


### PR DESCRIPTION
Details in the extensions when an error occurs;

```json
{
  "request": {
    "endpoint": "https://api.example.com/graphql",
    "method": "POST",
    "body": {
      "query": "query { hello }"
    }
  },
  "http": {
    "status": 500,
    "statusText": "Internal Server Error",
    "headers": {
      "content-type": "application/json"
    }
  },
  "responseBody": {
    "errors": [
      {
        "message": "Internal Server Error"
      }
    ]
  }
}
```