### PR TITLE
CODEGEN-334 - Throw custom NoDocumentFoundError if no document found whilst loading documents

### DIFF
--- a/.changeset/soft-stars-pay.md
+++ b/.changeset/soft-stars-pay.md
@@ -1,0 +1,8 @@
+---
+'@graphql-tools/load': minor
+---
+
+Throw NoDocumentFoundError when cannot find documents instead of the standard Error
+
+This helps libraries such as GraphQL Code Generator to handle loading error cases
+more flexibly.

--- a/packages/load/src/load-typedefs.ts
+++ b/packages/load/src/load-typedefs.ts
@@ -135,7 +135,7 @@ function prepareResult({
   const pointerList = Object.keys(pointerOptionMap);
 
   if (pointerList.length > 0 && validSources.length === 0) {
-    throw new Error(`
+    throw new NoDocumentFoundError(`
       Unable to find any GraphQL type definitions for the following pointers:
         ${pointerList.map(
           p => `
@@ -150,4 +150,11 @@ function prepareResult({
 
   debugTimerEnd('@graphql-tools/load: prepareResult');
   return sortedResult;
+}
+
+export class NoDocumentFoundError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = 'NoDocumentFoundError';
+  }
 }

--- a/packages/load/tests/loaders/documents/documents-from-glob.spec.ts
+++ b/packages/load/tests/loaders/documents/documents-from-glob.spec.ts
@@ -2,7 +2,7 @@ import { join } from 'path';
 import { parse, separateOperations } from 'graphql';
 import { CodeFileLoader } from '@graphql-tools/code-file-loader';
 import { GraphQLFileLoader } from '@graphql-tools/graphql-file-loader';
-import { loadDocuments, loadDocumentsSync } from '@graphql-tools/load';
+import { loadDocuments, loadDocumentsSync, NoDocumentFoundError } from '@graphql-tools/load';
 import { runTests } from '../../../../testing/utils.js';
 import '../../../../testing/to-be-similar-string';
 import { readFileSync } from 'fs';
@@ -93,15 +93,12 @@ describe('documentsFromGlob', () => {
     });
 
     test(`Should throw on empty files and empty result`, async () => {
-      try {
-        const glob = join(__dirname, 'test-files', '*.empty.graphql');
-        await load(glob, {
-          loaders: [new GraphQLFileLoader()],
-        });
-        expect(true).toBeFalsy();
-      } catch (e: any) {
-        expect(e).toBeDefined();
-      }
+      const glob = join(__dirname, 'test-files', '*.empty.graphql');
+      const promise = load(glob, {
+        loaders: [new GraphQLFileLoader()],
+      });
+
+      expect(promise).rejects.toThrow(NoDocumentFoundError);
     });
 
     test(`Should throw on invalid files`, async () => {


### PR DESCRIPTION
## Description

GraphQL Code Generator uses `@graphql-tool/load` to load documents.
When there are no documents found given a pattern, `@graphql-tool/load` throws an error. However, Codegen doesn't know if it's a syntax error, no document found error or anything else.

This PR adds and exports a custom error `NoDocumentFoundError` to `@graphql-tool/load` to allow libraries like Codegen to handle No Document Found error case more explicitly


Related Codegen issue https://github.com/dotansimha/graphql-code-generator/issues/9172 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Unit test
- [ ] I will use an alpha version to test the Codegen integration

