### PR TITLE
Strip ignored characters when printing a query in executor-http

### DIFF
--- a/.changeset/brave-jars-work.md
+++ b/.changeset/brave-jars-work.md
@@ -1,0 +1,5 @@
+---
+"@graphql-tools/executor-http": patch
+---
+
+Strip ignored characters when printing a query in executor-http

--- a/packages/executors/http/src/defaultPrintFn.ts
+++ b/packages/executors/http/src/defaultPrintFn.ts
@@ -1,11 +1,11 @@
-import { DocumentNode, print } from 'graphql';
+import { DocumentNode, print, stripIgnoredCharacters } from 'graphql';
 
 const printCache = new WeakMap<DocumentNode, string>();
 
 export function defaultPrintFn(document: DocumentNode) {
   let printed = printCache.get(document);
   if (!printed) {
-    printed = print(document);
+    printed = stripIgnoredCharacters(print(document));
     printCache.set(document, printed);
   }
   return printed;


### PR DESCRIPTION
Save up payload size