### PR TITLE
[executors/ws] Allow to configure headers

### DIFF
--- a/.changeset/cuddly-ants-change.md
+++ b/.changeset/cuddly-ants-change.md
@@ -2,4 +2,4 @@
 '@graphql-tools/executor-graphql-ws': minor
 ---
 
-Allow to configure headers of the WebSocket sent with the connection request.
+Allow to configure headers of the WebSocket sent with the upgrade request.

--- a/.changeset/cuddly-ants-change.md
+++ b/.changeset/cuddly-ants-change.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/executor-graphql-ws': minor
+---
+
+Allow to configure headers of the WebSocket sent with the connection request.

--- a/packages/executors/graphql-ws/src/index.ts
+++ b/packages/executors/graphql-ws/src/index.ts
@@ -14,7 +14,10 @@ interface GraphQLWSExecutorOptions extends ClientOptions {
   onClient?: (client: Client) => void;
   print?: typeof print;
   /**
-   * Additional headers to include when querying the original schema
+   * Additional headers to include with the upgrade request.
+   * It will never be sent again during the lifecycle of the socket.
+   *
+   * Warning: This is a noop in browser environments
    */
   headers?: Record<string, string>;
 }


### PR DESCRIPTION
## Description

This PR aims to allow users to configure HTTP headers for the WS connection request.
This is needed to allow headers propagation for subscriptions based on WebSockets in Hive Gateway

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
