### PR TITLE
feat(utils): Add `subgraphName` to `ExecutionRequest` type

### DIFF
--- a/.changeset/three-impalas-love.md
+++ b/.changeset/three-impalas-love.md
@@ -1,0 +1,6 @@
+---
+'@graphql-tools/utils': minor
+---
+
+Add optional `subgraphName` preoperty to the `ExecutionRequest` interface for usage in Gateways like
+Hive Gateway.

--- a/packages/utils/src/Interfaces.ts
+++ b/packages/utils/src/Interfaces.ts
@@ -89,6 +89,8 @@ export interface ExecutionRequest<
   rootValue?: TRootValue;
   // If the request originates within execution of a parent request, it may contain the parent context and info
   context?: TContext;
+  // If the request originates within a supergraph execution, it may contain the target subgraph name
+  subgraphName?: string;
   info?: GraphQLResolveInfo;
   signal?: AbortSignal;
 }


### PR DESCRIPTION
## Description

This PR aims to ease the development of GraphQL Gateways (like Hive Gateway) by adding an optional `subgraphName` property to the `ExecutionRequest` type. This property can be populated with the targeted subgraph name by the Gateway to make it easier to identify them.

Related to https://github.com/graphql-hive/gateway/issues/1311

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

This will allow to remove an annoying point in Hive Gateway Plugin development: The subgraph name can't be access directly from `onFetch` hook. It has to be retrieve from a global weak map with the execution request as a key. With this change, the subgraph name will be directly accessible and easy to find for new developers.
