### PR TITLE
fix(federation/stitch): avoid recursively type-merging in case of multiple keys

### DIFF
--- a/.changeset/eleven-schools-build.md
+++ b/.changeset/eleven-schools-build.md
@@ -1,0 +1,70 @@
+---
+'@graphql-tools/federation': patch
+'@graphql-tools/delegate': patch
+'@graphql-tools/stitch': patch
+---
+
+When there are two services like below then the following query senty, the gateway tries to fetch `id` as an extra field because it considers `id` might be needed while this is not correct.
+This patch avoids any extra calls, and forwards the query as is to the 2nd service.
+
+```graphql
+query {
+  viewer {
+    booksContainer(input: $input) {
+      edges {
+        cursor
+        node {
+          source {
+            # Book(upc=)
+            upc
+          }
+        }
+      }
+      pageInfo {
+        endCursor
+      }
+    }
+  }
+}
+```
+
+```graphql
+type Book @key(fields: "id") @key(fields: "upc") {
+  id: ID!
+  upc: ID!
+}
+```
+
+```graphql
+type BookContainer { # the type that is used in a collection
+  id: ID!
+  # ... other stuff here
+  source: Book!
+}
+
+type Book @key(fields: "upc") {
+  upc: ID!
+}
+
+type Query {
+  viewer: Viewer
+}
+
+type Viewer {
+  booksContainer: BooksContainerResult
+}
+
+type BooksContainerResult {
+  edges: [BooksContainerEdge!]!
+  pageInfo: PageInfo!
+}
+
+type BooksContainerEdge {
+  node: BookContainer!
+  cursor: String!
+}
+
+type PageInfo {
+  endCursor: String
+}
+```

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -148,7 +148,9 @@ jobs:
       - name: Setup env
         uses: the-guild-org/shared-config/setup@main
         with:
-          nodeVersion: 18
+          nodeVersion: 22
+      - name: Setup Chrome
+        uses: browser-actions/setup-chrome@v1
       - name: Build Packages
         run: yarn build
       - name: Test

--- a/packages/delegate/src/extractUnavailableFields.ts
+++ b/packages/delegate/src/extractUnavailableFields.ts
@@ -112,6 +112,12 @@ export const extractUnavailableFieldsFromSelectionSet = memoize4(
               },
             });
           }
+        } else if (isObjectType(subFieldType) || isInterfaceType(subFieldType)) {
+          for (const subSelection of selection.selectionSet.selections) {
+            if (shouldAdd(subFieldType, subSelection as FieldNode)) {
+              unavailableSelections.push(subSelection);
+            }
+          }
         }
       }
     }

--- a/packages/federation/test/optimizations.test.ts
+++ b/packages/federation/test/optimizations.test.ts
@@ -1,4 +1,6 @@
-import { GraphQLSchema, parse, versionInfo } from 'graphql';
+import { GraphQLSchema, parse, print, versionInfo } from 'graphql';
+import { kebabCase } from 'lodash';
+import { buildSubgraphSchema } from '@apollo/subgraph';
 import { createDefaultExecutor } from '@graphql-tools/delegate';
 import { normalizedExecutor } from '@graphql-tools/executor';
 import { ExecutionRequest, Executor } from '@graphql-tools/utils';
@@ -242,4 +244,198 @@ describe('awareness-of-other-fields', () => {
       E: 1,
     });
   });
+});
+
+it('prevents recursively depending fields in case of multiple keys', async () => {
+  const books = [
+    {
+      __typename: 'Book',
+      id: '1',
+      upc: '1_upc',
+    },
+    {
+      __typename: 'Book',
+      id: '2',
+      upc: '2_upc',
+    },
+  ];
+  const booksSchema = buildSubgraphSchema({
+    typeDefs: parse(/* GraphQL */ `
+      type Book @key(fields: "id") @key(fields: "upc") {
+        id: ID!
+        upc: ID!
+      }
+    `),
+    resolvers: {
+      Book: {
+        __resolveReference(reference: { id?: string; upc?: string }) {
+          if (reference.id) {
+            return books.find(book => book.id === reference.id);
+          }
+          if (reference.upc) {
+            return books.find(book => book.upc === reference.upc);
+          }
+          return null;
+        },
+      },
+    },
+  });
+  const multiLocationMgmt = buildSubgraphSchema({
+    typeDefs: parse(/* GraphQL */ `
+      type BookContainer { # the type that is used in a collection
+        id: ID!
+        # ... other stuff here
+        source: Book!
+      }
+
+      type Book @key(fields: "upc") {
+        upc: ID!
+      }
+
+      type Query {
+        viewer: Viewer
+      }
+
+      type Viewer {
+        booksContainer: BooksContainerResult
+      }
+
+      type BooksContainerResult {
+        edges: [BooksContainerEdge!]!
+        pageInfo: PageInfo!
+      }
+
+      type BooksContainerEdge {
+        node: BookContainer!
+        cursor: String!
+      }
+
+      type PageInfo {
+        endCursor: String
+      }
+    `),
+    resolvers: {
+      Query: {
+        viewer() {
+          return {
+            booksContainer: {
+              edges: [
+                {
+                  node: {
+                    id: '1',
+                    source: {
+                      upc: '2_upc',
+                    },
+                  },
+                  cursor: '1',
+                },
+                {
+                  node: {
+                    id: '2',
+                    source: {
+                      upc: '2_upc',
+                    },
+                  },
+                  cursor: '2',
+                },
+              ],
+              pageInfo: {
+                endCursor: '2',
+              },
+            },
+          };
+        },
+      },
+    },
+  });
+
+  const { IntrospectAndCompose, LocalGraphQLDataSource } = await import('@apollo/gateway');
+  const introspectAndCompose = await new IntrospectAndCompose({
+    subgraphs: [
+      { name: 'books', url: 'books' },
+      { name: 'other-service', url: 'other-service' },
+    ],
+  }).initialize({
+    healthCheck() {
+      return Promise.resolve();
+    },
+    update() {},
+    getDataSource({ name }) {
+      switch (kebabCase(name)) {
+        case 'books':
+          return new LocalGraphQLDataSource(booksSchema);
+        case 'other-service':
+          return new LocalGraphQLDataSource(multiLocationMgmt);
+      }
+      throw new Error(`Unknown subgraph ${name}`);
+    },
+  });
+  const supergraphSdl = introspectAndCompose.supergraphSdl;
+  await introspectAndCompose.cleanup();
+  const subgraphCallsMap = {};
+  function createTracedExecutor(subgraphName: string, schema: GraphQLSchema): Executor {
+    const executor = createDefaultExecutor(schema);
+    return function tracedExecutor(execReq) {
+      subgraphCallsMap[subgraphName] ||= [];
+      subgraphCallsMap[subgraphName].push({
+        query: print(execReq.document),
+        variables: execReq.variables,
+      });
+      return executor(execReq);
+    };
+  }
+  const gwSchema = getStitchedSchemaFromSupergraphSdl({
+    supergraphSdl,
+    onSubschemaConfig(subschemaConfig) {
+      const subgraphName = kebabCase(subschemaConfig.name);
+      switch (subgraphName) {
+        case 'books':
+          subschemaConfig.executor = createTracedExecutor(subgraphName, booksSchema);
+          break;
+        case 'other-service':
+          subschemaConfig.executor = createTracedExecutor(subgraphName, multiLocationMgmt);
+          break;
+        default:
+          throw new Error(`Unknown subgraph ${subgraphName}`);
+      }
+    },
+  });
+  const result = await normalizedExecutor({
+    schema: gwSchema,
+    document: parse(/* GraphQL */ `
+      query {
+        viewer {
+          booksContainer(input: $input) {
+            edges {
+              cursor
+              node {
+                source {
+                  # Book(upc=)
+                  upc
+                }
+              }
+            }
+            pageInfo {
+              endCursor
+            }
+          }
+        }
+      }
+    `),
+  });
+  expect(result).toEqual({
+    data: {
+      viewer: {
+        booksContainer: {
+          edges: [
+            { cursor: '1', node: { source: { upc: '2_upc' } } },
+            { cursor: '2', node: { source: { upc: '2_upc' } } },
+          ],
+          pageInfo: { endCursor: '2' },
+        },
+      },
+    },
+  });
+  expect(Object.keys(subgraphCallsMap)).toEqual(['other-service']);
+  expect(subgraphCallsMap['other-service'].length).toBe(1);
 });

--- a/packages/loaders/url/tests/url-loader-browser.spec.ts
+++ b/packages/loaders/url/tests/url-loader-browser.spec.ts
@@ -151,6 +151,7 @@ describe('[url-loader] webpack bundle compat', () => {
       });
       browser = await puppeteer.launch({
         // headless: false,
+        args: ['--no-sandbox', '--disable-setuid-sandbox'],
       });
       page = await browser.newPage();
       await page.goto(httpAddress);

--- a/packages/stitch/src/createDelegationPlanBuilder.ts
+++ b/packages/stitch/src/createDelegationPlanBuilder.ts
@@ -251,6 +251,7 @@ export function createDelegationPlanBuilder(mergedTypeInfo: MergedTypeInfo): Del
       fieldNodes,
       fragments,
       variableValues,
+      sourceSubschema,
     );
 
     if (!fieldsNotInSubschema.length) {

--- a/packages/stitch/src/subschemaConfigTransforms/isolateComputedFieldsTransformer.ts
+++ b/packages/stitch/src/subschemaConfigTransforms/isolateComputedFieldsTransformer.ts
@@ -180,8 +180,8 @@ export function isolateComputedFieldsTransformer(
 
   if (Object.keys(isolatedSchemaTypes).length) {
     return [
-      filterBaseSubschema({ ...subschemaConfig, merge: baseSchemaTypes }, isolatedSchemaTypes),
       filterIsolatedSubschema({ ...subschemaConfig, merge: isolatedSchemaTypes }),
+      filterBaseSubschema({ ...subschemaConfig, merge: baseSchemaTypes }, isolatedSchemaTypes),
     ];
   }
   return [subschemaConfig];
@@ -234,14 +234,14 @@ function filterBaseSubschema(
         if (!typesForInterface[typeName]) {
           typesForInterface[typeName] = getImplementingTypes(typeName, schema);
         }
-        const isIsolatedFieldName = [typeName, ...typesForInterface[typeName]].some(
-          implementingTypeName =>
-            isIsolatedField(implementingTypeName, fieldName, isolatedSchemaTypes),
+        const allTypes = [typeName, ...typesForInterface[typeName]];
+        const isIsolatedFieldName = allTypes.some(implementingTypeName =>
+          isIsolatedField(implementingTypeName, fieldName, isolatedSchemaTypes),
         );
-        return (
-          !isIsolatedFieldName ||
-          (isolatedSchemaTypes[typeName]?.keyFieldNames ?? []).includes(fieldName)
+        const isKeyFieldName = allTypes.some(implementingTypeName =>
+          (isolatedSchemaTypes[implementingTypeName]?.keyFieldNames ?? []).includes(fieldName),
         );
+        return !isIsolatedFieldName || isKeyFieldName;
       },
     }),
   );

--- a/packages/stitch/tests/isolateComputedFieldsTransformer.test.ts
+++ b/packages/stitch/tests/isolateComputedFieldsTransformer.test.ts
@@ -35,7 +35,7 @@ describe('isolateComputedFieldsTransformer', () => {
     });
 
     it('splits a subschema into base and computed portions', async () => {
-      const [baseConfig, computedConfig] = isolateComputedFieldsTransformer({
+      const [computedConfig, baseConfig] = isolateComputedFieldsTransformer({
         schema: storefrontSchema,
         merge: {
           Product: {
@@ -146,7 +146,7 @@ describe('isolateComputedFieldsTransformer', () => {
     });
 
     it('splits a subschema into base and computed portions', async () => {
-      const [baseConfig, computedConfig] = isolateComputedFieldsTransformer({
+      const [computedConfig, baseConfig] = isolateComputedFieldsTransformer({
         schema: storefrontSchema,
         merge: {
           Product: {
@@ -256,7 +256,7 @@ describe('isolateComputedFieldsTransformer', () => {
     });
 
     it('moves all computed types to the computed schema', async () => {
-      const [baseConfig, computedConfig] = isolateComputedFieldsTransformer({
+      const [computedConfig, baseConfig] = isolateComputedFieldsTransformer({
         schema: storefrontSchema,
         merge: {
           Storefront: {
@@ -351,7 +351,7 @@ describe('isolateComputedFieldsTransformer', () => {
         `,
       });
 
-      const [baseConfig, computedConfig] = isolateComputedFieldsTransformer({
+      const [computedConfig, baseConfig] = isolateComputedFieldsTransformer({
         schema: testSchema,
         merge: {
           Product: {
@@ -414,7 +414,7 @@ describe('isolateComputedFieldsTransformer', () => {
           }
         `,
       });
-      const [baseConfig, computedConfig] = isolateComputedFieldsTransformer({
+      const [computedConfig, baseConfig] = isolateComputedFieldsTransformer({
         schema: testSchema,
         merge: {
           Product: {
@@ -517,7 +517,7 @@ type Mutation {
         `,
       },
     ])('does not isolate $name referenced from other fields', async ({ variant }) => {
-      const [baseConfig, computedConfig] = isolateComputedFieldsTransformer({
+      const [computedConfig, baseConfig] = isolateComputedFieldsTransformer({
         schema: makeExecutableSchema({
           typeDefs: /* GraphQL */ `
             scalar _Any
@@ -587,7 +587,7 @@ type Mutation {
         `,
       });
 
-      const [baseConfig, computedConfig] = isolateComputedFieldsTransformer({
+      const [computedConfig, baseConfig] = isolateComputedFieldsTransformer({
         schema: testSchema,
         merge: {
           Product: {
@@ -670,7 +670,7 @@ type Mutation {
     });
 
     it.skip('return type is unmerged type', () => {
-      const [baseConfig, computedConfig] = isolateComputedFieldsTransformer({
+      const [computedConfig, baseConfig] = isolateComputedFieldsTransformer({
         schema: testSchema,
         merge: {
           Item: {
@@ -717,7 +717,7 @@ type Mutation {
     });
 
     it('return type is merged type', () => {
-      const [baseConfig, computedConfig] = isolateComputedFieldsTransformer({
+      const [computedConfig, baseConfig] = isolateComputedFieldsTransformer({
         schema: testSchema,
         merge: {
           Item: {

--- a/packages/stitch/tests/mergeComputedFields.test.ts
+++ b/packages/stitch/tests/mergeComputedFields.test.ts
@@ -496,8 +496,8 @@ describe('test merged composite computed fields', () => {
       });
     });
 
-    it('selection set is remote', async () => {
-      const { data } = await graphql({
+    it.only('selection set is remote', async () => {
+      const result = await graphql({
         schema: gatewaySchema,
         source: /* GraphQL */ `
           query {
@@ -514,14 +514,15 @@ describe('test merged composite computed fields', () => {
         `,
       });
 
-      assertSome(data);
-      expect(data).toEqual({
-        byId: {
-          value: 1,
-          next: {
-            value: 2,
+      expect(result).toEqual({
+        data: {
+          byId: {
+            value: 1,
             next: {
-              id: '3',
+              value: 2,
+              next: {
+                id: '3',
+              },
             },
           },
         },


### PR DESCRIPTION
When there are two services like below then the following query senty, the gateway tries to fetch `id` as an extra field because it considers `id` might be needed while this is not correct.
This patch avoids any extra calls, and forwards the query as is to the 2nd service.

```graphql
query {
  viewer {
    booksContainer(input: $input) {
      edges {
        cursor
        node {
          source {
            # Book(upc=)
            upc
          }
        }
      }
      pageInfo {
        endCursor
      }
    }
  }
}
```

```graphql
type Book @key(fields: "id") @key(fields: "upc") {
  id: ID!
  upc: ID!
}
```

```graphql
type BookContainer { # the type that is used in a collection
  id: ID!
  # ... other stuff here
  source: Book!
}

type Book @key(fields: "upc") {
  upc: ID!
}

type Query {
  viewer: Viewer
}

type Viewer {
  booksContainer: BooksContainerResult
}

type BooksContainerResult {
  edges: [BooksContainerEdge!]!
  pageInfo: PageInfo!
}

type BooksContainerEdge {
  node: BookContainer!
  cursor: String!
}

type PageInfo {
  endCursor: String
}
```