### PR TITLE
Fix errors in find and filter with an empty store

### DIFF
--- a/.changeset/early-birds-taste.md
+++ b/.changeset/early-birds-taste.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/mock': patch
+---
+
+fix errors in find and filter with an empty store

--- a/packages/mock/src/MockStore.ts
+++ b/packages/mock/src/MockStore.ts
@@ -192,12 +192,12 @@ export class MockStore implements IMockStore {
 
   filter(key: string, predicate: (val: Entity) => boolean) {
     const entity = this.store[key];
-    return Object.values(entity).filter(predicate);
+    return entity ? Object.values(entity).filter(predicate) : [];
   }
 
   find(key: string, predicate: (val: Entity) => boolean) {
     const entity = this.store[key];
-    return Object.values(entity).find(predicate);
+    return entity ? Object.values(entity).find(predicate) : undefined;
   }
 
   private getImpl<KeyT extends KeyTypeConstraints>(args: GetArgs<KeyT>) {

--- a/packages/mock/tests/store.spec.ts
+++ b/packages/mock/tests/store.spec.ts
@@ -1,7 +1,7 @@
-import { buildSchema } from 'graphql';
-import { createMockStore } from '../src/index.js';
-import { assertIsRef, Ref } from '../src/types.js';
-import { makeRef } from '../src/utils.js';
+import {buildSchema} from 'graphql';
+import {createMockStore, MockStore} from '../src/index.js';
+import {assertIsRef, Ref} from '../src/types.js';
+import {makeRef} from '../src/utils.js';
 
 const typeDefs = /* GraphQL */ `
   type User {
@@ -626,4 +626,42 @@ describe('MockStore', () => {
     expect(store.get('User', '123', 'name', { format: 'fullName' })).toEqual('Alexandre the Great');
     expect(store.get('User', '123', 'name', { format: 'shortName' })).toEqual('Alex');
   });
+
+  describe('filter method', () => {
+    it('should be able to filter an empty list', () => {
+      const store = new MockStore({schema})
+      store.set('User', 'user1', {name: 'Ross'})
+      expect(store.filter('User', () => false)).toEqual([])
+      store.reset()
+      expect(store.filter('User', () => true)).toEqual([])
+    })
+
+    it('should apply the filter', () => {
+      const store = new MockStore({schema})
+      store.set('User', 'user1', {name: 'Ross'})
+      store.set('User', 'user2', {name: 'Nico'})
+      expect(store.filter('User', () => true)).toEqual([{name: 'Ross'}, {name: 'Nico'}])
+      expect(store.filter('User', ({name}) => (name as string).startsWith('R'))).toEqual([{name: 'Ross'}])
+    })
+  })
+
+  describe('find method', () => {
+    it('should return undefined for an empty store', () => {
+      const store = new MockStore({schema})
+      expect(store.find('User', () => true)).toBeUndefined()
+    })
+
+    it('should return undefined for a miss', () => {
+      const store = new MockStore({schema})
+      store.set('User', 'user1', {name: 'Ross'})
+      expect(store.find('User', () => false)).toBeUndefined()
+    })
+
+    it('should return a match', () => {
+      const store = new MockStore({schema})
+      store.set('User', 'user1', {name: 'Ross'})
+      store.set('User', 'user2', {name: 'Nico'})
+      expect(store.find('User', ({name}) => (name as string).startsWith('N'))).toEqual({name: 'Nico'})
+    })
+  })
 });

--- a/packages/mock/tests/store.spec.ts
+++ b/packages/mock/tests/store.spec.ts
@@ -1,7 +1,7 @@
-import {buildSchema} from 'graphql';
-import {createMockStore, MockStore} from '../src/index.js';
-import {assertIsRef, Ref} from '../src/types.js';
-import {makeRef} from '../src/utils.js';
+import { buildSchema } from 'graphql';
+import { createMockStore, MockStore } from '../src/index.js';
+import { assertIsRef, Ref } from '../src/types.js';
+import { makeRef } from '../src/utils.js';
 
 const typeDefs = /* GraphQL */ `
   type User {

--- a/packages/mock/tests/store.spec.ts
+++ b/packages/mock/tests/store.spec.ts
@@ -629,39 +629,43 @@ describe('MockStore', () => {
 
   describe('filter method', () => {
     it('should be able to filter an empty list', () => {
-      const store = new MockStore({schema})
-      store.set('User', 'user1', {name: 'Ross'})
-      expect(store.filter('User', () => false)).toEqual([])
-      store.reset()
-      expect(store.filter('User', () => true)).toEqual([])
-    })
+      const store = new MockStore({ schema });
+      store.set('User', 'user1', { name: 'Ross' });
+      expect(store.filter('User', () => false)).toEqual([]);
+      store.reset();
+      expect(store.filter('User', () => true)).toEqual([]);
+    });
 
     it('should apply the filter', () => {
-      const store = new MockStore({schema})
-      store.set('User', 'user1', {name: 'Ross'})
-      store.set('User', 'user2', {name: 'Nico'})
-      expect(store.filter('User', () => true)).toEqual([{name: 'Ross'}, {name: 'Nico'}])
-      expect(store.filter('User', ({name}) => (name as string).startsWith('R'))).toEqual([{name: 'Ross'}])
-    })
-  })
+      const store = new MockStore({ schema });
+      store.set('User', 'user1', { name: 'Ross' });
+      store.set('User', 'user2', { name: 'Nico' });
+      expect(store.filter('User', () => true)).toEqual([{ name: 'Ross' }, { name: 'Nico' }]);
+      expect(store.filter('User', ({ name }) => (name as string).startsWith('R'))).toEqual([
+        { name: 'Ross' },
+      ]);
+    });
+  });
 
   describe('find method', () => {
     it('should return undefined for an empty store', () => {
-      const store = new MockStore({schema})
-      expect(store.find('User', () => true)).toBeUndefined()
-    })
+      const store = new MockStore({ schema });
+      expect(store.find('User', () => true)).toBeUndefined();
+    });
 
     it('should return undefined for a miss', () => {
-      const store = new MockStore({schema})
-      store.set('User', 'user1', {name: 'Ross'})
-      expect(store.find('User', () => false)).toBeUndefined()
-    })
+      const store = new MockStore({ schema });
+      store.set('User', 'user1', { name: 'Ross' });
+      expect(store.find('User', () => false)).toBeUndefined();
+    });
 
     it('should return a match', () => {
-      const store = new MockStore({schema})
-      store.set('User', 'user1', {name: 'Ross'})
-      store.set('User', 'user2', {name: 'Nico'})
-      expect(store.find('User', ({name}) => (name as string).startsWith('N'))).toEqual({name: 'Nico'})
-    })
-  })
+      const store = new MockStore({ schema });
+      store.set('User', 'user1', { name: 'Ross' });
+      store.set('User', 'user2', { name: 'Nico' });
+      expect(store.find('User', ({ name }) => (name as string).startsWith('N'))).toEqual({
+        name: 'Nico',
+      });
+    });
+  });
 });


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

In MockStore, this change guards against an empty store in calls to filter/find to avoid calling Object.values() on undefined.

Related #6262 

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [x] store.spec.ts:filter method
- [x] store.spec.ts:find method

**Test Environment**:

- OS: macos
- `@graphql-tools/mock`: 9.0.3
- NodeJS: v22.2.0

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments
None