### PR TITLE
build(load-files):  generic for `loadFilesSync` and `loadFiles`

### DIFF
--- a/packages/load-files/src/index.ts
+++ b/packages/load-files/src/index.ts
@@ -129,7 +129,7 @@ const LoadFilesDefaultOptions: LoadFilesOptions = {
  * @param pattern Glob pattern or patterns to use when loading files
  * @param options Additional options
  */
-export function loadFilesSync<T = any>(
+export function loadFilesSync<T = DocumentNode>(
   pattern: string | string[],
   options: LoadFilesOptions = LoadFilesDefaultOptions,
 ): T[] {
@@ -227,10 +227,10 @@ const checkExtension = (
  * @param pattern Glob pattern or patterns to use when loading files
  * @param options Additional options
  */
-export async function loadFiles(
+export async function loadFiles<T = DocumentNode>(
   pattern: string | string[],
   options: LoadFilesOptions = LoadFilesDefaultOptions,
-): Promise<any[]> {
+): Promise<T[]> {
   const execOptions = { ...LoadFilesDefaultOptions, ...options };
   const relevantPaths = await scanForFiles(
     await Promise.all(


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

- `loadFilesSync` has  generic while `loadFiles`. So generic is added to `loadFiles`.
- Instead of `<T = any>`, `<T = DocumentNode>` is used, since they are mainly used for loading schema. This even makes it work with `graphql-module`.

```ts
import { createModule } from 'graphql-modules'

export default createModule({
  // `typeDefs` requires `DocumentNode[]`. 
  // Before, `loadFiles` caused type error as it's `any[]`. 
  // But by this PR, it works as expected.
  typeDefs: await loadFiles('...'),
})

```

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [?] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [x] This change requires a documentation update

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
