### PR TITLE
expose the loaded supergraph sdl in the `schema` event

### DIFF
--- a/.changeset/yellow-boats-walk.md
+++ b/.changeset/yellow-boats-walk.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/federation': minor
+---
+
+Expose the loaded supergrapth SDL in the `schema` event

--- a/packages/federation/src/managed-federation.ts
+++ b/packages/federation/src/managed-federation.ts
@@ -304,7 +304,7 @@ export type SupergraphSchemaManagerOptions = Omit<
 };
 
 export class SupergraphSchemaManager extends EventEmitter<{
-  schema: [GraphQLSchema];
+  schema: [GraphQLSchema, string];
   error: [FetchError | unknown];
   failure: [FetchError | unknown, number];
   log: [{ source: 'uplink' | 'manager'; message: string; level: 'error' | 'warn' | 'info' }];
@@ -376,7 +376,7 @@ export class SupergraphSchemaManager extends EventEmitter<{
       if ('schema' in result) {
         this.#lastSeenId = result.id;
         this.schema = result.schema;
-        this.emit('schema', result.schema);
+        this.emit('schema', result.schema, result.supergraphSdl);
         this.#log('info', 'Supergraph successfully updated');
       } else {
         this.#log('info', 'Supergraph is up to date');


### PR DESCRIPTION
## Description

The `schema` event is emitted each time we load a new schema with the already stitched schema. 

It can be useful to also have access to the raw supergraph SDL.

This is for example usefull for the integration with Apollo Server and its usage reporting feature.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
