### PR TITLE
Refactor Federation package

### DIFF
--- a/.changeset/hot-planes-smoke.md
+++ b/.changeset/hot-planes-smoke.md
@@ -1,0 +1,9 @@
+---
+'@graphql-tools/federation': major
+---
+
+BREAKING CHANGES:
+- `getSubschemasFromSupergraphSdl` has been removed in favor of the new `getStitchingOptionsFromSupergraphSdl`, and it returns the options for `stitchSchemas` instead of the map of subschemas
+- `onExecutor` has been removed in favor of `onSubschemaConfig`
+- To change the default HTTP executor options, use `httpExecutorOpts` instead of `onExecutor`
+

--- a/.changeset/lovely-jokes-pull.md
+++ b/.changeset/lovely-jokes-pull.md
@@ -1,0 +1,6 @@
+---
+'@graphql-tools/executor-envelop': major
+'@graphql-tools/executor-yoga': major
+---
+
+BREAKING: `invalidateSupergraph` is now replaced with `invalidateUnifiedGraph`

--- a/packages/executors/envelop/src/index.ts
+++ b/packages/executors/envelop/src/index.ts
@@ -15,14 +15,16 @@ export type ExecutorPluginOpts = Parameters<typeof schemaFromExecutor>[2] & {
   polling?: number;
 };
 
-export function useExecutor(
-  executor: Executor,
-  opts?: ExecutorPluginOpts,
-): Plugin & {
-  invalidateSupergraph: () => void;
+export interface ExecutorPluginExtras {
+  invalidateUnifiedGraph: () => void;
   pluginCtx: ExecutorPluginContext;
   ensureSchema(ctx?: any): void;
-} {
+}
+
+export function useExecutor<TPluginContext extends Record<string, any>>(
+  executor: Executor,
+  opts?: ExecutorPluginOpts,
+): Plugin<TPluginContext> & ExecutorPluginExtras {
   const EMPTY_ARRAY = Object.freeze([]);
   function executorToExecuteFn(executionArgs: ExecutionArgs) {
     return executor({
@@ -127,7 +129,7 @@ export function useExecutor(
     },
     pluginCtx,
     ensureSchema,
-    invalidateSupergraph() {
+    invalidateUnifiedGraph() {
       pluginCtx.schema$ = undefined;
       pluginCtx.schema = undefined;
       pluginCtx.skipIntrospection = false;

--- a/packages/executors/yoga/src/index.ts
+++ b/packages/executors/yoga/src/index.ts
@@ -1,5 +1,6 @@
-import type { Plugin } from 'graphql-yoga';
+import { YogaInitialContext, type Plugin } from 'graphql-yoga';
 import {
+  ExecutorPluginExtras,
   ExecutorPluginOpts,
   useExecutor as useEnvelopExecutor,
 } from '@graphql-tools/executor-envelop';
@@ -8,15 +9,10 @@ import { Executor } from '@graphql-tools/utils';
 export function useExecutor(
   executor: Executor,
   opts?: ExecutorPluginOpts,
-): Plugin & { invalidateSupergraph: () => void } {
-  const envelopPlugin = useEnvelopExecutor(executor, opts);
+): Plugin & ExecutorPluginExtras {
+  const envelopPlugin = useEnvelopExecutor<YogaInitialContext>(executor, opts);
   return {
-    onPluginInit({ addPlugin }) {
-      addPlugin(
-        // @ts-expect-error TODO: fix typings
-        envelopPlugin,
-      );
-    },
+    ...envelopPlugin,
     onRequestParse({ serverContext }) {
       return {
         onRequestParseDone() {
@@ -27,6 +23,5 @@ export function useExecutor(
         },
       };
     },
-    invalidateSupergraph: envelopPlugin.invalidateSupergraph,
   };
 }

--- a/packages/federation/test/gateway.test.ts
+++ b/packages/federation/test/gateway.test.ts
@@ -264,11 +264,12 @@ describe('Federation', () => {
     const serviceCallCounts: Record<string, number> = {};
     const gatewaySchema = getStitchedSchemaFromSupergraphSdl({
       supergraphSdl,
-      onExecutor({ subgraphName }) {
+      onSubschemaConfig(subschemaConfig) {
+        const subgraphName = subschemaConfig.name;
         serviceCallCounts[subgraphName] = 0;
         const schema = serviceInputs.find(({ name }) => name === subgraphName)!.schema;
         const executor = createDefaultExecutor(schema);
-        return function subschemaExecutor(executionRequest) {
+        subschemaConfig.executor = function subschemaExecutor(executionRequest) {
           serviceCallCounts[subgraphName]++;
           const errors = validate(schema, executionRequest.document);
           if (errors.length > 0) {

--- a/packages/federation/test/optimizations.test.ts
+++ b/packages/federation/test/optimizations.test.ts
@@ -36,11 +36,12 @@ describe('Optimizations', () => {
         join(__dirname, 'fixtures', 'gateway', 'supergraph.graphql'),
         'utf8',
       ),
-      onExecutor({ subgraphName }) {
+      onSubschemaConfig(subschemaConfig) {
+        const subgraphName = subschemaConfig.name;
         const schema = buildSubgraphSchema(services[subgraphName]);
         const executor = createDefaultExecutor(schema);
         serviceCallCnt[subgraphName] = 0;
-        return async args => {
+        subschemaConfig.executor = args => {
           serviceCallCnt[subgraphName]++;
           return executor(args);
         };
@@ -202,20 +203,27 @@ describe('awareness-of-other-fields', () => {
       .then(() => {
         gwSchema = getStitchedSchemaFromSupergraphSdl({
           supergraphSdl,
-          onExecutor({ subgraphName }) {
+          onSubschemaConfig(subschemaConfig) {
+            const subgraphName = subschemaConfig.name;
             switch (subgraphName) {
               case 'A':
-                return getTracedExecutor(subgraphName, Aschema);
+                subschemaConfig.executor = getTracedExecutor(subgraphName, Aschema);
+                break;
               case 'B':
-                return getTracedExecutor(subgraphName, Bschema);
+                subschemaConfig.executor = getTracedExecutor(subgraphName, Bschema);
+                break;
               case 'C':
-                return getTracedExecutor(subgraphName, Cschema);
+                subschemaConfig.executor = getTracedExecutor(subgraphName, Cschema);
+                break;
               case 'D':
-                return getTracedExecutor(subgraphName, Dschema);
+                subschemaConfig.executor = getTracedExecutor(subgraphName, Dschema);
+                break;
               case 'E':
-                return getTracedExecutor(subgraphName, Eschema);
+                subschemaConfig.executor = getTracedExecutor(subgraphName, Eschema);
+                break;
+              default:
+                throw new Error(`Unknown subgraph ${subgraphName}`);
             }
-            throw new Error(`Unknown subgraph ${subgraphName}`);
           },
         });
       });

--- a/packages/federation/test/queries.test.ts
+++ b/packages/federation/test/queries.test.ts
@@ -9,8 +9,8 @@ it('should not do a fragment spread on a union', () => {
 
   const schema = getStitchedSchemaFromSupergraphSdl({
     supergraphSdl: readFileSync(join(__dirname, 'fixtures', 'supergraphs', 'c.graphql'), 'utf8'),
-    onExecutor() {
-      return function executor(request) {
+    onSubschemaConfig(subschemaConfig) {
+      subschemaConfig.executor = function executor(request) {
         queries.push(print(request.document));
         return {};
       };


### PR DESCRIPTION

BREAKING CHANGES:
- `getSubschemasFromSupergraphSdl` has been removed in favor of the new `getStitchingOptionsFromSupergraphSdl`, and it returns the options for `stitchSchemas` instead of the map of subschemas
- `onExecutor` has been removed in favor of `onSubschemaConfig`
- To change the default HTTP executor options, use `httpExecutorOpts` instead of `onExecutor`
