### PR TITLE
Replace dependency @theguild/federation-composition in graphqlt-tools/merge

### DIFF
--- a/.changeset/@graphql-tools_merge-7298-dependencies.md
+++ b/.changeset/@graphql-tools_merge-7298-dependencies.md
@@ -1,0 +1,5 @@
+---
+"@graphql-tools/merge": patch
+---
+dependencies updates:
+  - Removed dependency [`@theguild/federation-composition@^0.19.0` ↗︎](https://www.npmjs.com/package/@theguild/federation-composition/v/0.19.0) (from `dependencies`)

--- a/.changeset/fine-beers-wear.md
+++ b/.changeset/fine-beers-wear.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/merge': patch
+---
+
+Fix "Named export 'OperationTypeNode' not found"

--- a/packages/merge/package.json
+++ b/packages/merge/package.json
@@ -52,7 +52,6 @@
   },
   "dependencies": {
     "@graphql-tools/utils": "^10.9.0",
-    "@theguild/federation-composition": "^0.19.0",
     "tslib": "^2.4.0"
   },
   "devDependencies": {

--- a/packages/merge/src/links.ts
+++ b/packages/merge/src/links.ts
@@ -1,0 +1,189 @@
+/**
+ * A simplified, GraphQL v15 compatible version of
+ * https://github.com/graphql-hive/federation-composition/blob/main/src/utils/link/index.ts
+ * that does not provide the same safeguards or functionality, but still can determine the
+ * correct name of an linked resource.
+ */
+import { ConstArgumentNode, ConstValueNode, DocumentNode, Kind, StringValueNode } from 'graphql';
+
+type FederationNamedImport = {
+  name: string;
+  as?: string;
+};
+
+type FederationLinkUrl = {
+  identity: string;
+  name: string | null;
+  version: string | null;
+};
+
+type FederatedLink = {
+  url: FederationLinkUrl;
+  as?: string;
+  imports: FederationNamedImport[];
+};
+
+function namespace(link: FederatedLink) {
+  return link.as ?? link.url.name;
+}
+
+function defaultImport(link: FederatedLink) {
+  const name = namespace(link);
+  return name && `@${name}`;
+}
+
+export function resolveImportName(link: FederatedLink, elementName: string): string {
+  if (link.url.name && elementName === `@${link.url.name}`) {
+    // @note: default is a directive... So remove the `@`
+    return defaultImport(link)!.substring(1);
+  }
+  const imported = link.imports.find(i => i.name === elementName);
+  const resolvedName = imported?.as ?? imported?.name ?? namespaced(namespace(link), elementName);
+  // Strip the `@` prefix for directives because in all implementations of mapping or visiting a schema,
+  // directive names are not prefixed with `@`. The `@` is only for SDL.
+  return resolvedName.startsWith('@') ? resolvedName.substring(1) : resolvedName;
+}
+
+function namespaced(namespace: string | null, name: string) {
+  if (namespace?.length) {
+    if (name.startsWith('@')) {
+      return `@${namespace}__${name.substring(1)}`;
+    }
+    return `${namespace}__${name}`;
+  }
+  return name;
+}
+
+export function extractLinks(typeDefs: DocumentNode): FederatedLink[] {
+  let links: FederatedLink[] = [];
+  for (const definition of typeDefs.definitions) {
+    if (definition.kind === Kind.SCHEMA_EXTENSION || definition.kind === Kind.SCHEMA_DEFINITION) {
+      const defLinks = definition.directives?.filter(directive => directive.name.value === 'link');
+      const parsedLinks =
+        defLinks?.map(l => linkFromArgs(l.arguments ?? [])).filter(l => l !== undefined) ?? [];
+      links = links.concat(parsedLinks);
+
+      // Federation 1 support... Federation 1 uses "@core" instead of "@link", but behavior is similar enough that
+      //  it can be translated.
+      const defCores = definition.directives?.filter(({ name }) => name.value === 'core');
+      const coreLinks = defCores
+        ?.map(c => linkFromCoreArgs(c.arguments ?? []))
+        .filter(l => l !== undefined);
+      if (coreLinks) {
+        links = links.concat(...coreLinks);
+      }
+    }
+  }
+  return links;
+}
+
+function linkFromArgs(args: readonly ConstArgumentNode[]): FederatedLink | undefined {
+  let url: FederationLinkUrl | undefined;
+  let imports: FederationNamedImport[] = [];
+  let as: string | undefined;
+
+  for (const arg of args) {
+    switch (arg.name.value) {
+      case 'url': {
+        if (arg.value.kind === Kind.STRING) {
+          url = parseFederationLinkUrl(arg.value.value);
+        }
+        break;
+      }
+      case 'import': {
+        imports = parseImportNode(arg.value);
+        break;
+      }
+      case 'as': {
+        if (arg.value.kind === Kind.STRING) {
+          as = arg.value.value ?? undefined;
+        }
+        break;
+      }
+      default: {
+        // ignore. It's not the job of this package to validate. Federation should validate links.
+      }
+    }
+  }
+  if (url !== undefined) {
+    return {
+      url,
+      as,
+      imports,
+    };
+  }
+}
+
+/**
+ * Supports federation 1
+ */
+function linkFromCoreArgs(args: readonly ConstArgumentNode[]): FederatedLink | undefined {
+  const feature = args.find(
+    ({ name, value }) => name.value === 'feature' && value.kind === Kind.STRING,
+  );
+  if (feature) {
+    const url = parseFederationLinkUrl((feature.value as StringValueNode).value);
+    return {
+      url,
+      imports: [],
+    };
+  }
+}
+
+function parseImportNode(node: ConstValueNode): FederationNamedImport[] {
+  if (node.kind === Kind.LIST) {
+    const imports = node.values.map((v): FederationNamedImport | undefined => {
+      let namedImport: FederationNamedImport | undefined;
+      if (v.kind === Kind.STRING) {
+        namedImport = { name: v.value };
+      } else if (v.kind === Kind.OBJECT) {
+        let name: string = '';
+        let as: string | undefined;
+
+        for (const f of v.fields) {
+          if (f.name.value === 'name') {
+            if (f.value.kind === Kind.STRING) {
+              name = f.value.value;
+            }
+          } else if (f.name.value === 'as') {
+            if (f.value.kind === Kind.STRING) {
+              as = f.value.value;
+            }
+          }
+        }
+        namedImport = { name, as };
+      }
+      return namedImport;
+    });
+    return imports.filter(i => i !== undefined);
+  }
+  return [];
+}
+
+const VERSION_MATCH = /v(\d{1,3})\.(\d{1,4})/i;
+
+function parseFederationLinkUrl(urlSource: string): FederationLinkUrl {
+  const url = new URL(urlSource);
+  const parts = url.pathname.split('/').filter(Boolean);
+  const versionOrName = parts[parts.length - 1];
+  if (versionOrName) {
+    if (VERSION_MATCH.test(versionOrName)) {
+      const maybeName = parts[parts.length - 2];
+      return {
+        identity: url.origin + (maybeName ? `/${parts.slice(0, parts.length - 1).join('/')}` : ''),
+        name: maybeName ?? null,
+        version: versionOrName,
+      };
+    }
+    return {
+      identity: `${url.origin}/${parts.join('/')}`,
+      name: versionOrName,
+      version: null,
+    };
+  }
+  return {
+    identity: url.origin,
+    name: null,
+    version: null,
+  };
+}

--- a/packages/merge/src/links.ts
+++ b/packages/merge/src/links.ts
@@ -4,7 +4,13 @@
  * that does not provide the same safeguards or functionality, but still can determine the
  * correct name of an linked resource.
  */
-import { ConstArgumentNode, ConstValueNode, DocumentNode, Kind, StringValueNode } from 'graphql';
+import {
+  Kind,
+  type ArgumentNode,
+  type DocumentNode,
+  type StringValueNode,
+  type ValueNode,
+} from 'graphql';
 
 type FederationNamedImport = {
   name: string;
@@ -77,7 +83,7 @@ export function extractLinks(typeDefs: DocumentNode): FederatedLink[] {
   return links;
 }
 
-function linkFromArgs(args: readonly ConstArgumentNode[]): FederatedLink | undefined {
+function linkFromArgs(args: readonly ArgumentNode[]): FederatedLink | undefined {
   let url: FederationLinkUrl | undefined;
   let imports: FederationNamedImport[] = [];
   let as: string | undefined;
@@ -117,7 +123,7 @@ function linkFromArgs(args: readonly ConstArgumentNode[]): FederatedLink | undef
 /**
  * Supports federation 1
  */
-function linkFromCoreArgs(args: readonly ConstArgumentNode[]): FederatedLink | undefined {
+function linkFromCoreArgs(args: readonly ArgumentNode[]): FederatedLink | undefined {
   const feature = args.find(
     ({ name, value }) => name.value === 'feature' && value.kind === Kind.STRING,
   );
@@ -130,7 +136,7 @@ function linkFromCoreArgs(args: readonly ConstArgumentNode[]): FederatedLink | u
   }
 }
 
-function parseImportNode(node: ConstValueNode): FederationNamedImport[] {
+function parseImportNode(node: ValueNode): FederationNamedImport[] {
   if (node.kind === Kind.LIST) {
     const imports = node.values.map((v): FederationNamedImport | undefined => {
       let namedImport: FederationNamedImport | undefined;


### PR DESCRIPTION
## Description

Removes the dependency "@theguild/federation-composition" from "@graphql-tools/merge" by creating a lightweight copy of the code used for extracting and resolving linked schema types' names.

Related https://github.com/ardatan/graphql-tools/issues/7290

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Existing unit tests cover the link extraction/resolving behavior.

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
