### PR TITLE
add graphql conf 2024 banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![GraphQLConf 2024 Banner: September 10-12, San Francisco. Hosted by the GraphQL Foundation](https://github.com/user-attachments/assets/bdb8cd5d-5186-4ece-b06b-b00a499b7868)](https://graphql.org/conf/2024/?utm_source=github&utm_medium=graphql_tools&utm_campaign=readme)
+
 [![toolkit](https://user-images.githubusercontent.com/20847995/80261023-feb6e380-8691-11ea-8680-5747fa02c5d8.gif)](https://graphql-tools.com)
 
 [![npm version](https://badge.fury.io/js/%40graphql-tools%2Futils.svg)](https://badge.fury.io/js/%40graphql-tools%2Futils)


### PR DESCRIPTION
Way to boost GraphQL Conf. Discussed on [Slack](https://guild-oss.slack.com/archives/C03J3MBLJ6M/p1722873867810819).
