### PR TITLE
fix(utils): handle array of primitives correctly

### DIFF
--- a/.changeset/three-houses-cry.md
+++ b/.changeset/three-houses-cry.md
@@ -1,0 +1,16 @@
+---
+'@graphql-tools/utils': patch
+---
+
+Handle array of primitives correctly
+
+The bug was following;
+```ts
+mergeDeep([
+  { options: ['$a', '$b'] },
+  { options: ['$c'] },
+  { options: ['$d', '$e'] },
+])
+
+// results in { options: [{}, {}] }
+```

--- a/packages/utils/tests/mergeDeep.test.ts
+++ b/packages/utils/tests/mergeDeep.test.ts
@@ -66,4 +66,10 @@ describe('mergeDeep', () => {
       { b: 2, d: 4 },
     ]);
   });
+
+  it('merges string arrays', () => {
+    const a = { options: ['$A', '$B'] };
+    const b = { options: ['$A', '$B'] };
+    expect(mergeDeep([a, b], undefined, true, true)).toEqual({ options: ['$A', '$B'] });
+  });
 });


### PR DESCRIPTION
Handle array of primitives correctly

The bug was following;
```ts
mergeDeep([
  { options: ['$a', '$b'] },
  { options: ['$c'] },
  { options: ['$d', '$e'] },
])

// results in { options: [{}, {}] }
```
