### PR TITLE
perf: Assume internally created schemas as valid

### DIFF
--- a/.changeset/mean-goats-invent.md
+++ b/.changeset/mean-goats-invent.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/stitch': minor
+---
+
+Performance improvement in stitchSchemas

--- a/packages/stitch/src/stitchSchemas.ts
+++ b/packages/stitch/src/stitchSchemas.ts
@@ -101,7 +101,7 @@ export function stitchSchemas<TContext extends Record<string, any> = Record<stri
     astNode: schemaDefs.schemaDef,
     extensionASTNodes: schemaDefs.schemaExtensions,
     extensions: null,
-    assumeValid: true,
+    assumeValid: rest.assumeValid,
   });
 
   for (const extension of extensions) {

--- a/packages/stitch/src/stitchSchemas.ts
+++ b/packages/stitch/src/stitchSchemas.ts
@@ -101,7 +101,7 @@ export function stitchSchemas<TContext extends Record<string, any> = Record<stri
     astNode: schemaDefs.schemaDef,
     extensionASTNodes: schemaDefs.schemaExtensions,
     extensions: null,
-    assumeValid: true
+    assumeValid: true,
   });
 
   for (const extension of extensions) {

--- a/packages/stitch/src/stitchSchemas.ts
+++ b/packages/stitch/src/stitchSchemas.ts
@@ -101,6 +101,7 @@ export function stitchSchemas<TContext extends Record<string, any> = Record<stri
     astNode: schemaDefs.schemaDef,
     extensionASTNodes: schemaDefs.schemaExtensions,
     extensions: null,
+    assumeValid: true
   });
 
   for (const extension of extensions) {


### PR DESCRIPTION
## Description

Sets assumeValid to true when creating new GraphqlSchema in stitchSchemas.

Im not 100% sure if this is really safe to do so, but the perf implications are non negligible. So if we cannot just assume the schema to be valid at this stage then we can hopefully at least leave this for the user to decide somehow?

## Type of change

- [x] Performance improvement

## How Has This Been Tested?

Internal releases.

**Test Environment**:

- NodeJS:

## Checklist:

- [ ] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

