### PR TITLE
Nested Computed Fields Edge Case

### DIFF
--- a/.changeset/four-deers-protect.md
+++ b/.changeset/four-deers-protect.md
@@ -3,5 +3,189 @@
 '@graphql-tools/delegate': patch
 ---
 
-Handle nested computed fields correctly
-If there is a field in a subschema that requires another field that requires another field, add all dependencies to the query plan. This is necessary for computed fields that depend on other computed fields.
+Fix the bug happens when a merged field is a computed field requires another computed field requires a field from the initial subschema.
+
+In the following test case, `totalOrdersPrices` needs `userOrders` which needs `lastName` from initial `Query.user`.
+So the bug was skipping the dependencies of `userOrders` because it assumed `lastName` already there by mistake.
+
+```ts
+    const schema1 = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        type User {
+          id: ID!
+          firstName: String!
+          lastName: String!
+          address: String
+        }
+
+        type Query {
+          user: User
+        }
+      `,
+      resolvers: {
+        Query: {
+          user: () => {
+            return {
+              id: 1,
+              firstName: 'Jake',
+              lastName: 'Dawkins',
+              address: 'everywhere',
+            };
+          },
+        },
+      },
+    });
+    const schema2 = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        type UserOrder {
+          id: ID!
+        }
+
+        type User {
+          id: ID!
+          totalOrdersPrices: Int
+          aggregatedOrdersByStatus: Int
+        }
+
+        type Query {
+          userWithOrderDetails(userId: ID!, userOrderIds: [ID]): User
+        }
+      `,
+      resolvers: {
+        Query: {
+          userWithOrderDetails: (_root, { userId, userOrderIds }) => {
+            return {
+              id: userId,
+              userOrders: userOrderIds?.map((userOrderId: string) => ({ id: userOrderId })),
+            };
+          },
+        },
+        User: {
+          totalOrdersPrices(user) {
+            if (user.userOrders instanceof Error) {
+              return user.userOrders;
+            }
+            if (!user.userOrders) {
+              throw new Error('UserOrders is required');
+            }
+            return 0;
+          },
+          aggregatedOrdersByStatus(user) {
+            if (user.userOrders instanceof Error) {
+              return user.userOrders;
+            }
+            if (!user.userOrders) {
+              throw new Error('UserOrders is required');
+            }
+            return 1;
+          },
+        },
+      },
+    });
+    const schema3 = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        type User {
+          id: ID!
+          userOrders: [UserOrder!]
+        }
+
+        type UserOrder {
+          id: ID!
+        }
+
+        type Query {
+          userWithOrders(id: ID!, lastName: String): User
+        }
+      `,
+      resolvers: {
+        Query: {
+          userWithOrders: (_root, { id, lastName }) => {
+            return {
+              id,
+              lastName,
+            };
+          },
+        },
+        User: {
+          userOrders(user) {
+            if (!user.lastName) {
+              throw new Error('LastName is required');
+            }
+            return [
+              {
+                id: `${user.lastName}1`,
+              },
+            ];
+          },
+        },
+      },
+    });
+    const stitchedSchema = stitchSchemas({
+      subschemas: [
+        {
+          schema: schema1,
+        },
+        {
+          schema: schema2,
+          merge: {
+            User: {
+              selectionSet: '{ id }',
+              fieldName: 'userWithOrderDetails',
+              args: ({ id, userOrders }: { id: string; userOrders: any[] }) => ({
+                userId: id,
+                userOrderIds: userOrders?.map?.(({ id }: { id: string }) => id),
+              }),
+              fields: {
+                totalOrdersPrices: {
+                  selectionSet: '{ userOrders { id } }',
+                  computed: true,
+                },
+                aggregatedOrdersByStatus: {
+                  selectionSet: '{ userOrders { id } }',
+                  computed: true,
+                },
+              },
+            },
+          },
+        },
+        {
+          schema: schema3,
+          merge: {
+            User: {
+              selectionSet: '{ id }',
+              fieldName: 'userWithOrders',
+              args: ({ id, lastName }: { id: string; lastName: string }) => ({
+                id,
+                lastName,
+              }),
+              fields: {
+                userOrders: {
+                  selectionSet: '{ lastName }',
+                  computed: true,
+                },
+              },
+            },
+          },
+        },
+      ],
+    });
+    const res = await normalizedExecutor({
+      schema: stitchedSchema,
+      document: parse(/* GraphQL */ `
+        query User {
+          user {
+            aggregatedOrdersByStatus
+            totalOrdersPrices
+          }
+        }
+      `),
+    });
+    expect(res).toEqual({
+      data: {
+        user: {
+          aggregatedOrdersByStatus: 1,
+          totalOrdersPrices: 0,
+        },
+      },
+    });
+```

--- a/.changeset/four-deers-protect.md
+++ b/.changeset/four-deers-protect.md
@@ -1,0 +1,7 @@
+---
+'@graphql-tools/federation': patch
+'@graphql-tools/delegate': patch
+---
+
+Handle nested computed fields correctly
+If there is a field in a subschema that requires another field that requires another field, add all dependencies to the query plan. This is necessary for computed fields that depend on other computed fields.

--- a/packages/delegate/tests/prepareGatewayDocument.test.ts
+++ b/packages/delegate/tests/prepareGatewayDocument.test.ts
@@ -527,6 +527,7 @@ describe('prepareGatewayDocument', () => {
       }
     `);
   });
+  // `totalOrdersPrices` needs `userOrders` which needs `lastName` when `totalOrdersPrices` is asked by `Query.user`
   it('adds dependencies nestedly', async () => {
     const schema1 = makeExecutableSchema({
       typeDefs: /* GraphQL */ `

--- a/packages/delegate/tests/prepareGatewayDocument.test.ts
+++ b/packages/delegate/tests/prepareGatewayDocument.test.ts
@@ -527,4 +527,185 @@ describe('prepareGatewayDocument', () => {
       }
     `);
   });
+  it('adds dependencies nestedly', async () => {
+    const schema1 = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        type User {
+          id: ID!
+          firstName: String!
+          lastName: String!
+          address: String
+        }
+
+        type Query {
+          user: User
+        }
+      `,
+      resolvers: {
+        Query: {
+          user: () => {
+            return {
+              id: 1,
+              firstName: 'Jake',
+              lastName: 'Dawkins',
+              address: 'everywhere',
+            };
+          },
+        },
+      },
+    });
+    const schema2 = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        type UserOrder {
+          id: ID!
+        }
+
+        type User {
+          id: ID!
+          totalOrdersPrices: Int
+          aggregatedOrdersByStatus: Int
+        }
+
+        type Query {
+          userWithOrderDetails(userId: ID!, userOrderIds: [ID]): User
+        }
+      `,
+      resolvers: {
+        Query: {
+          userWithOrderDetails: (_root, { userId, userOrderIds }) => {
+            return {
+              id: userId,
+              userOrders: userOrderIds?.map((userOrderId: string) => ({ id: userOrderId })),
+            };
+          },
+        },
+        User: {
+          totalOrdersPrices(user) {
+            if (user.userOrders instanceof Error) {
+              return user.userOrders;
+            }
+            if (!user.userOrders) {
+              throw new Error('UserOrders is required');
+            }
+            return 0;
+          },
+          aggregatedOrdersByStatus(user) {
+            if (user.userOrders instanceof Error) {
+              return user.userOrders;
+            }
+            if (!user.userOrders) {
+              throw new Error('UserOrders is required');
+            }
+            return 1;
+          },
+        },
+      },
+    });
+    const schema3 = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        type User {
+          id: ID!
+          userOrders: [UserOrder!]
+        }
+
+        type UserOrder {
+          id: ID!
+        }
+
+        type Query {
+          userWithOrders(id: ID!, lastName: String): User
+        }
+      `,
+      resolvers: {
+        Query: {
+          userWithOrders: (_root, { id, lastName }) => {
+            return {
+              id,
+              lastName,
+            };
+          },
+        },
+        User: {
+          userOrders(user) {
+            if (!user.lastName) {
+              throw new Error('LastName is required');
+            }
+            return [
+              {
+                id: `${user.lastName}1`,
+              },
+            ];
+          },
+        },
+      },
+    });
+    const stitchedSchema = stitchSchemas({
+      subschemas: [
+        {
+          schema: schema1,
+        },
+        {
+          schema: schema2,
+          merge: {
+            User: {
+              selectionSet: '{ id }',
+              fieldName: 'userWithOrderDetails',
+              args: ({ id, userOrders }: { id: string; userOrders: any[] }) => ({
+                userId: id,
+                userOrderIds: userOrders?.map?.(({ id }: { id: string }) => id),
+              }),
+              fields: {
+                totalOrdersPrices: {
+                  selectionSet: '{ userOrders { id } }',
+                  computed: true,
+                },
+                aggregatedOrdersByStatus: {
+                  selectionSet: '{ userOrders { id } }',
+                  computed: true,
+                },
+              },
+            },
+          },
+        },
+        {
+          schema: schema3,
+          merge: {
+            User: {
+              selectionSet: '{ id }',
+              fieldName: 'userWithOrders',
+              args: ({ id, lastName }: { id: string; lastName: string }) => ({
+                id,
+                lastName,
+              }),
+              fields: {
+                userOrders: {
+                  selectionSet: '{ lastName }',
+                  computed: true,
+                },
+              },
+            },
+          },
+        },
+      ],
+    });
+    const res = await normalizedExecutor({
+      schema: stitchedSchema,
+      document: parse(/* GraphQL */ `
+        query User {
+          user {
+            aggregatedOrdersByStatus
+            totalOrdersPrices
+          }
+        }
+      `),
+    });
+    expect(res).toEqual({
+      data: {
+        user: {
+          aggregatedOrdersByStatus: 1,
+          totalOrdersPrices: 0,
+        },
+      },
+    });
+  });
 });

--- a/packages/federation/src/utils.ts
+++ b/packages/federation/src/utils.ts
@@ -10,7 +10,7 @@ export function getKeyForFederation<TRoot>(root: TRoot): TRoot {
 }
 
 export function projectDataSelectionSet(data: any, selectionSet?: SelectionSetNode): any {
-  if (data == null || selectionSet == null) {
+  if (data == null || selectionSet == null || data instanceof Error) {
     return data;
   }
   if (Array.isArray(data)) {
@@ -25,12 +25,14 @@ export function projectDataSelectionSet(data: any, selectionSet?: SelectionSetNo
       if (Object.prototype.hasOwnProperty.call(data, key)) {
         const projectedKeyData = projectDataSelectionSet(data[key], selection.selectionSet);
         if (projectedData[key]) {
-          projectedData[key] = mergeDeep(
-            [projectedData[key], projectedKeyData],
-            undefined,
-            true,
-            true,
-          );
+          if (projectedKeyData != null && !(projectedKeyData instanceof Error)) {
+            projectedData[key] = mergeDeep(
+              [projectedData[key], projectedKeyData],
+              undefined,
+              true,
+              true,
+            );
+          }
         } else {
           projectedData[key] = projectedKeyData;
         }

--- a/packages/federation/test/federation-compatibility.test.ts
+++ b/packages/federation/test/federation-compatibility.test.ts
@@ -21,7 +21,7 @@ import {
 } from '@graphql-tools/utils';
 import { getStitchedSchemaFromSupergraphSdl } from '../src/supergraph';
 
-describe.skip('Federation Compatibility', () => {
+describe('Federation Compatibility', () => {
   if (!existsSync(join(__dirname, 'fixtures', 'federation-compatibility'))) {
     console.warn('Make sure you fetched the fixtures from the API first');
     it.skip('skipping tests', () => {});


### PR DESCRIPTION

Fix the bug happens when a merged field is a computed field requires another computed field requires a field from the initial subschema.

In the following test case, `totalOrdersPrices` needs `userOrders` which needs `lastName` from initial `Query.user`.
So the bug was skipping the dependencies of `userOrders` because it assumed `lastName` already there by mistake.

```ts
    const schema1 = makeExecutableSchema({
      typeDefs: /* GraphQL */ `
        type User {
          id: ID!
          firstName: String!
          lastName: String!
          address: String
        }

        type Query {
          user: User
        }
      `,
      resolvers: {
        Query: {
          user: () => {
            return {
              id: 1,
              firstName: 'Jake',
              lastName: 'Dawkins',
              address: 'everywhere',
            };
          },
        },
      },
    });
    const schema2 = makeExecutableSchema({
      typeDefs: /* GraphQL */ `
        type UserOrder {
          id: ID!
        }

        type User {
          id: ID!
          totalOrdersPrices: Int
          aggregatedOrdersByStatus: Int
        }

        type Query {
          userWithOrderDetails(userId: ID!, userOrderIds: [ID]): User
        }
      `,
      resolvers: {
        Query: {
          userWithOrderDetails: (_root, { userId, userOrderIds }) => {
            return {
              id: userId,
              userOrders: userOrderIds?.map((userOrderId: string) => ({ id: userOrderId })),
            };
          },
        },
        User: {
          totalOrdersPrices(user) {
            if (user.userOrders instanceof Error) {
              return user.userOrders;
            }
            if (!user.userOrders) {
              throw new Error('UserOrders is required');
            }
            return 0;
          },
          aggregatedOrdersByStatus(user) {
            if (user.userOrders instanceof Error) {
              return user.userOrders;
            }
            if (!user.userOrders) {
              throw new Error('UserOrders is required');
            }
            return 1;
          },
        },
      },
    });
    const schema3 = makeExecutableSchema({
      typeDefs: /* GraphQL */ `
        type User {
          id: ID!
          userOrders: [UserOrder!]
        }

        type UserOrder {
          id: ID!
        }

        type Query {
          userWithOrders(id: ID!, lastName: String): User
        }
      `,
      resolvers: {
        Query: {
          userWithOrders: (_root, { id, lastName }) => {
            return {
              id,
              lastName,
            };
          },
        },
        User: {
          userOrders(user) {
            if (!user.lastName) {
              throw new Error('LastName is required');
            }
            return [
              {
                id: `${user.lastName}1`,
              },
            ];
          },
        },
      },
    });
    const stitchedSchema = stitchSchemas({
      subschemas: [
        {
          schema: schema1,
        },
        {
          schema: schema2,
          merge: {
            User: {
              selectionSet: '{ id }',
              fieldName: 'userWithOrderDetails',
              args: ({ id, userOrders }: { id: string; userOrders: any[] }) => ({
                userId: id,
                userOrderIds: userOrders?.map?.(({ id }: { id: string }) => id),
              }),
              fields: {
                totalOrdersPrices: {
                  selectionSet: '{ userOrders { id } }',
                  computed: true,
                },
                aggregatedOrdersByStatus: {
                  selectionSet: '{ userOrders { id } }',
                  computed: true,
                },
              },
            },
          },
        },
        {
          schema: schema3,
          merge: {
            User: {
              selectionSet: '{ id }',
              fieldName: 'userWithOrders',
              args: ({ id, lastName }: { id: string; lastName: string }) => ({
                id,
                lastName,
              }),
              fields: {
                userOrders: {
                  selectionSet: '{ lastName }',
                  computed: true,
                },
              },
            },
          },
        },
      ],
    });
    const res = await normalizedExecutor({
      schema: stitchedSchema,
      document: parse(/* GraphQL */ `
        query User {
          user {
            aggregatedOrdersByStatus
            totalOrdersPrices
          }
        }
      `),
    });
    expect(res).toEqual({
      data: {
        user: {
          aggregatedOrdersByStatus: 1,
          totalOrdersPrices: 0,
        },
      },
    });
```
