### PR TITLE
Fix for code scanning alert no. 29: Prototype-polluting assignment

### DIFF
--- a/.changeset/dark-crabs-glow.md
+++ b/.changeset/dark-crabs-glow.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/merge': patch
+---
+
+Prevent prototype polluting assignment

--- a/packages/merge/src/merge-resolvers.ts
+++ b/packages/merge/src/merge-resolvers.ts
@@ -72,7 +72,10 @@ export function mergeResolvers<TSource, TContext>(
   if (options?.exclusions) {
     for (const exclusion of options.exclusions) {
       const [typeName, fieldName] = exclusion.split('.');
-      if (['__proto__', 'constructor', 'prototype'].includes(typeName) || ['__proto__', 'constructor', 'prototype'].includes(fieldName)) {
+      if (
+        ['__proto__', 'constructor', 'prototype'].includes(typeName) ||
+        ['__proto__', 'constructor', 'prototype'].includes(fieldName)
+      ) {
         continue;
       }
       if (!fieldName || fieldName === '*') {

--- a/packages/merge/src/merge-resolvers.ts
+++ b/packages/merge/src/merge-resolvers.ts
@@ -72,6 +72,9 @@ export function mergeResolvers<TSource, TContext>(
   if (options?.exclusions) {
     for (const exclusion of options.exclusions) {
       const [typeName, fieldName] = exclusion.split('.');
+      if (['__proto__', 'constructor', 'prototype'].includes(typeName) || ['__proto__', 'constructor', 'prototype'].includes(fieldName)) {
+        continue;
+      }
       if (!fieldName || fieldName === '*') {
         delete result[typeName];
       } else if (result[typeName]) {


### PR DESCRIPTION
Potential fix for [https://github.com/ardatan/graphql-tools/security/code-scanning/29](https://github.com/ardatan/graphql-tools/security/code-scanning/29)

To fix the prototype pollution vulnerability, we need to ensure that the `typeName` and `fieldName` values cannot be special property names like `__proto__`, `constructor`, or `prototype`. We can achieve this by adding a validation step before using these values to delete properties from the `result` object.

The best way to fix this problem without changing existing functionality is to add a check to ensure that `typeName` and `fieldName` are not one of the special property names. If they are, we should skip the deletion operation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
