### PR TITLE
test: backport test from graphql-js

### DIFF
--- a/packages/executor/src/execution/__tests__/executor-test.ts
+++ b/packages/executor/src/execution/__tests__/executor-test.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { inspect } from 'cross-inspect';
 import {
   GraphQLBoolean,
@@ -14,6 +15,7 @@ import {
   parse,
 } from 'graphql';
 import { expectJSON } from '../../__testUtils__/expectJSON.js';
+import { resolveOnNextTick } from '../../__testUtils__/resolveOnNextTick.js';
 import { execute, executeSync } from '../execute.js';
 
 describe('Execute: Handles basic execution tasks', () => {
@@ -561,6 +563,55 @@ describe('Execute: Handles basic execution tasks', () => {
         },
       ],
     });
+  });
+
+  it('handles sync errors combined with rejections', async () => {
+    let isAsyncResolverFinished = false;
+
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          syncNullError: {
+            type: new GraphQLNonNull(GraphQLString),
+            resolve: () => null,
+          },
+          asyncNullError: {
+            type: new GraphQLNonNull(GraphQLString),
+            async resolve() {
+              await resolveOnNextTick();
+              await resolveOnNextTick();
+              await resolveOnNextTick();
+              isAsyncResolverFinished = true;
+              return null;
+            },
+          },
+        },
+      }),
+    });
+
+    // Order is important here, as the promise has to be created before the synchronous error is thrown
+    const document = parse(`
+      {
+        asyncNullError
+        syncNullError
+      }
+    `);
+
+    const result = execute({ schema, document });
+
+    expect(isAsyncResolverFinished).toEqual(false);
+    expectJSON(await result).toDeepEqual({
+      data: null,
+      errors: [
+        {
+          message: 'Cannot return null for non-nullable field Query.syncNullError.',
+          locations: [{ line: 4, column: 9 }],
+          path: ['syncNullError'],
+        },
+      ],
+    });
+    expect(isAsyncResolverFinished).toEqual(true);
   });
 
   it('Full response path is included for non-nullable fields', () => {


### PR DESCRIPTION
Backports the test case from https://github.com/graphql/graphql-js/commit/)4a82557ae6d3b3c6cd72bcd528254296ecf7e9e8

The actual fix is already here.