### PR TITLE
Fix for code scanning alert no. 45: Incomplete string escaping or encoding

### DIFF
--- a/.changeset/whole-hands-smell.md
+++ b/.changeset/whole-hands-smell.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/utils': patch
+---
+
+Better handling for field name handling in `buildOperationForField`

--- a/packages/utils/src/build-operation-for-field.ts
+++ b/packages/utils/src/build-operation-for-field.ts
@@ -479,9 +479,9 @@ function resolveField({
   if (fieldTypeMap.has(fieldPathStr) && fieldTypeMap.get(fieldPathStr) !== field.type.toString()) {
     fieldName += (field.type as any)
       .toString()
-      .replace('!', 'NonNull')
-      .replace('[', 'List')
-      .replace(']', '');
+      .replace(/!/g, 'NonNull')
+      .replace(/\[/g, 'List')
+      .replace(/\]/g, '');
   }
   fieldTypeMap.set(fieldPathStr, field.type.toString());
 


### PR DESCRIPTION
Fix for [https://github.com/ardatan/graphql-tools/security/code-scanning/45](https://github.com/ardatan/graphql-tools/security/code-scanning/45)

To fix the problem, we need to ensure that all occurrences of the characters '!', '[', and ']' are replaced, not just the first occurrence. This can be achieved by using regular expressions with the global flag. Specifically, we will replace the `replace` method calls with regular expressions that include the global flag (`/g`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
