### PR TITLE
Make two types compatible with strict tsc config

### DIFF
--- a/.changeset/wise-parrots-walk.md
+++ b/.changeset/wise-parrots-walk.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/utils': patch
+---
+
+Make two types compatible with strict tsc config

--- a/packages/utils/src/getDirectiveExtensions.ts
+++ b/packages/utils/src/getDirectiveExtensions.ts
@@ -3,11 +3,17 @@ import { valueFromAST, valueFromASTUntyped } from 'graphql';
 import { getArgumentValues } from './getArgumentValues.js';
 import { memoize1 } from './memoize.js';
 
-export type DirectableASTNode = ASTNode & { directives?: readonly DirectiveNode[] };
+export type DirectableASTNode = ASTNode & {
+  directives?: readonly DirectiveNode[] | undefined;
+};
+
 export type DirectableObject = {
-  astNode?: DirectableASTNode | null;
-  extensionASTNodes?: readonly DirectableASTNode[] | null;
-  extensions?: { directives?: Record<string, any> } | null;
+  astNode?: DirectableASTNode | null | undefined;
+  extensionASTNodes?: readonly DirectableASTNode[] | null | undefined;
+  extensions?:
+    | { directives?: Record<string, any> | undefined }
+    | null
+    | undefined;
 };
 
 export function getDirectiveExtensions<

--- a/packages/utils/src/getDirectiveExtensions.ts
+++ b/packages/utils/src/getDirectiveExtensions.ts
@@ -10,10 +10,7 @@ export type DirectableASTNode = ASTNode & {
 export type DirectableObject = {
   astNode?: DirectableASTNode | null | undefined;
   extensionASTNodes?: readonly DirectableASTNode[] | null | undefined;
-  extensions?:
-    | { directives?: Record<string, any> | undefined }
-    | null
-    | undefined;
+  extensions?: { directives?: Record<string, any> | undefined } | null | undefined;
 };
 
 export function getDirectiveExtensions<


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

> 🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**
> _Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

I did not create an issue in advance. The change was small and quick to make, so no worries if the PR is rejected.

## Description

After upgrading `@graphql-tools/utils@10.2.0` to `10.5.4`, I noticed this TypeScript error in custom schema directives:

```ts
import { getDirective, MapperKind, mapSchema } from "@graphql-tools/utils";
import type { GraphQLSchema } from "graphql";

export function applyFooBarSchemaTransformer(schema: GraphQLSchema) {
  return mapSchema(schema, {
    [MapperKind.OBJECT_FIELD]: (fieldConfig) => {
      const [directive] =
        getDirective(
          schema,
          fieldConfig,
          // ↑↑↑↑
          // Argument of type 'GraphQLFieldConfig<any, any, any>' is not assignable to parameter
          // of type 'DirectableObject' with 'exactOptionalPropertyTypes: true'. Consider adding
          // 'undefined' to the types of the target's properties.
          // Types of property 'astNode' are incompatible.
          //   Type 'Maybe<FieldDefinitionNode>' is not assignable to type 'DirectableASTNode | null'.
          //   Type 'undefined' is not assignable to type 'DirectableASTNode | null'.ts(2379)
          "fooBar",
        ) ?? [];

      /* custom logic */

      return { ...fieldConfig };
    },
  });
}
```

This is related to the shape of `DirectableObject` type:
https://github.com/ardatan/graphql-tools/blob/2ca029e904a585369b948cb92243cc6c213fe434/packages/utils/src/getDirectiveExtensions.ts#L7-L11

When [`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes) is enabled in `tsconfig.json`, these two types do not match:

```ts
type Foo1 = { bar?: string | null }
type Foo2 = { bar?: string | null | undefined }
```
In the first case, `bar` can be omitted, but when it is set, it must be `string` or `null` but not `undefined`. The difference is subtle, but it may be important in some rare cases. For example, `<Button disabled={alwaysBoolean} />` & `<Button />` are fine but `<Button disabled={booleanThatCanBecomeUndefined} />` isn’t . I believe that the subtlety does not apply here.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

N/A

## How Has This Been Tested?

Bu adding `| undefined` next to `| null` locally, I was able to resolve the issue that I faced. It’s a local `pnpm patch` for now.

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- ~I have commented my code, particularly in hard-to-understand areas~
- ~I have made corresponding changes to the documentation~
- ~My changes generate no new warnings~
- ~I have added tests that prove my fix is effective or that my feature works~
- ~New and existing unit tests and linter rules pass locally with my changes~
- ~Any dependent changes have been merged and published in downstream modules~

## Further comments


Related commits, according to `git blame`:
- https://github.com/ardatan/graphql-tools/commit/b8bf584fde87d3064c204d8ac2f9da5b869249c0
- https://github.com/ardatan/graphql-tools/commit/07b87eda0d895c5b39e926a454e01815a407f886
