### PR TITLE
Fix nested computed fields

### DIFF
--- a/.changeset/stale-feet-rhyme.md
+++ b/.changeset/stale-feet-rhyme.md
@@ -1,0 +1,41 @@
+---
+'@graphql-tools/federation': patch
+'@graphql-tools/delegate': patch
+---
+
+Handle merged selection sets in the computed fields;
+
+When a selection set for a computed field needs to be merged, resolve that required selection set fully then resolve the computed field.
+In the following case, the selection set for the `author` field in the `Post` type is merged with the selection set for the `authorId` field in the `Comment` type.
+
+```graphql
+type Query {
+  feed: [Post!]!
+}
+
+type Post {
+  id: ID!
+  author: User! @computed(selectionSet: "{ comments { authorId } }")
+}
+
+type Comment {
+  id: ID!
+  authorId: ID!
+}
+
+type User {
+  id: ID!
+  name: String!
+}
+```
+
+```graphql
+type Post {
+  id: ID!
+  comments: [Comment!]!
+}
+
+type Comment {
+  id: ID!
+}
+```

--- a/packages/delegate/src/mergeFields.ts
+++ b/packages/delegate/src/mergeFields.ts
@@ -37,9 +37,9 @@ export function annotateExternalObject<TContext>(
   subschemaMap: Record<string, GraphQLSchema | SubschemaConfig<any, any, any, Record<string, any>>>,
 ): ExternalObject {
   Object.defineProperties(object, {
-    [OBJECT_SUBSCHEMA_SYMBOL]: { value: subschema },
-    [FIELD_SUBSCHEMA_MAP_SYMBOL]: { value: subschemaMap },
-    [UNPATHED_ERRORS_SYMBOL]: { value: errors },
+    [OBJECT_SUBSCHEMA_SYMBOL]: { value: subschema, writable: true },
+    [FIELD_SUBSCHEMA_MAP_SYMBOL]: { value: subschemaMap, writable: true },
+    [UNPATHED_ERRORS_SYMBOL]: { value: errors, writable: true },
   });
   return object;
 }

--- a/packages/delegate/src/resolveExternalValue.ts
+++ b/packages/delegate/src/resolveExternalValue.ts
@@ -178,7 +178,7 @@ function reportUnpathedErrorsViaNull(unpathedErrors: Array<GraphQLError>) {
 
     if (unreportedErrors.length) {
       if (unreportedErrors.length === 1) {
-        return unreportedErrors[0];
+        return locatedError(unreportedErrors[0], undefined as any, unreportedErrors[0].path as any);
       }
 
       return new AggregateError(

--- a/packages/federation/src/supergraph.ts
+++ b/packages/federation/src/supergraph.ts
@@ -662,9 +662,12 @@ export function getStitchingOptionsFromSupergraphSdl(
         if (fieldsKeyMap) {
           const fieldsConfig: Record<string, MergedFieldConfig> = (mergedTypeConfig.fields = {});
           for (const [fieldName, fieldNameKey] of fieldsKeyMap) {
-            extraKeys.add(fieldNameKey);
+            const aliasedFieldNameKey = fieldNameKey.includes('(')
+              ? `_${fieldNameKey.split('(')[0]}: ${fieldNameKey}`
+              : fieldNameKey;
+            extraKeys.add(aliasedFieldNameKey);
             fieldsConfig[fieldName] = {
-              selectionSet: `{ ${fieldNameKey} }`,
+              selectionSet: `{ ${aliasedFieldNameKey} }`,
               computed: true,
             };
           }

--- a/packages/federation/src/utils.ts
+++ b/packages/federation/src/utils.ts
@@ -24,20 +24,21 @@ export function projectDataSelectionSet(data: any, selectionSet?: SelectionSetNo
   };
   for (const selection of selectionSet.selections) {
     if (selection.kind === Kind.FIELD) {
-      const key = selection.name.value;
-      if (Object.prototype.hasOwnProperty.call(data, key)) {
-        const projectedKeyData = projectDataSelectionSet(data[key], selection.selectionSet);
-        if (projectedData[key]) {
+      const fieldName = selection.name.value;
+      const responseKey = selection.alias?.value || selection.name.value;
+      if (Object.prototype.hasOwnProperty.call(data, responseKey)) {
+        const projectedKeyData = projectDataSelectionSet(data[responseKey], selection.selectionSet);
+        if (projectedData[fieldName]) {
           if (projectedKeyData != null && !(projectedKeyData instanceof Error)) {
-            projectedData[key] = mergeDeep(
-              [projectedData[key], projectedKeyData],
+            projectedData[fieldName] = mergeDeep(
+              [projectedData[fieldName], projectedKeyData],
               undefined,
               true,
               true,
             );
           }
         } else {
-          projectedData[key] = projectedKeyData;
+          projectedData[fieldName] = projectedKeyData;
         }
       }
     } else if (selection.kind === Kind.INLINE_FRAGMENT) {

--- a/packages/federation/test/federation-compatibility.test.ts
+++ b/packages/federation/test/federation-compatibility.test.ts
@@ -21,7 +21,7 @@ import {
 } from '@graphql-tools/utils';
 import { getStitchedSchemaFromSupergraphSdl } from '../src/supergraph';
 
-describe.skip('Federation Compatibility', () => {
+describe('Federation Compatibility', () => {
   if (!existsSync(join(__dirname, 'fixtures', 'federation-compatibility'))) {
     console.warn('Make sure you fetched the fixtures from the API first');
     it.skip('skipping tests', () => {});


### PR DESCRIPTION

Handle merged selection sets in the computed fields;

When a selection set for a computed field needs to be merged, resolve that required selection set fully then resolve the computed field.
In the following case, the selection set for the `author` field in the `Post` type is merged with the selection set for the `authorId` field in the `Comment` type.

Query:
```graphql
{
  feed {
   author { id }
  }
}
```

Subschema A;
```graphql
type Query {
  feed: [Post!]!
}

type Post {
  id: ID!
  author: User! @computed(selectionSet: "{ comments { authorId } }")
}

type Comment {
  id: ID!
  authorId: ID!
}

type User {
  id: ID!
  name: String!
}
```

Subschema B;
```graphql
type Post {
  id: ID!
  comments: [Comment!]!
}

type Comment {
  id: ID!
}
```