### PR TITLE
fix(utils): Allow invalid path in getDirectiveExtensions

### DIFF
--- a/packages/utils/src/getDirectiveExtensions.ts
+++ b/packages/utils/src/getDirectiveExtensions.ts
@@ -68,7 +68,7 @@ export function getDirectiveExtensions<
   if (directableObj.extensions) {
     let directivesInExtensions = directableObj.extensions;
     for (const pathSegment of pathToDirectivesInExtensions) {
-      directivesInExtensions = directivesInExtensions[pathSegment];
+      directivesInExtensions = directivesInExtensions?.[pathSegment];
     }
     if (directivesInExtensions != null) {
       for (const directiveNameProp in directivesInExtensions) {

--- a/packages/utils/tests/getDirectiveExtensions.spec.ts
+++ b/packages/utils/tests/getDirectiveExtensions.spec.ts
@@ -1,0 +1,65 @@
+import { GraphQLObjectType } from 'graphql';
+import { getDirectiveExtensions } from '../src';
+
+describe('getDirectiveExtensions', () => {
+  it('should return directive extensions when they are in the directives path', () => {
+    const objectType = new GraphQLObjectType({
+      name: 'User',
+      fields: () => ({}),
+      extensions: {
+        directives: {
+          id: {},
+        },
+      },
+    });
+
+    const directiveExtensions = getDirectiveExtensions(objectType);
+    expect(directiveExtensions).toEqual(expect.objectContaining({ id: expect.any(Object) }));
+  });
+
+  it('should return directive extensions when they are in the a custom path', () => {
+    const objectType = new GraphQLObjectType({
+      name: 'TestObject',
+      fields: () => ({}),
+      extensions: {
+        custom: {
+          directives: {
+            path: {
+              id: {},
+            },
+          },
+        },
+      },
+    });
+
+    const directiveExtensions = getDirectiveExtensions(objectType, undefined, [
+      'custom',
+      'directives',
+      'path',
+    ]);
+    expect(directiveExtensions).toEqual(expect.objectContaining({ id: expect.any(Object) }));
+  });
+
+  it('should return no directive extensions when they are no defined', () => {
+    const objectType = new GraphQLObjectType({
+      name: 'TestObject',
+      fields: () => ({}),
+    });
+    const directiveExtensions = getDirectiveExtensions(objectType);
+    expect(directiveExtensions).toEqual({});
+  });
+
+  it('should return no directive extensions when an invalid extension path is given', () => {
+    const objectType = new GraphQLObjectType({
+      name: 'TestObject',
+      fields: () => ({}),
+    });
+    const directiveExtensions = getDirectiveExtensions(objectType, undefined, [
+      'not',
+      'a',
+      'real',
+      'path',
+    ]);
+    expect(directiveExtensions).toEqual({});
+  });
+});


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

This change allow for invalid paths to be specified within the `getDirectiveExtensions` function.

Related #6435 

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

The function is tested in other tests, but a small set of tests specific to the function is now included with failing test that has been fixed:
```
 PASS  packages/utils/tests/getDirectiveExtensions.spec.ts
```

**Test Environment**:

- OS:
- `@graphql-tools/...`:
- NodeJS:

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
