### PR TITLE
fix(federation): filter errors as \`null\` while projecting the entity for the key

### DIFF
--- a/.changeset/witty-lemons-drive.md
+++ b/.changeset/witty-lemons-drive.md
@@ -3,3 +3,5 @@
 ---
 
 Filter errors as null in the projected key
+
+If the key field has `Error`, do not send them to the subgraphs as objects but `null`.

--- a/.changeset/witty-lemons-drive.md
+++ b/.changeset/witty-lemons-drive.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/federation': patch
+---
+
+Filter errors as null in the projected key

--- a/packages/federation/src/utils.ts
+++ b/packages/federation/src/utils.ts
@@ -10,8 +10,11 @@ export function getKeyForFederation<TRoot>(root: TRoot): TRoot {
 }
 
 export function projectDataSelectionSet(data: any, selectionSet?: SelectionSetNode): any {
-  if (data == null || selectionSet == null || data instanceof Error) {
+  if (data == null || selectionSet == null) {
     return data;
+  }
+  if (data instanceof Error) {
+    return null;
   }
   if (Array.isArray(data)) {
     return data.map(entry => projectDataSelectionSet(entry, selectionSet));

--- a/packages/federation/test/getKeyFnForFederation.test.ts
+++ b/packages/federation/test/getKeyFnForFederation.test.ts
@@ -1,3 +1,4 @@
+import { createGraphQLError } from '@graphql-tools/utils';
 import { getKeyFnForFederation } from '../src/utils';
 
 describe('getKeyFnForFederation', () => {
@@ -61,6 +62,22 @@ describe('getKeyFnForFederation', () => {
           tag: 'Test2',
         },
       ],
+    });
+  });
+  it('filter errors as null', () => {
+    const key = ['name', 'address { city }'];
+    const data = {
+      __typename: 'Test',
+      name: 'Test',
+      address: createGraphQLError('Failed to fetch address'),
+      price: 100,
+      extra: 'Extra',
+    };
+    const keyFn = getKeyFnForFederation('Test', key);
+    expect(keyFn(data)).toEqual({
+      __typename: 'Test',
+      name: 'Test',
+      address: null,
     });
   });
 });


### PR DESCRIPTION
Filter errors as null in the projected key

If the key field has `Error`, do not send them to the subgraphs as objects but `null`.