### PR TITLE
preserve resolvers should use the resolved typename

### DIFF
--- a/.changeset/huge-clocks-turn.md
+++ b/.changeset/huge-clocks-turn.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/mock': patch
+---
+
+preserveResolvers uses resolved type name for abstract types if available

--- a/packages/mock/src/addMocksToSchema.ts
+++ b/packages/mock/src/addMocksToSchema.ts
@@ -155,6 +155,10 @@ export function addMocksToSchema<TResolvers = IResolvers>({
   };
 
   const typeResolver: GraphQLTypeResolver<any, any> = data => {
+    if (data.__typename) {
+      return data.__typename;
+    }
+
     if (isRef(data)) {
       return data.$ref.typeName;
     }


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on GraphQL Tools!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

## Description

Modifies the `typeResolver` to use the resolved __typename before using the mocked `$ref`'s type.

Resolves https://github.com/ardatan/graphql-tools/issues/7209

<!--
  Please do not use "Fixed" or "Resolves". Keep "Related" as-is.
-->

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] See unit test

**Test Environment**:

- OS: macos
- `@graphql-tools/...`: latest
- NodeJS: v22.13.1

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose
the solution you did and what alternatives you considered, etc...
