### PR TITLE
Use upstream sync fetch instead of our fork

### DIFF
--- a/.changeset/@graphql-tools_apollo-engine-loader-6831-dependencies.md
+++ b/.changeset/@graphql-tools_apollo-engine-loader-6831-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-tools/apollo-engine-loader": patch
+---
+dependencies updates:
+  - Added dependency [`sync-fetch@0.6.0-2` ↗︎](https://www.npmjs.com/package/sync-fetch/v/0.6.0) (to `dependencies`)
+  - Removed dependency [`@ardatan/sync-fetch@^0.0.1` ↗︎](https://www.npmjs.com/package/@ardatan/sync-fetch/v/0.0.1) (from `dependencies`)

--- a/.changeset/@graphql-tools_github-loader-6831-dependencies.md
+++ b/.changeset/@graphql-tools_github-loader-6831-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-tools/github-loader": patch
+---
+dependencies updates:
+  - Added dependency [`sync-fetch@0.6.0-2` ↗︎](https://www.npmjs.com/package/sync-fetch/v/0.6.0) (to `dependencies`)
+  - Removed dependency [`@ardatan/sync-fetch@^0.0.1` ↗︎](https://www.npmjs.com/package/@ardatan/sync-fetch/v/0.0.1) (from `dependencies`)

--- a/.changeset/@graphql-tools_url-loader-6831-dependencies.md
+++ b/.changeset/@graphql-tools_url-loader-6831-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-tools/url-loader": patch
+---
+dependencies updates:
+  - Added dependency [`sync-fetch@0.6.0-2` ↗︎](https://www.npmjs.com/package/sync-fetch/v/0.6.0) (to `dependencies`)
+  - Removed dependency [`@ardatan/sync-fetch@^0.0.1` ↗︎](https://www.npmjs.com/package/@ardatan/sync-fetch/v/0.0.1) (from `dependencies`)

--- a/packages/loaders/apollo-engine/package.json
+++ b/packages/loaders/apollo-engine/package.json
@@ -51,9 +51,9 @@
     "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "dependencies": {
-    "@ardatan/sync-fetch": "^0.0.1",
     "@graphql-tools/utils": "^10.7.2",
     "@whatwg-node/fetch": "^0.10.0",
+    "sync-fetch": "0.6.0-2",
     "tslib": "^2.4.0"
   },
   "publishConfig": {

--- a/packages/loaders/apollo-engine/src/index.ts
+++ b/packages/loaders/apollo-engine/src/index.ts
@@ -1,4 +1,4 @@
-import syncFetch from '@ardatan/sync-fetch';
+import syncFetch from 'sync-fetch';
 import { BaseLoaderOptions, Loader, parseGraphQLSDL, Source } from '@graphql-tools/utils';
 import { fetch } from '@whatwg-node/fetch';
 

--- a/packages/loaders/github/package.json
+++ b/packages/loaders/github/package.json
@@ -51,11 +51,11 @@
     "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "dependencies": {
-    "@ardatan/sync-fetch": "^0.0.1",
     "@graphql-tools/executor-http": "^1.1.9",
     "@graphql-tools/graphql-tag-pluck": "^8.3.12",
     "@graphql-tools/utils": "^10.7.2",
     "@whatwg-node/fetch": "^0.10.0",
+    "sync-fetch": "0.6.0-2",
     "tslib": "^2.4.0",
     "value-or-promise": "^1.0.12"
   },

--- a/packages/loaders/github/src/index.ts
+++ b/packages/loaders/github/src/index.ts
@@ -1,6 +1,6 @@
 import { parse } from 'graphql';
+import syncFetch from 'sync-fetch';
 import { ValueOrPromise } from 'value-or-promise';
-import syncFetch from '@ardatan/sync-fetch';
 import { AsyncFetchFn, FetchFn, SyncFetchFn } from '@graphql-tools/executor-http';
 import {
   gqlPluckFromCodeStringSync,

--- a/packages/loaders/url/declarations.d.ts
+++ b/packages/loaders/url/declarations.d.ts
@@ -1,1 +1,0 @@
-declare module '@ardatan/sync-fetch';

--- a/packages/loaders/url/package.json
+++ b/packages/loaders/url/package.json
@@ -51,7 +51,6 @@
     "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
   },
   "dependencies": {
-    "@ardatan/sync-fetch": "^0.0.1",
     "@graphql-tools/executor-graphql-ws": "^1.3.2",
     "@graphql-tools/executor-http": "^1.1.9",
     "@graphql-tools/executor-legacy-ws": "^1.1.10",
@@ -60,6 +59,7 @@
     "@types/ws": "^8.0.0",
     "@whatwg-node/fetch": "^0.10.0",
     "isomorphic-ws": "^5.0.0",
+    "sync-fetch": "0.6.0-2",
     "tslib": "^2.4.0",
     "value-or-promise": "^1.0.11",
     "ws": "^8.17.1"

--- a/packages/loaders/url/src/defaultSyncFetch.ts
+++ b/packages/loaders/url/src/defaultSyncFetch.ts
@@ -1,4 +1,4 @@
-import syncFetchImported from '@ardatan/sync-fetch';
+import syncFetchImported from 'sync-fetch';
 import { SyncFetchFn, SyncResponse } from '@graphql-tools/executor-http';
 
 export const defaultSyncFetch: SyncFetchFn = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -76,13 +76,6 @@
     signedsource "^1.0.0"
     yargs "^15.3.1"
 
-"@ardatan/sync-fetch@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@ardatan/sync-fetch/-/sync-fetch-0.0.1.tgz#3385d3feedceb60a896518a1db857ec1e945348f"
-  integrity sha512-xhlTqH0m31mnsG0tIP4ETgfSB6gXDaYYsUWTrlUV93fFQPI9dd8hE0Ot6MHLCtqgB32hwJAC3YZMWlXZw7AleA==
-  dependencies:
-    node-fetch "^2.6.1"
-
 "@astrojs/compiler@^2.3.4":
   version "2.10.3"
   resolved "https://registry.yarnpkg.com/@astrojs/compiler/-/compiler-2.10.3.tgz#852386445029f7765a70b4c1d1140e175e1d8c27"
@@ -5172,6 +5165,11 @@ dagre-d3-es@7.0.11:
     d3 "^7.9.0"
     lodash-es "^4.17.21"
 
+data-uri-to-buffer@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
+  integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
+
 data-uri-to-buffer@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz#8a58bb67384b261a38ef18bea1810cb01badd28b"
@@ -6278,6 +6276,14 @@ fd-slicer@~1.1.0:
   dependencies:
     pend "~1.2.0"
 
+fetch-blob@^3.1.2, fetch-blob@^3.1.4:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
+  integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
+  dependencies:
+    node-domexception "^1.0.0"
+    web-streams-polyfill "^3.0.3"
+
 file-entry-cache@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-8.0.0.tgz#7787bddcf1131bffb92636c69457bbc0edd6d81f"
@@ -6405,6 +6411,13 @@ format@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
   integrity sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==
+
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+  dependencies:
+    fetch-blob "^3.1.2"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -9461,12 +9474,26 @@ no-case@^3.0.4:
     lower-case "^2.0.2"
     tslib "^2.0.3"
 
-node-fetch@^2.5.0, node-fetch@^2.6.1, node-fetch@^2.6.5, node-fetch@^2.7.0:
+node-domexception@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
+node-fetch@^2.5.0, node-fetch@^2.6.5, node-fetch@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
+
+node-fetch@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.2.tgz#d1e889bacdf733b4ff3b2b243eb7a12866a0b78b"
+  integrity sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==
+  dependencies:
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.4"
+    formdata-polyfill "^4.0.10"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -11511,6 +11538,15 @@ symbol-observable@^4.0.0:
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-4.0.0.tgz#5b425f192279e87f2f9b937ac8540d1984b39205"
   integrity sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==
 
+sync-fetch@0.6.0-2:
+  version "0.6.0-2"
+  resolved "https://registry.yarnpkg.com/sync-fetch/-/sync-fetch-0.6.0-2.tgz#d82d6dc8efaf2d103a9015e7bd7ba0bfc8e078f2"
+  integrity sha512-c7AfkZ9udatCuAy9RSfiGPpeOKKUAUK5e1cXadLOGUjasdxqYqAK0jTNkM/FSEyJ3a5Ra27j/tw/PS0qLmaF/A==
+  dependencies:
+    node-fetch "^3.3.2"
+    timeout-signal "^2.0.0"
+    whatwg-mimetype "^4.0.0"
+
 synckit@^0.9.0:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.9.2.tgz#a3a935eca7922d48b9e7d6c61822ee6c3ae4ec62"
@@ -11647,6 +11683,11 @@ through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
+
+timeout-signal@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/timeout-signal/-/timeout-signal-2.0.0.tgz#23207ea448d50258bb0defe3beea4a467643abba"
+  integrity sha512-YBGpG4bWsHoPvofT6y/5iqulfXIiIErl5B0LdtHT1mGXDFTAhhRrbUpTvBgYbovr+3cKblya2WAOcpoy90XguA==
 
 tinyexec@^0.3.0:
   version "0.3.2"
@@ -12293,6 +12334,11 @@ web-namespaces@^2.0.0:
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-2.0.1.tgz#1010ff7c650eccb2592cebeeaf9a1b253fd40692"
   integrity sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==
 
+web-streams-polyfill@^3.0.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz#2073b91a2fdb1fbfbd401e7de0ac9f8214cecb4b"
+  integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
+
 webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
@@ -12350,6 +12396,11 @@ webpack@5.97.1, webpack@^5:
     terser-webpack-plugin "^5.3.10"
     watchpack "^2.4.1"
     webpack-sources "^3.2.3"
+
+whatwg-mimetype@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz#bc1bf94a985dc50388d54a9258ac405c3ca2fc0a"
+  integrity sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==
 
 whatwg-url@^5.0.0:
   version "5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6198,15 +6198,15 @@ fast-fifo@^1.2.0, fast-fifo@^1.3.2:
   integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
 
 fast-glob@^3.2.12, fast-glob@^3.2.9, fast-glob@^3.3.0, fast-glob@^3.3.2:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
-  integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"
+  integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
     glob-parent "^5.1.2"
     merge2 "^1.3.0"
-    micromatch "^4.0.8"
+    micromatch "^4.0.4"
 
 fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
The only reason to use our fork was to avoid `Buffer` usage for the browser code. Now it's not used anymore, and we can use the upstream `sync-fetch` package directly instead of `@ardatan/sync-fetch` fork.