### PR TITLE
Fix for code scanning alert no. 30: Prototype-polluting assignment

### DIFF
--- a/packages/mock/src/MockStore.ts
+++ b/packages/mock/src/MockStore.ts
@@ -263,6 +263,12 @@ export class MockStore implements IMockStore {
       value = deepResolveMockList(value);
     }
 
+    if (typeName === '__proto__' || typeName === 'constructor' || typeName === 'prototype') {
+      throw new Error(`Invalid typeName: ${typeName}`);
+    }
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      throw new Error(`Invalid key: ${key}`);
+    }
     if (this.store[typeName] === undefined) {
       this.store[typeName] = {};
     }


### PR DESCRIPTION
Potential fix for [https://github.com/ardatan/graphql-tools/security/code-scanning/30](https://github.com/ardatan/graphql-tools/security/code-scanning/30)

To fix the prototype pollution issue, we need to ensure that `typeName` and `key` cannot be set to `__proto__`, `constructor`, or `prototype`. This can be achieved by adding a validation step before using these variables as keys in the `this.store` object. If either `typeName` or `key` matches any of these restricted values, we should throw an error or handle it appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
