### PR TITLE
Potential fix for code scanning alert no. 31: Prototype-polluting assignment

### DIFF
--- a/packages/mock/src/MockStore.ts
+++ b/packages/mock/src/MockStore.ts
@@ -263,6 +263,9 @@ export class MockStore implements IMockStore {
       value = deepResolveMockList(value);
     }
 
+    if (typeName === '__proto__' || typeName === 'constructor' || typeName === 'prototype') {
+      throw new Error(`Invalid typeName: ${typeName}`);
+    }
     if (this.store[typeName] === undefined) {
       this.store[typeName] = {};
     }


### PR DESCRIPTION
Potential fix for [https://github.com/ardatan/graphql-tools/security/code-scanning/31](https://github.com/ardatan/graphql-tools/security/code-scanning/31)

To fix the problem, we need to ensure that `typeName` cannot be set to `__proto__`, `constructor`, or `prototype`. This can be done by adding a validation step before using `typeName` as a key in `this.store`. If `typeName` is one of these forbidden values, we should throw an error or handle it appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
