### PR TITLE
Single place for AbortSignal listeners -> #6789

### DIFF
--- a/.changeset/hip-bikes-hunt.md
+++ b/.changeset/hip-bikes-hunt.md
@@ -1,0 +1,8 @@
+---
+'@graphql-tools/utils': minor
+---
+
+- New helper function `getAbortPromise` to get a promise rejected when `AbortSignal` is aborted
+- New helper function `registerAbortSignalListener` to register a listener to abort a promise when `AbortSignal` is aborted
+
+Instead of using `.addEventListener('abort', () => {/* ... */})`, we register a single listener to avoid warnings on Node.js like `MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 abort listeners added. Use emitter.setMaxListeners() to increase limit`.

--- a/packages/executor/src/execution/execute.ts
+++ b/packages/executor/src/execution/execute.ts
@@ -952,7 +952,7 @@ async function completeAsyncIteratorValue(
   iterator: AsyncIterator<unknown>,
   asyncPayloadRecord?: AsyncPayloadRecord,
 ): Promise<ReadonlyArray<unknown>> {
-  if (exeContext.signal) {
+  if (exeContext.signal && iterator.return) {
     registerAbortSignalListener(exeContext.signal, () => {
       iterator.return?.();
     });
@@ -1755,9 +1755,12 @@ function assertEventStream(result: unknown, signal?: AbortSignal): AsyncIterable
     return {
       [Symbol.asyncIterator]() {
         const asyncIterator = result[Symbol.asyncIterator]();
-        registerAbortSignalListener(signal, () => {
-          asyncIterator.return?.();
-        });
+
+        if (asyncIterator.return) {
+          registerAbortSignalListener(signal, () => {
+            asyncIterator.return?.();
+          });
+        }
 
         return asyncIterator;
       },

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -58,3 +58,4 @@ export * from './getDirectiveExtensions.js';
 export * from './map-maybe-promise.js';
 export * from './fakePromise.js';
 export * from './createDeferred.js';
+export * from './registerAbortSignalListener.js';

--- a/packages/utils/src/registerAbortSignalListener.ts
+++ b/packages/utils/src/registerAbortSignalListener.ts
@@ -1,0 +1,43 @@
+import { memoize1 } from './memoize.js';
+
+// AbortSignal handler cache to avoid the "possible EventEmitter memory leak detected"
+// on Node.js
+const getListenersOfAbortSignal = memoize1(function getListenersOfAbortSignal(signal: AbortSignal) {
+  const listeners = new Set<EventListener>();
+  signal.addEventListener(
+    'abort',
+    e => {
+      for (const listener of listeners) {
+        listener(e);
+      }
+    },
+    { once: true },
+  );
+  return listeners;
+});
+
+/**
+ * Register an AbortSignal handler for a signal.
+ * This helper function mainly exists to work around the
+ * "possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit."
+ * warning occuring on Node.js
+ */
+export function registerAbortSignalListener(signal: AbortSignal, listener: VoidFunction) {
+  if (signal.aborted) {
+    listener();
+    return;
+  }
+  getListenersOfAbortSignal(signal).add(listener);
+}
+
+export const getAbortPromise = memoize1(function getAbortPromise(signal: AbortSignal) {
+  return new Promise<void>((_resolve, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason);
+    } else {
+      registerAbortSignalListener(signal, () => {
+        reject(signal.reason);
+      });
+    }
+  });
+});

--- a/packages/utils/src/registerAbortSignalListener.ts
+++ b/packages/utils/src/registerAbortSignalListener.ts
@@ -1,4 +1,3 @@
-import { fakeRejectPromise } from './fakePromise.js';
 import { memoize1 } from './memoize.js';
 
 // AbortSignal handler cache to avoid the "possible EventEmitter memory leak detected"
@@ -33,11 +32,12 @@ export function registerAbortSignalListener(signal: AbortSignal, listener: VoidF
 }
 
 export const getAbortPromise = memoize1(function getAbortPromise(signal: AbortSignal) {
-  // If the signal is already aborted, return a rejected promise
-  if (signal.aborted) {
-    return fakeRejectPromise(signal.reason);
-  }
   return new Promise<void>((_resolve, reject) => {
+    // If the signal is already aborted, return a rejected promise
+    if (signal.aborted) {
+      reject(signal.reason);
+      return;
+    }
     registerAbortSignalListener(signal, () => {
       reject(signal.reason);
     });

--- a/website/theme.config.tsx
+++ b/website/theme.config.tsx
@@ -29,5 +29,6 @@ export default defineConfig({
   },
   websiteName: 'GraphQL-Tools',
   description: PRODUCTS.TOOLS.title,
+  // @ts-expect-error - Typings are not updated
   logo: PRODUCTS.TOOLS.logo({ className: 'w-9' }),
 });


### PR DESCRIPTION
PR to #6789 PR
- Single helper for AbortSignal event listener registration so it can be used by other packages, too.
- Replace `if(signal.aborted) throw` logic with `signal?.throwIfAborted`
- Check if there is only one listener registered to AbortSignal in tests
- Shared rejection promise for AbortSignal instead of creating it multiple times