### PR TITLE
fix: remove optional chaining in debug environment variable check

### DIFF
--- a/packages/utils/src/debugTimer.ts
+++ b/packages/utils/src/debugTimer.ts
@@ -1,7 +1,7 @@
 const debugNamesOngoing = new Set<string>();
 
 export function debugTimerStart(name: string) {
-  const debugEnvVar = globalThis.process.env['DEBUG'] || (globalThis as any).DEBUG;
+  const debugEnvVar = globalThis.process?.env?.['DEBUG'] || (globalThis as any).DEBUG;
   if (debugEnvVar === '1' || debugEnvVar?.includes(name)) {
     debugNamesOngoing.add(name);
     console.time(name);

--- a/packages/utils/src/debugTimer.ts
+++ b/packages/utils/src/debugTimer.ts
@@ -1,7 +1,7 @@
 const debugNamesOngoing = new Set<string>();
 
 export function debugTimerStart(name: string) {
-  const debugEnvVar = globalThis?.process.env['DEBUG'] || (globalThis as any).DEBUG;
+  const debugEnvVar = globalThis.process.env['DEBUG'] || (globalThis as any).DEBUG;
   if (debugEnvVar === '1' || debugEnvVar?.includes(name)) {
     debugNamesOngoing.add(name);
     console.time(name);


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

## Description

Removed optional chaining from `globalThis?.process.env['DEBUG'] || globalThis.DEBUG` to ensure it runs on Cloudflare Workers.
 
The current implementation with optional chaining is flawed as it fails when `globalThis` is undefined, resulting in an error when accessing `process.env`. Although this change does not fully resolve the issue, it aligns with the requirement for Cloudflare Workers compatibility.

Related https://github.com/cloudflare/workers-sdk/issues/6402

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

![image](https://github.com/user-attachments/assets/68323c6a-504b-4857-9625-8224421d8afa)

**Test Environment**:

- OS: MacOS
- `@graphql-tools/...`:
- NodeJS: 20



## Further comments

The original error is within the Cloudflare Worker runtime, but this update ensures it will work in that environment.
