### PR TITLE
support parsing vue single-file-components using composition API

### DIFF
--- a/packages/graphql-tag-pluck/package.json
+++ b/packages/graphql-tag-pluck/package.json
@@ -47,7 +47,13 @@
   },
   "typings": "dist/typings/index.d.ts",
   "peerDependencies": {
+    "@vue/compiler-sfc": "^3.3.1",
     "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@vue/compiler-sfc": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@babel/core": "^7.26.10",

--- a/packages/graphql-tag-pluck/package.json
+++ b/packages/graphql-tag-pluck/package.json
@@ -58,10 +58,12 @@
     "@graphql-tools/utils": "^10.8.6",
     "tslib": "^2.4.0"
   },
+  "optionalDependencies": {
+    "@vue/compiler-sfc": "^3.3.1"
+  },
   "devDependencies": {
     "@astrojs/compiler": "2.12.2",
     "@types/babel__traverse": "7.20.7",
-    "@vue/compiler-sfc": "3.5.17",
     "astrojs-compiler-sync": "1.1.1",
     "content-tag": "4.0.0",
     "svelte": "5.35.2",

--- a/packages/graphql-tag-pluck/package.json
+++ b/packages/graphql-tag-pluck/package.json
@@ -47,13 +47,7 @@
   },
   "typings": "dist/typings/index.d.ts",
   "peerDependencies": {
-    "@vue/compiler-sfc": "^3.3.1",
     "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-  },
-  "peerDependenciesMeta": {
-    "@vue/compiler-sfc": {
-      "optional": true
-    }
   },
   "dependencies": {
     "@babel/core": "^7.26.10",

--- a/packages/graphql-tag-pluck/package.json
+++ b/packages/graphql-tag-pluck/package.json
@@ -58,12 +58,10 @@
     "@graphql-tools/utils": "^10.8.6",
     "tslib": "^2.4.0"
   },
-  "optionalDependencies": {
-    "@vue/compiler-sfc": "^3.3.1"
-  },
   "devDependencies": {
     "@astrojs/compiler": "2.12.2",
     "@types/babel__traverse": "7.20.7",
+    "@vue/compiler-sfc": "3.5.17",
     "astrojs-compiler-sync": "1.1.1",
     "content-tag": "4.0.0",
     "svelte": "5.35.2",

--- a/packages/graphql-tag-pluck/src/index.ts
+++ b/packages/graphql-tag-pluck/src/index.ts
@@ -158,6 +158,14 @@ function parseWithVue(
   fileData: string,
   filePath: string,
 ) {
+  // Calls to registerTS are idempotent, so it's safe to call it repeatedly like
+  // we are here.
+  //
+  // See https://github.com/ardatan/graphql-tools/pull/7271 for more details.
+  //
+  // eslint-disable-next-line import/no-extraneous-dependencies
+  vueTemplateCompiler.registerTS(() => require('typescript'));
+
   const { descriptor } = vueTemplateCompiler.parse(fileData, { filename: filePath });
 
   return descriptor.script || descriptor.scriptSetup
@@ -397,7 +405,6 @@ const MissingGlimmerCompilerError = new Error(
 
 async function loadVueCompilerAsync() {
   try {
-    // eslint-disable-next-line import/no-extraneous-dependencies
     return await import('@vue/compiler-sfc');
   } catch {
     throw MissingVueTemplateCompilerError;
@@ -406,7 +413,6 @@ async function loadVueCompilerAsync() {
 
 function loadVueCompilerSync() {
   try {
-    // eslint-disable-next-line import/no-extraneous-dependencies
     return require('@vue/compiler-sfc');
   } catch {
     throw MissingVueTemplateCompilerError;

--- a/packages/graphql-tag-pluck/src/index.ts
+++ b/packages/graphql-tag-pluck/src/index.ts
@@ -405,6 +405,7 @@ const MissingGlimmerCompilerError = new Error(
 
 async function loadVueCompilerAsync() {
   try {
+    // eslint-disable-next-line import/no-extraneous-dependencies
     return await import('@vue/compiler-sfc');
   } catch {
     throw MissingVueTemplateCompilerError;
@@ -413,6 +414,7 @@ async function loadVueCompilerAsync() {
 
 function loadVueCompilerSync() {
   try {
+    // eslint-disable-next-line import/no-extraneous-dependencies
     return require('@vue/compiler-sfc');
   } catch {
     throw MissingVueTemplateCompilerError;

--- a/packages/graphql-tag-pluck/src/index.ts
+++ b/packages/graphql-tag-pluck/src/index.ts
@@ -153,8 +153,12 @@ const supportedExtensions = [
 ];
 
 // tslint:disable-next-line: no-implicit-dependencies
-function parseWithVue(vueTemplateCompiler: typeof import('@vue/compiler-sfc'), fileData: string) {
-  const { descriptor } = vueTemplateCompiler.parse(fileData);
+function parseWithVue(
+  vueTemplateCompiler: typeof import('@vue/compiler-sfc'),
+  fileData: string,
+  filePath: string,
+) {
+  const { descriptor } = vueTemplateCompiler.parse(fileData, { filename: filePath });
 
   return descriptor.script || descriptor.scriptSetup
     ? vueTemplateCompiler.compileScript(descriptor, { id: Date.now().toString() }).content
@@ -168,7 +172,7 @@ function customBlockFromVue(
   filePath: string,
   blockType: string,
 ): Source | undefined {
-  const { descriptor } = vueTemplateCompiler.parse(fileData);
+  const { descriptor } = vueTemplateCompiler.parse(fileData, { filename: filePath });
 
   const block = descriptor.customBlocks.find(b => b.type === blockType);
   if (block === undefined) {
@@ -232,7 +236,7 @@ export const gqlPluckFromCodeString = async (
     if (options.gqlVueBlock) {
       blockSource = await pluckVueFileCustomBlock(code, filePath, options.gqlVueBlock);
     }
-    code = await pluckVueFileScript(code);
+    code = await pluckVueFileScript(code, filePath);
   } else if (fileExt === '.svelte') {
     code = await pluckSvelteFileScript(code);
   } else if (fileExt === '.astro') {
@@ -273,7 +277,7 @@ export const gqlPluckFromCodeStringSync = (
     if (options.gqlVueBlock) {
       blockSource = pluckVueFileCustomBlockSync(code, filePath, options.gqlVueBlock);
     }
-    code = pluckVueFileScriptSync(code);
+    code = pluckVueFileScriptSync(code, filePath);
   } else if (fileExt === '.svelte') {
     code = pluckSvelteFileScriptSync(code);
   } else if (fileExt === '.astro') {
@@ -409,14 +413,14 @@ function loadVueCompilerSync() {
   }
 }
 
-async function pluckVueFileScript(fileData: string) {
+async function pluckVueFileScript(fileData: string, filePath: string) {
   const vueTemplateCompiler = await loadVueCompilerAsync();
-  return parseWithVue(vueTemplateCompiler, fileData);
+  return parseWithVue(vueTemplateCompiler, fileData, filePath);
 }
 
-function pluckVueFileScriptSync(fileData: string) {
+function pluckVueFileScriptSync(fileData: string, filePath: string) {
   const vueTemplateCompiler = loadVueCompilerSync();
-  return parseWithVue(vueTemplateCompiler, fileData);
+  return parseWithVue(vueTemplateCompiler, fileData, filePath);
 }
 
 async function pluckVueFileCustomBlock(fileData: string, filePath: string, blockType: string) {

--- a/packages/graphql-tag-pluck/src/index.ts
+++ b/packages/graphql-tag-pluck/src/index.ts
@@ -164,7 +164,7 @@ function parseWithVue(
   //
   // See https://github.com/ardatan/graphql-tools/pull/7271 for more details.
   //
-   
+
   vueTemplateCompiler.registerTS(() => typescriptPackage);
 
   const { descriptor } = vueTemplateCompiler.parse(fileData, { filename: filePath });
@@ -410,9 +410,11 @@ const MissingTypeScriptPackageError = new Error(
         Please install it and try again.
 
         Via NPM:
+
             $ npm install typescript
 
         Via Yarn:
+
             $ yarn add typescript
       `),
 );
@@ -468,7 +470,7 @@ function pluckVueFileScriptSync(fileData: string, filePath: string) {
 }
 
 async function pluckVueFileCustomBlock(fileData: string, filePath: string, blockType: string) {
-  const vueTemplateCompiler = await loadVueCompilerSync();
+  const vueTemplateCompiler = await loadVueCompilerAsync();
   return customBlockFromVue(vueTemplateCompiler, fileData, filePath, blockType);
 }
 

--- a/packages/graphql-tag-pluck/tests/graphql-tag-pluck.test.ts
+++ b/packages/graphql-tag-pluck/tests/graphql-tag-pluck.test.ts
@@ -855,7 +855,7 @@ describe('graphql-tag-pluck', () => {
       );
     });
 
-    it('should pluck graphql-tag template literals from .vue 3 setup with compiler macros', async () => {
+    it('should pluck graphql-tag template literals from .vue 3 setup with compiler macros and imports', async () => {
       const EXTERNAL_PROPS_SOURCE = freeText(`
         export type ExternalProps = {
           foo: string;
@@ -863,7 +863,7 @@ describe('graphql-tag-pluck', () => {
       `);
 
       const VUE_SFC_SOURCE = freeText(`
-        <template lang="pug">
+        <template>
           <div>test</div>
         </template>
 
@@ -885,6 +885,11 @@ describe('graphql-tag-pluck', () => {
         </script>
       `);
 
+      // We must write the files to disk because this test is specifically
+      // ensuring that imports work in Vue SFC files with compiler macros and
+      // imports are resolved on disk by the typescript runtime.
+      //
+      // See https://github.com/ardatan/graphql-tools/pull/7271 for details.
       const tmpDirectory = fs.mkdtempSync(os.tmpdir());
       fs.writeFileSync(path.join(tmpDirectory, 'ExternalProps.ts'), EXTERNAL_PROPS_SOURCE);
       fs.writeFileSync(path.join(tmpDirectory, 'component.vue'), VUE_SFC_SOURCE);

--- a/packages/graphql-tag-pluck/tests/graphql-tag-pluck.test.ts
+++ b/packages/graphql-tag-pluck/tests/graphql-tag-pluck.test.ts
@@ -1,5 +1,4 @@
 import fs from 'node:fs/promises';
-import os from 'node:os';
 import path from 'node:path';
 import { runTests } from '../../testing/utils.js';
 import { gqlPluckFromCodeString, gqlPluckFromCodeStringSync } from '../src/index.js';
@@ -10,6 +9,8 @@ import { freeText } from '../src/utils.js';
 let tmpDir: string;
 
 beforeEach(async () => {
+  // We create temporary directories in the test directory because our test
+  // infrastructure denies writes to the host's tmp directory.
   tmpDir = await fs.mkdtemp(path.join(__dirname, 'tmp-'));
 });
 


### PR DESCRIPTION
## Description

TL;DR: this package has a dependency on `@vue/compiler-sfc` which updated two years ago in a non-backwards compatible way. Minor changes are required so that this package conforms to the changes in https://github.com/vuejs/core/pull/8083

Fixes #6945 (cc @felixxxxxs)

### Details

vue's composition API (most common syntax as of Vue 3) heavily leverages compiler macros. As part of the implementation of this feature, vue's SFC compiler requires two things:

1. The module `typescript` to be registered with `@vue/compiler-sfc` ([code pointer](https://github.com/vuejs/core/blob/eca0e1c/packages/compiler-sfc/src/script/resolveType.ts#L845))
2. Parsed files to include a file path for the purpose or resolving local imports ([code pointer](https://github.com/vuejs/core/blob/eca0e1c/packages/compiler-sfc/src/parse.ts#L26))

Currently this project satisfies neither of these requirements, meaning that any vue single-file-component using compiler macros (most of Vue 3 code) will crash the parser with an error like:

> [@vue/compiler-sfc] No fs option provided to 'compileScript' in non-Node environment. File system access is required for resolving imported types.

Though cryptic, this error can be traced back to `typescript` not being registered correctly (see [@vue/compiler-sf#resolveFS](https://github.com/vuejs/core/blob/eca0e1c/packages/compiler-sfc/src/script/resolveType.ts#L876-L879)). We have a few options to fix this.

1. Rely on callers to register typescript with the vue compiler themselves. This can be easily achieved by adding `import 'vue/compiler-sfc';` to their codegen.ts file.
2. Whenever vue files need to be parsed, ensure first that `registerTS` has been called.

Of these two options I'd recommend the latter. `typescript` registration is a low-level concept which is handled for clients by most of the `vue` ecosystem. It's easy for clients of `graphql-codegen` to miss or be confused on why `import 'vue/compiler-sfc';` is required especially given the cryptic error when it's missing.

For this PR I've taken option (2) and ensured that this project correctly calls `registerTS`.

For our second requirement, "file paths must be included for parsed files to resolve local imports" we can easily remedy this by plumbing file path information down to `@vue/compiler-sfc` which this PR also does.

And one last note. I've moved `@vue/compiler-sfc` to optional dependencies as this package does actually include it at runtime and *not* just as a dev dependency. I've also reframed it's version constraint to `^3.3.1` which is the first version which included the non-backwards compatible change this PR addresses.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots/Sandbox (if appropriate/relevant):

N/A

## How Has This Been Tested?

1. This has been tested locally in a vue repo in which graphql-codegen was failing due to the above root cause analysis. By applying these changes graphql-codegen now passes.
2. I also added a test which fails on main but passes in this PR to replicate my graphql-codegen project

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
