### PR TITLE
fix: forward operation directives to the subschema requests

### DIFF
--- a/.changeset/@graphql-tools_delegate-6420-dependencies.md
+++ b/.changeset/@graphql-tools_delegate-6420-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@graphql-tools/delegate": patch
+---
+dependencies updates:
+  - Added dependency [`@repeaterjs/repeater@^3.0.6` ↗︎](https://www.npmjs.com/package/@repeaterjs/repeater/v/3.0.6) (to `dependencies`)

--- a/.changeset/good-parents-push.md
+++ b/.changeset/good-parents-push.md
@@ -1,0 +1,10 @@
+---
+'@graphql-tools/delegate': patch
+---
+
+Pass operation directives correctly to the subschema;
+```graphql
+query {
+  hello @someDir
+}
+```

--- a/.changeset/nice-parrots-kick.md
+++ b/.changeset/nice-parrots-kick.md
@@ -1,0 +1,6 @@
+---
+'@graphql-tools/executor': patch
+'@graphql-tools/utils': patch
+---
+
+`mapAsyncIterator` now accepts `AsyncIterable`

--- a/packages/delegate/package.json
+++ b/packages/delegate/package.json
@@ -54,6 +54,7 @@
     "@graphql-tools/executor": "^1.3.0",
     "@graphql-tools/schema": "^10.0.4",
     "@graphql-tools/utils": "^10.2.3",
+    "@repeaterjs/repeater": "^3.0.6",
     "dataloader": "^2.2.2",
     "tslib": "^2.5.0"
   },

--- a/packages/delegate/src/createRequest.ts
+++ b/packages/delegate/src/createRequest.ts
@@ -107,8 +107,8 @@ export function createRequest({
       newVariables,
     );
   }
-
-  const rootFieldName = targetFieldName ?? fieldNodes?.[0]?.name.value;
+  const fieldNode = fieldNodes?.[0];
+  const rootFieldName = targetFieldName ?? fieldNode?.name.value;
 
   if (rootFieldName === undefined) {
     throw new Error(`Either "targetFieldName" or a non empty "fieldNodes" array must be provided.`);
@@ -122,6 +122,7 @@ export function createRequest({
       value: rootFieldName,
     },
     selectionSet: newSelectionSet,
+    directives: fieldNode?.directives,
   };
 
   const operationName: NameNode | undefined = targetOperationName

--- a/packages/executor/src/execution/execute.ts
+++ b/packages/executor/src/execution/execute.ts
@@ -1641,7 +1641,7 @@ function mapSourceToResponse(
   // "ExecuteQuery" algorithm, for which `execute` is also used.
   return flattenAsyncIterable(
     mapAsyncIterator(
-      resultOrStream[Symbol.asyncIterator](),
+      resultOrStream,
       async (payload: unknown) =>
         ensureAsyncIterable(await executeImpl(buildPerEventExecutionContext(exeContext, payload))),
       (error: Error) => {

--- a/packages/federation/test/__snapshots__/defer-stream.test.ts.snap
+++ b/packages/federation/test/__snapshots__/defer-stream.test.ts.snap
@@ -291,7 +291,7 @@ exports[`Defer/Stream streams: stream 1`] = `
     ],
   },
   {
-    "hasNext": false,
+    "hasNext": true,
     "incremental": [
       {
         "items": [
@@ -316,6 +316,9 @@ exports[`Defer/Stream streams: stream 1`] = `
         ],
       },
     ],
+  },
+  {
+    "hasNext": false,
   },
 ]
 `;

--- a/packages/stitch/tests/operationDirectives.test.ts
+++ b/packages/stitch/tests/operationDirectives.test.ts
@@ -1,0 +1,48 @@
+import { parse, print } from 'graphql';
+import { normalizedExecutor } from '@graphql-tools/executor';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { stitchSchemas } from '../src/stitchSchemas';
+
+describe('Operation Directives', () => {
+  it('sends the directives to the subschema operations', async () => {
+    const schema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        directive @strExpr on FIELD
+        type Query {
+          hello: String
+        }
+      `,
+      resolvers: {
+        Query: {
+          hello: (_source, _args, _context, info) => {
+            return print(info.operation);
+          },
+        },
+      },
+    });
+
+    const gateway = stitchSchemas({
+      subschemas: [schema],
+      mergeDirectives: true,
+    });
+
+    const res = await normalizedExecutor({
+      schema: gateway,
+      document: parse(/* GraphQL */ `
+        query getHello {
+          hello @strExpr
+        }
+      `),
+    });
+
+    expect(res).toEqual({
+      data: {
+        hello: /* GraphQL */ `
+query getHello {
+  __typename
+  hello @strExpr
+}`.trim(),
+      },
+    });
+  });
+});

--- a/packages/utils/src/mapAsyncIterator.ts
+++ b/packages/utils/src/mapAsyncIterator.ts
@@ -6,11 +6,14 @@ import { isPromise } from './jsutils.js';
  * which produces values mapped via calling the callback function.
  */
 export function mapAsyncIterator<T, U>(
-  iterator: AsyncIterator<T>,
+  iterator: AsyncIterable<T> | AsyncIterator<T>,
   onNext: (value: T) => MaybePromise<U>,
   onError?: any,
   onEnd?: () => MaybePromise<void>,
 ): AsyncIterableIterator<U> {
+  if (Symbol.asyncIterator in iterator) {
+    iterator = iterator[Symbol.asyncIterator]();
+  }
   let $return: () => Promise<IteratorResult<T>>;
   let abruptClose: (error: any) => Promise<never>;
   let onEndWithValue: <R>(value: R) => MaybePromise<R>;

--- a/packages/wrap/tests/requests.test.ts
+++ b/packages/wrap/tests/requests.test.ts
@@ -1,6 +1,7 @@
-import { OperationTypeNode, parse } from 'graphql';
+import { OperationTypeNode, print } from 'graphql';
 import { createRequest } from '@graphql-tools/delegate';
 import { parseSelectionSet } from '@graphql-tools/utils';
+import '../../testing/to-be-similar-gql-doc';
 
 function removeLocations(value: any): any {
   if (value == null) {
@@ -37,16 +38,7 @@ describe('requests', () => {
       }),
     );
 
-    const expectedRequest = removeLocations({
-      document: parse(/* GraphQL */ `
-        query test {
-          version {
-            major
-            minor
-            patch
-          }
-        }
-      `),
+    expect(request).toMatchObject({
       rootValue: undefined,
       variables: {},
       operationName: 'test',
@@ -55,6 +47,14 @@ describe('requests', () => {
       info: undefined,
     });
 
-    expect(expectedRequest).toMatchObject(request);
+    expect(print(request.document)).toBeSimilarGqlDoc(/* GraphQL */ `
+      query test {
+        version {
+          major
+          minor
+          patch
+        }
+      }
+    `);
   });
 });


### PR DESCRIPTION
Pass operation directives correctly to the subschema;
```graphql
query {
  hello @someDir
}
```

Closes https://github.com/ardatan/graphql-tools/issues/6292