### PR TITLE
fix: avoid "possible EventEmitter memory leak detected" warning

### DIFF
--- a/.changeset/hip-bikes-hunt.md
+++ b/.changeset/hip-bikes-hunt.md
@@ -1,0 +1,8 @@
+---
+'@graphql-tools/utils': minor
+---
+
+- New helper function `getAbortPromise` to get a promise rejected when `AbortSignal` is aborted
+- New helper function `registerAbortSignalListener` to register a listener to abort a promise when `AbortSignal` is aborted
+
+Instead of using `.addEventListener('abort', () => {/* ... */})`, we register a single listener to avoid warnings on Node.js like `MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 abort listeners added. Use emitter.setMaxListeners() to increase limit`.

--- a/.changeset/selfish-worms-decide.md
+++ b/.changeset/selfish-worms-decide.md
@@ -1,0 +1,8 @@
+---
+'@graphql-tools/executor': patch
+---
+
+Surpress the "possible EventEmitter memory leak detected." warning occuring on Node.js when passing
+a `AbortSignal` to `execute`.
+
+Each execution will now only set up a single listener on the supplied `AbortSignal`. While the warning is harmless it can be misleading, which is the main motivation of this change.

--- a/packages/executor/src/execution/__tests__/abort-signal.test.ts
+++ b/packages/executor/src/execution/__tests__/abort-signal.test.ts
@@ -129,7 +129,6 @@ describe('Abort Signal', () => {
     controller.abort();
     await expect($next).rejects.toMatchInlineSnapshot(`DOMException {}`);
     expect(aResolverGotInvoked).toEqual(false);
-    expect(controller.signal.addEventListener).toHaveBeenCalledTimes(1);
   });
   it('should stop the serial mutation execution', async () => {
     let didInvokeFirstFn = false;

--- a/packages/executor/src/execution/execute.ts
+++ b/packages/executor/src/execution/execute.ts
@@ -35,6 +35,7 @@ import {
   collectFields,
   createGraphQLError,
   fakePromise,
+  getAbortPromise,
   getArgumentValues,
   getDefinedRootType,
   GraphQLResolveInfo,
@@ -52,6 +53,7 @@ import {
   Path,
   pathToArray,
   promiseReduce,
+  registerAbortSignalListener,
 } from '@graphql-tools/utils';
 import { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { DisposableSymbols } from '@whatwg-node/disposablestack';
@@ -287,41 +289,10 @@ export function execute<TData = any, TVariables = any, TContext = any>(
   return executeImpl(exeContext);
 }
 
-// AbortSignal handler cache to avoid the "possible EventEmitter memory leak detected"
-// on Node.js
-const abortSignalHandlers = new WeakMap<AbortSignal, Set<VoidFunction>>();
-
-/**
- * Register an AbortSignal handler for a signal.
- * This helper function mainly exists to work around the
- * "possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit."
- * warning occuring on Node.js
- */
-function registerAbortSignalHandler(signal: AbortSignal, handler: VoidFunction): void {
-  let handlers = abortSignalHandlers.get(signal);
-
-  if (!Array.isArray(handlers)) {
-    handlers = new Set();
-    abortSignalHandlers.set(signal, handlers);
-
-    function abortSignalHandler() {
-      for (const handler of handlers!) {
-        handler();
-      }
-    }
-
-    signal.addEventListener('abort', abortSignalHandler, { once: true });
-  }
-
-  handlers.add(handler);
-}
-
 function executeImpl<TData = any, TVariables = any, TContext = any>(
   exeContext: ExecutionContext<TVariables, TContext>,
 ): MaybePromise<SingularExecutionResult<TData> | IncrementalExecutionResults<TData>> {
-  if (exeContext.signal?.aborted) {
-    throw exeContext.signal.reason;
-  }
+  exeContext.signal?.throwIfAborted();
 
   // Return a Promise that will eventually resolve to the data described by
   // The "Response" section of the GraphQL specification.
@@ -351,9 +322,7 @@ function executeImpl<TData = any, TVariables = any, TContext = any>(
         return initialResult;
       },
       (error: any) => {
-        if (exeContext.signal?.aborted) {
-          throw exeContext.signal.reason;
-        }
+        exeContext.signal?.throwIfAborted();
 
         if (error.errors) {
           exeContext.errors.push(...error.errors);
@@ -587,9 +556,7 @@ function executeFieldsSerially<TData>(
     fields,
     (results, [responseName, fieldNodes]) => {
       const fieldPath = addPath(path, responseName, parentType.name);
-      if (exeContext.signal?.aborted) {
-        throw exeContext.signal.reason;
-      }
+      exeContext.signal?.throwIfAborted();
 
       return new ValueOrPromise(() =>
         executeField(exeContext, parentType, sourceValue, fieldNodes, fieldPath),
@@ -624,9 +591,7 @@ function executeFields(
 
   try {
     for (const [responseName, fieldNodes] of fields) {
-      if (exeContext.signal?.aborted) {
-        throw exeContext.signal.reason;
-      }
+      exeContext.signal?.throwIfAborted();
 
       const fieldPath = addPath(path, responseName, parentType.name);
       const result = executeField(
@@ -987,8 +952,8 @@ async function completeAsyncIteratorValue(
   iterator: AsyncIterator<unknown>,
   asyncPayloadRecord?: AsyncPayloadRecord,
 ): Promise<ReadonlyArray<unknown>> {
-  if (exeContext.signal) {
-    registerAbortSignalHandler(exeContext.signal, () => {
+  if (exeContext.signal && iterator.return) {
+    registerAbortSignalListener(exeContext.signal, () => {
       iterator.return?.();
     });
   }
@@ -1786,18 +1751,22 @@ function assertEventStream(result: unknown, signal?: AbortSignal): AsyncIterable
       'Subscription field must return Async Iterable. ' + `Received: ${inspect(result)}.`,
     );
   }
-  return {
-    [Symbol.asyncIterator]() {
-      const asyncIterator = result[Symbol.asyncIterator]();
-      if (signal) {
-        registerAbortSignalHandler(signal, () => {
-          asyncIterator.return?.();
-        });
-      }
+  if (signal) {
+    return {
+      [Symbol.asyncIterator]() {
+        const asyncIterator = result[Symbol.asyncIterator]();
 
-      return asyncIterator;
-    },
-  };
+        if (asyncIterator.return) {
+          registerAbortSignalListener(signal, () => {
+            asyncIterator.return?.();
+          });
+        }
+
+        return asyncIterator;
+      },
+    };
+  }
+  return result;
 }
 
 function executeDeferredFragment(
@@ -2115,24 +2084,22 @@ function yieldSubsequentPayloads(
 ): AsyncGenerator<SubsequentIncrementalExecutionResult, void, void> {
   let isDone = false;
 
-  const abortPromise = new Promise<void>((_, reject) => {
-    if (exeContext.signal) {
-      registerAbortSignalHandler(exeContext.signal, () => {
-        isDone = true;
-        reject(exeContext.signal?.reason);
-      });
-    }
-  });
+  const abortPromise = exeContext.signal ? getAbortPromise(exeContext.signal) : undefined;
 
   async function next(): Promise<IteratorResult<SubsequentIncrementalExecutionResult, void>> {
     if (isDone) {
       return { value: undefined, done: true };
     }
 
-    await Promise.race([
-      abortPromise,
-      ...Array.from(exeContext.subsequentPayloads).map(p => p.promise),
-    ]);
+    const subSequentPayloadPromises = Array.from(exeContext.subsequentPayloads).map(
+      record => record.promise,
+    );
+
+    if (abortPromise) {
+      await Promise.race([abortPromise, ...subSequentPayloadPromises]);
+    } else {
+      await Promise.race(subSequentPayloadPromises);
+    }
 
     if (isDone) {
       // a different call to next has exhausted all payloads

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -58,3 +58,4 @@ export * from './getDirectiveExtensions.js';
 export * from './map-maybe-promise.js';
 export * from './fakePromise.js';
 export * from './createDeferred.js';
+export * from './registerAbortSignalListener.js';

--- a/packages/utils/src/registerAbortSignalListener.ts
+++ b/packages/utils/src/registerAbortSignalListener.ts
@@ -1,0 +1,45 @@
+import { memoize1 } from './memoize.js';
+
+// AbortSignal handler cache to avoid the "possible EventEmitter memory leak detected"
+// on Node.js
+const getListenersOfAbortSignal = memoize1(function getListenersOfAbortSignal(signal: AbortSignal) {
+  const listeners = new Set<EventListener>();
+  signal.addEventListener(
+    'abort',
+    e => {
+      for (const listener of listeners) {
+        listener(e);
+      }
+    },
+    { once: true },
+  );
+  return listeners;
+});
+
+/**
+ * Register an AbortSignal handler for a signal.
+ * This helper function mainly exists to work around the
+ * "possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit."
+ * warning occuring on Node.js
+ */
+export function registerAbortSignalListener(signal: AbortSignal, listener: VoidFunction) {
+  // If the signal is already aborted, call the listener immediately
+  if (signal.aborted) {
+    listener();
+    return;
+  }
+  getListenersOfAbortSignal(signal).add(listener);
+}
+
+export const getAbortPromise = memoize1(function getAbortPromise(signal: AbortSignal) {
+  return new Promise<void>((_resolve, reject) => {
+    // If the signal is already aborted, return a rejected promise
+    if (signal.aborted) {
+      reject(signal.reason);
+      return;
+    }
+    registerAbortSignalListener(signal, () => {
+      reject(signal.reason);
+    });
+  });
+});

--- a/website/theme.config.tsx
+++ b/website/theme.config.tsx
@@ -29,5 +29,6 @@ export default defineConfig({
   },
   websiteName: 'GraphQL-Tools',
   description: PRODUCTS.TOOLS.title,
+  // @ts-expect-error - Typings are not updated
   logo: PRODUCTS.TOOLS.logo({ className: 'w-9' }),
 });


### PR DESCRIPTION
## Description

I noticed the "possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit." warning within our Hive GraphQL API service, which leads back to setting up too many event listeners here.

While the warning is not a real issue, we should avoid triggering it.

Extra from @ardatan ;

- Single helper for AbortSignal event listener registration so it can be used by other packages, too.
- Replace if(signal.aborted) throw logic with signal?.throwIfAborted
- Check if there is only one listener registered to AbortSignal in tests
- Shared rejection promise for AbortSignal instead of creating it multiple times

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Existing tests pass, so the provided functionality stays the same.
