### PR TITLE
Declare global PromiseWithResolvers type

### DIFF
--- a/.changeset/eight-wasps-cover.md
+++ b/.changeset/eight-wasps-cover.md
@@ -1,0 +1,5 @@
+---
+"@graphql-tools/delegate": patch
+---
+
+Declare global PromiseWithResolvers type

--- a/packages/delegate/src/leftOver.ts
+++ b/packages/delegate/src/leftOver.ts
@@ -2,6 +2,15 @@ import { FieldNode } from 'graphql';
 import { Subschema } from './Subschema.js';
 import { DelegationPlanBuilder, ExternalObject } from './types.js';
 
+/**
+ * Declare PromiseWithResolvers in case ESNext is not added to the tsconfig lib causing
+ * PromiseWithResolvers interface is not defined. For developers with ESNext added,
+ * the PromiseWithResolvers interface will be merged correctly.
+ */
+declare global {
+  interface PromiseWithResolvers<T> {}
+}
+
 export type Deferred<T = unknown> = PromiseWithResolvers<T>;
 
 // TODO: Remove this after Node 22


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

🚨 **IMPORTANT: Please do not create a Pull Request without creating an issue first.**

_Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of
the pull request._

## Description

Declares a global type to allow builds for users who are not using ESNext to pass. This takes a similar approach to other libraries where the DOM lib is not present.

Related #6353

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## Screenshots/Sandbox (if appropriate/relevant):

Adding links to sandbox or providing screenshots can help us understand more about this PR and take
action on it as appropriate

## How Has This Been Tested?

Locally editing the node module with the global

**Test Environment**:

- NodeJS: 20

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
^ Not sure how. Can confirm it now passes locally
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

