### PR TITLE
fix(federation): continue if currentUnavailableSelectionSet.selections is empty array

### DIFF
--- a/.changeset/changelog.md
+++ b/.changeset/changelog.md
@@ -1,0 +1,5 @@
+---
+"@graphql-tools/federation": patch
+---
+
+If `currentUnavailableSelectionSet.selections` is empty array then "query planning" will fail.

--- a/packages/federation/src/supergraph.ts
+++ b/packages/federation/src/supergraph.ts
@@ -1078,7 +1078,11 @@ export function getStitchingOptionsFromSupergraphSdl(
                 // that can resolve the remaining fields for this selection directly from the root field
                 // instead of applying a type merging in advance
                 for (const friendCandidate of realCandidates) {
-                  if (friendCandidate === candidate || !friendCandidate.transformedSubschema) {
+                  if (
+                    friendCandidate === candidate ||
+                    !friendCandidate.transformedSubschema ||
+                    !currentUnavailableSelectionSet.selections.length
+                  ) {
                     continue;
                   }
                   const unavailableFieldsInFriend = extractUnavailableFieldsFromSelectionSet(


### PR DESCRIPTION
## Description

If `currentUnavailableSelectionSet.selections` is empty array then "query planning" always fails in subsequent code.
Details can be found in issue [#6588](https://github.com/ardatan/graphql-tools/issues/6588).

Fixes [#6588](https://github.com/ardatan/graphql-tools/issues/6588)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested by downloading the currently fully functional supergraph from our Apollo Studio GraphQL registry (schema composition is validated by Apollo) which is transformed to stitched schema by `getStitchedSchemaFromSupergraphSdl()`method and served by GraphQL Yoga. No special configuration is used during transforming of supergraphSdl.

```ts
import { getStitchedSchemaFromSupergraphSdl } from '@graphql-tools/federation';

const schema = getStitchedSchemaFromSupergraphSdl({ supergraphSdl });
```

**Test Environment**:

- NodeJS: node@20


