### PR TITLE
fix(load): support ESM custom loaders

### DIFF
--- a/.changeset/load-esm-custom-loaders.md
+++ b/.changeset/load-esm-custom-loaders.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/load': patch
+---
+
+Load custom schema/document loaders with `import()` after `createRequire`, so ESM loader files and packages work with async `load` (including graphql-codegen). Closes #6656.

--- a/packages/load/src/utils/custom-loader.ts
+++ b/packages/load/src/utils/custom-loader.ts
@@ -1,5 +1,6 @@
+import { existsSync, readFileSync } from 'fs';
 import { createRequire } from 'module';
-import { isAbsolute, join as joinPaths } from 'path';
+import { dirname, isAbsolute, join as joinPaths } from 'path';
 import { pathToFileURL } from 'url';
 
 function extractLoaderFromModule(loaderModule: any) {
@@ -18,10 +19,76 @@ function createLoaderRequire(cwd: string) {
   return createRequire(joinPaths(cwd, 'noop.js'));
 }
 
-function resolveLoaderModuleUrl(path: string, cwd: string, requireFn: NodeRequire): string {
+function isBarePackageSpecifier(specifier: string): boolean {
+  return !isAbsolute(specifier) && !specifier.startsWith('.') && !specifier.startsWith('file:');
+}
+
+function findPackageDir(packageName: string, cwd: string): string | undefined {
+  let dir = cwd;
+  while (true) {
+    const candidate = joinPaths(dir, 'node_modules', ...packageName.split('/'));
+    if (existsSync(joinPaths(candidate, 'package.json'))) {
+      return candidate;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      return undefined;
+    }
+    dir = parent;
+  }
+}
+
+function packageImportEntry(exportsField: unknown): string | undefined {
+  if (typeof exportsField === 'string') {
+    return exportsField;
+  }
+  if (exportsField == null || typeof exportsField !== 'object') {
+    return undefined;
+  }
+  const root = (exportsField as Record<string, unknown>)['.'];
+  if (typeof root === 'string') {
+    return root;
+  }
+  if (root == null || typeof root !== 'object') {
+    return undefined;
+  }
+  const importEntry = (root as Record<string, unknown>).import;
+  if (typeof importEntry === 'string') {
+    return importEntry;
+  }
+  if (importEntry != null && typeof importEntry === 'object') {
+    const nested = (importEntry as Record<string, unknown>).default;
+    if (typeof nested === 'string') {
+      return nested;
+    }
+  }
+  return undefined;
+}
+
+function resolvePackageImportPath(packageDir: string): string | undefined {
+  const pkg = JSON.parse(readFileSync(joinPaths(packageDir, 'package.json'), 'utf8')) as {
+    exports?: unknown;
+    module?: string;
+    main?: string;
+  };
+  const entry = packageImportEntry(pkg.exports) ?? pkg.module ?? pkg.main;
+  if (entry == null) {
+    return undefined;
+  }
+  return joinPaths(packageDir, entry);
+}
+
+export function resolveLoaderModuleUrl(path: string, cwd: string, requireFn: NodeRequire): string {
   try {
     return pathToFileURL(requireFn.resolve(path)).href;
   } catch {
+    if (isBarePackageSpecifier(path)) {
+      const packageDir = findPackageDir(path, cwd);
+      const entry = packageDir != null ? resolvePackageImportPath(packageDir) : undefined;
+      if (entry != null) {
+        return pathToFileURL(entry).href;
+      }
+    }
     const absolutePath = isAbsolute(path) ? path : joinPaths(cwd, path);
     return pathToFileURL(absolutePath).href;
   }
@@ -39,7 +106,8 @@ export async function getCustomLoaderByPath(path: string, cwd: string) {
   }
 
   try {
-    const importedModule = await import(resolveLoaderModuleUrl(path, cwd, requireFn));
+    const href = resolveLoaderModuleUrl(path, cwd, requireFn);
+    const importedModule = await import(href);
     return extractLoaderFromModule(importedModule);
   } catch {
     return null;

--- a/packages/load/src/utils/custom-loader.ts
+++ b/packages/load/src/utils/custom-loader.ts
@@ -38,6 +38,31 @@ function findPackageDir(packageName: string, cwd: string): string | undefined {
   }
 }
 
+function stringFromConditionalExport(entry: unknown): string | undefined {
+  if (typeof entry === 'string') {
+    return entry;
+  }
+  if (entry == null || typeof entry !== 'object') {
+    return undefined;
+  }
+  const record = entry as Record<string, unknown>;
+  const importEntry = record['import'];
+  if (typeof importEntry === 'string') {
+    return importEntry;
+  }
+  if (importEntry != null && typeof importEntry === 'object') {
+    const nested = (importEntry as Record<string, unknown>)['default'];
+    if (typeof nested === 'string') {
+      return nested;
+    }
+  }
+  const defaultEntry = record['default'];
+  if (typeof defaultEntry === 'string') {
+    return defaultEntry;
+  }
+  return undefined;
+}
+
 function packageImportEntry(exportsField: unknown): string | undefined {
   if (typeof exportsField === 'string') {
     return exportsField;
@@ -45,24 +70,11 @@ function packageImportEntry(exportsField: unknown): string | undefined {
   if (exportsField == null || typeof exportsField !== 'object') {
     return undefined;
   }
-  const root = (exportsField as Record<string, unknown>)['.'];
-  if (typeof root === 'string') {
-    return root;
+  const record = exportsField as Record<string, unknown>;
+  if (Object.prototype.hasOwnProperty.call(record, '.')) {
+    return stringFromConditionalExport(record['.']);
   }
-  if (root == null || typeof root !== 'object') {
-    return undefined;
-  }
-  const importEntry = (root as Record<string, unknown>).import;
-  if (typeof importEntry === 'string') {
-    return importEntry;
-  }
-  if (importEntry != null && typeof importEntry === 'object') {
-    const nested = (importEntry as Record<string, unknown>).default;
-    if (typeof nested === 'string') {
-      return nested;
-    }
-  }
-  return undefined;
+  return stringFromConditionalExport(record);
 }
 
 function resolvePackageImportPath(packageDir: string): string | undefined {

--- a/packages/load/src/utils/custom-loader.ts
+++ b/packages/load/src/utils/custom-loader.ts
@@ -1,23 +1,57 @@
 import { createRequire } from 'module';
-import { join as joinPaths } from 'path';
+import { isAbsolute, join as joinPaths } from 'path';
+import { pathToFileURL } from 'url';
 
-export function getCustomLoaderByPath(path: string, cwd: string) {
+function extractLoaderFromModule(loaderModule: any) {
+  if (loaderModule == null) {
+    return undefined;
+  }
+  if (typeof loaderModule.default === 'function') {
+    return loaderModule.default;
+  }
+  if (typeof loaderModule === 'function') {
+    return loaderModule;
+  }
+}
+
+function createLoaderRequire(cwd: string) {
+  return createRequire(joinPaths(cwd, 'noop.js'));
+}
+
+function resolveLoaderModuleUrl(path: string, cwd: string, requireFn: NodeRequire): string {
   try {
-    const requireFn = createRequire(joinPaths(cwd, 'noop.js'));
-    const requiredModule = requireFn(path);
+    return pathToFileURL(requireFn.resolve(path)).href;
+  } catch {
+    const absolutePath = isAbsolute(path) ? path : joinPaths(cwd, path);
+    return pathToFileURL(absolutePath).href;
+  }
+}
 
-    if (requiredModule) {
-      if (requiredModule.default && typeof requiredModule.default === 'function') {
-        return requiredModule.default;
-      }
-
-      if (typeof requiredModule === 'function') {
-        return requiredModule;
-      }
+export async function getCustomLoaderByPath(path: string, cwd: string) {
+  const requireFn = createLoaderRequire(cwd);
+  try {
+    const loader = extractLoaderFromModule(requireFn(path));
+    if (typeof loader === 'function') {
+      return loader;
     }
-  } catch (e: any) {}
+  } catch {
+    // createRequire cannot load ESM; fall through to import().
+  }
 
-  return null;
+  try {
+    const importedModule = await import(resolveLoaderModuleUrl(path, cwd, requireFn));
+    return extractLoaderFromModule(importedModule);
+  } catch {
+    return null;
+  }
+}
+
+function getCustomLoaderByPathSync(path: string, cwd: string) {
+  try {
+    return extractLoaderFromModule(createLoaderRequire(cwd)(path)) ?? null;
+  } catch {
+    return null;
+  }
 }
 
 export async function useCustomLoader(loaderPointer: any, cwd: string) {
@@ -40,7 +74,7 @@ export function useCustomLoaderSync(loaderPointer: any, cwd: string) {
   let loader;
 
   if (typeof loaderPointer === 'string') {
-    loader = getCustomLoaderByPath(loaderPointer, cwd);
+    loader = getCustomLoaderByPathSync(loaderPointer, cwd);
   } else if (typeof loaderPointer === 'function') {
     loader = loaderPointer;
   }

--- a/packages/load/tests/custom-loader.mjs
+++ b/packages/load/tests/custom-loader.mjs
@@ -1,0 +1,18 @@
+import { buildSchema, parse } from 'graphql';
+
+export default function (_, { customLoaderContext: { loaderType }, fooFieldName }) {
+  if (loaderType === 'documents') {
+    return parse(/* GraphQL */ `
+      query TestQuery {
+        ${fooFieldName}
+      }
+    `);
+  } else if (loaderType === 'schema') {
+    return buildSchema(/* GraphQL */ `
+      type Query {
+        ${fooFieldName}: String
+      }
+    `);
+  }
+  return 'I like turtles';
+}

--- a/packages/load/tests/loaders/documents/documents-from-glob.spec.ts
+++ b/packages/load/tests/loaders/documents/documents-from-glob.spec.ts
@@ -194,6 +194,24 @@ describe('documentsFromGlob', () => {
       expect(result).toHaveLength(1);
       expect(result[0].rawSDL).toContain(pointerOptions.fooFieldName);
     });
+    test('should load documents from an ESM custom loader (#6656)', async () => {
+      const result = await load(
+        {
+          pointer: {
+            loader: join(__dirname, '../../custom-loader.mjs'),
+            fooFieldName: 'myFooField',
+          },
+        },
+        {
+          loaders: [],
+          customLoaderContext: {
+            loaderType: 'documents',
+          },
+        },
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].rawSDL).toContain('myFooField');
+    });
     test('should work only with a document string', async () => {
       const result = await load('query { foo }', {
         loaders: [],

--- a/packages/load/tests/loaders/schema/integration.spec.ts
+++ b/packages/load/tests/loaders/schema/integration.spec.ts
@@ -176,5 +176,23 @@ describe('loadSchema', () => {
       expect(result).toBeInstanceOf(GraphQLSchema);
       expect(result.getQueryType()?.getFields()?.['myFooField']).toBeDefined();
     });
+    test(`should load an ESM custom schema loader (#6656)`, async () => {
+      const result = await load(
+        {
+          pointer: {
+            loader: join(__dirname, '../../custom-loader.mjs'),
+            fooFieldName: 'myFooField',
+          },
+        },
+        {
+          loaders: [],
+          customLoaderContext: {
+            loaderType: 'schema',
+          },
+        },
+      );
+      expect(result).toBeInstanceOf(GraphQLSchema);
+      expect(result.getQueryType()?.getFields()?.['myFooField']).toBeDefined();
+    });
   });
 });

--- a/packages/load/tests/use-custom-loader.spec.ts
+++ b/packages/load/tests/use-custom-loader.spec.ts
@@ -1,9 +1,44 @@
-import { getCustomLoaderByPath } from '../src/utils/custom-loader.js';
+import { join } from 'path';
+import { GraphQLSchema, parse, print } from 'graphql';
+import {
+  getCustomLoaderByPath,
+  useCustomLoader,
+  useCustomLoaderSync,
+} from '../src/utils/custom-loader.js';
 
-describe('getCustomLoaderByPath', () => {
-  it('can load a custom loader from a file path', async () => {
-    const loader = getCustomLoaderByPath('./custom-loader.js', __dirname);
+describe('custom loaders', () => {
+  it('can load a CommonJS loader from a relative file path', async () => {
+    const loader = await getCustomLoaderByPath('./custom-loader.js', __dirname);
     expect(loader).toBeDefined();
     expect(loader('some-name', { customLoaderContext: {} })).toEqual('I like turtles');
+  });
+
+  it('can load an ESM loader from a relative file path', async () => {
+    const loader = await useCustomLoader('./custom-loader.mjs', __dirname);
+    expect(loader('some-name', { customLoaderContext: {} })).toEqual('I like turtles');
+  });
+
+  it('can load an ESM loader from an absolute file path', async () => {
+    const loader = await useCustomLoader(join(__dirname, 'custom-loader.mjs'), __dirname);
+    const schema = loader('schema.json', {
+      customLoaderContext: { loaderType: 'schema' },
+      fooFieldName: 'myFooField',
+    });
+    expect(schema).toBeInstanceOf(GraphQLSchema);
+    expect(schema.getQueryType()?.getFields()['myFooField']).toBeDefined();
+  });
+
+  it('can load a CommonJS loader synchronously', () => {
+    const loader = useCustomLoaderSync('./custom-loader.js', __dirname);
+    expect(loader('some-name', { customLoaderContext: {} })).toEqual('I like turtles');
+  });
+
+  it('loads ESM documents through the custom loader pointer', async () => {
+    const loader = await useCustomLoader('./custom-loader.mjs', __dirname);
+    const doc = loader('query.graphql', {
+      customLoaderContext: { loaderType: 'documents' },
+      fooFieldName: 'myFooField',
+    });
+    expect(print(doc)).toBe(print(parse('query TestQuery { myFooField }')));
   });
 });

--- a/packages/load/tests/use-custom-loader.spec.ts
+++ b/packages/load/tests/use-custom-loader.spec.ts
@@ -80,4 +80,39 @@ describe('custom loaders', () => {
       rmSync(cwd, { recursive: true, force: true });
     }
   });
+
+  it('resolves root-level exports.import without a "." subpath', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'import-only-root-exports-'));
+    const packageDir = join(cwd, 'node_modules', 'import-only-root-exports-loader');
+    mkdirSync(packageDir, { recursive: true });
+    writeFileSync(
+      join(cwd, 'package.json'),
+      JSON.stringify({ name: 'import-only-root-exports-app' }),
+    );
+    writeFileSync(
+      join(packageDir, 'package.json'),
+      JSON.stringify({
+        name: 'import-only-root-exports-loader',
+        type: 'module',
+        exports: {
+          import: './index.mjs',
+        },
+      }),
+    );
+    writeFileSync(
+      join(packageDir, 'index.mjs'),
+      'export default function () { return "import-only"; }\n',
+    );
+
+    try {
+      const href = resolveLoaderModuleUrl(
+        'import-only-root-exports-loader',
+        cwd,
+        createRequire(join(cwd, 'noop.js')),
+      );
+      expect(fileURLToPath(href)).toBe(join(packageDir, 'index.mjs'));
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/load/tests/use-custom-loader.spec.ts
+++ b/packages/load/tests/use-custom-loader.spec.ts
@@ -1,7 +1,12 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { createRequire } from 'module';
+import { tmpdir } from 'os';
 import { join } from 'path';
+import { fileURLToPath } from 'url';
 import { GraphQLSchema, parse, print } from 'graphql';
 import {
   getCustomLoaderByPath,
+  resolveLoaderModuleUrl,
   useCustomLoader,
   useCustomLoaderSync,
 } from '../src/utils/custom-loader.js';
@@ -40,5 +45,39 @@ describe('custom loaders', () => {
       fooFieldName: 'myFooField',
     });
     expect(print(doc)).toBe(print(parse('query TestQuery { myFooField }')));
+  });
+
+  it('resolves a package whose exports only define an import condition', () => {
+    const cwd = mkdtempSync(join(tmpdir(), 'import-only-loader-'));
+    const packageDir = join(cwd, 'node_modules', 'import-only-custom-loader');
+    mkdirSync(packageDir, { recursive: true });
+    writeFileSync(join(cwd, 'package.json'), JSON.stringify({ name: 'import-only-loader-app' }));
+    writeFileSync(
+      join(packageDir, 'package.json'),
+      JSON.stringify({
+        name: 'import-only-custom-loader',
+        type: 'module',
+        exports: {
+          '.': {
+            import: './index.mjs',
+          },
+        },
+      }),
+    );
+    writeFileSync(
+      join(packageDir, 'index.mjs'),
+      'export default function () { return "import-only"; }\n',
+    );
+
+    try {
+      const href = resolveLoaderModuleUrl(
+        'import-only-custom-loader',
+        cwd,
+        createRequire(join(cwd, 'noop.js')),
+      );
+      expect(fileURLToPath(href)).toBe(join(packageDir, 'index.mjs'));
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Custom loaders in async `load` / graphql-codegen now try `createRequire` first, then `import(pathToFileURL(require.resolve(...)))`, so ESM `.mjs` files and ESM packages work.
- Package-name and relative paths still resolve through `createRequire` (not `join(cwd, name)`).
- `loadSync` still uses `require` only.
- Adds Jest coverage for `.mjs` schema and document pointers.

Closes #6656

## Test plan
- [x] `use-custom-loader.spec.ts` loads CJS and ESM fixtures
- [x] `loadSchema` / `loadDocuments` integration with `custom-loader.mjs`