### PR TITLE
[executors/http] wrap upstream graphql errors in a GraphQLError instance

### DIFF
--- a/.changeset/dry-rice-design.md
+++ b/.changeset/dry-rice-design.md
@@ -1,0 +1,5 @@
+---
+"@graphql-tools/executor-http": patch
+---
+
+When proxying the requests to the HTTP executor, it should return \`GraphQLError\` instances in \`errors\` array

--- a/packages/executors/http/src/index.ts
+++ b/packages/executors/http/src/index.ts
@@ -259,6 +259,27 @@ export function buildHTTPExecutor(
                   ],
                 };
               }
+              console.log(parsedResult);
+              if (Array.isArray(parsedResult.errors)) {
+                return {
+                  ...parsedResult,
+                  errors: parsedResult.errors.map(
+                    ({ message, ...options }: { message: string; extensions: Record<string, unknown> }) =>
+                      createGraphQLError(message, {
+                        ...options,
+                        extensions: {
+                          code: 'DOWNSTREAM_SERVICE_ERROR',
+                          ...options.extensions || {},
+                        },
+                      }),
+                  ),
+                }
+                parsedResult.errors = parsedResult.errors.map(
+                  ({ message, ...options }: { message: string }) =>
+                    createGraphQLError(message, options),
+                );
+                console.log(parsedResult.errors);
+              }
               return parsedResult;
             } catch (e: any) {
               return {

--- a/packages/executors/http/src/index.ts
+++ b/packages/executors/http/src/index.ts
@@ -263,16 +263,22 @@ export function buildHTTPExecutor(
                 return {
                   ...parsedResult,
                   errors: parsedResult.errors.map(
-                    ({ message, ...options }: { message: string; extensions: Record<string, unknown> }) =>
+                    ({
+                      message,
+                      ...options
+                    }: {
+                      message: string;
+                      extensions: Record<string, unknown>;
+                    }) =>
                       createGraphQLError(message, {
                         ...options,
                         extensions: {
                           code: 'DOWNSTREAM_SERVICE_ERROR',
-                          ...options.extensions || {},
+                          ...(options.extensions || {}),
                         },
                       }),
                   ),
-                }
+                };
               }
               return parsedResult;
             } catch (e: any) {

--- a/packages/executors/http/src/index.ts
+++ b/packages/executors/http/src/index.ts
@@ -259,7 +259,6 @@ export function buildHTTPExecutor(
                   ],
                 };
               }
-              console.log(parsedResult);
               if (Array.isArray(parsedResult.errors)) {
                 return {
                   ...parsedResult,
@@ -274,11 +273,6 @@ export function buildHTTPExecutor(
                       }),
                   ),
                 }
-                parsedResult.errors = parsedResult.errors.map(
-                  ({ message, ...options }: { message: string }) =>
-                    createGraphQLError(message, options),
-                );
-                console.log(parsedResult.errors);
               }
               return parsedResult;
             } catch (e: any) {

--- a/packages/executors/http/tests/buildHTTPExecutor.test.ts
+++ b/packages/executors/http/tests/buildHTTPExecutor.test.ts
@@ -260,7 +260,7 @@ describe('buildHTTPExecutor', () => {
       useGETForQueries: true,
       fetch() {
         return new Response(
-          JSON.stringify({ errors: [{ message: 'test error', extension: { code: 'test code' } }] }),
+          JSON.stringify({ errors: [{ message: 'test error', extensions: { code: 'test code' } }] }),
           {
             headers: { 'Content-Type': 'application/json' },
           },

--- a/packages/executors/http/tests/buildHTTPExecutor.test.ts
+++ b/packages/executors/http/tests/buildHTTPExecutor.test.ts
@@ -259,12 +259,9 @@ describe('buildHTTPExecutor', () => {
     const executor = buildHTTPExecutor({
       useGETForQueries: true,
       fetch() {
-        return new Response(
-          JSON.stringify({ errors: [{ message: 'test error', extensions: { code: 'test code' } }] }),
-          {
-            headers: { 'Content-Type': 'application/json' },
-          },
-        );
+        return new Response(JSON.stringify({ errors: [{ message: 'test error' }] }), {
+          headers: { 'Content-Type': 'application/json' },
+        });
       },
     });
 


### PR DESCRIPTION
## Description

To allow errors to bubble up from upstream to client, errors contained into a valid execution result should be wrapped into an actual GraphQLError instance

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

