### PR TITLE
support absolute path aliases

### DIFF
--- a/.changeset/solid-loops-feel.md
+++ b/.changeset/solid-loops-feel.md
@@ -2,16 +2,6 @@
 '@graphql-tools/import': patch
 ---
 
-This change fixes a minor bug from #7310 that affects users of path aliases - a feature that lets GraphQL users leverage [tsconfig.json#paths](https://www.typescriptlang.org/tsconfig/#paths) aliasing syntax for GraphQL imports.
+Fix support for absolute path aliases in GraphQL imports
 
-The issue stems from the original implementation's execution order. Path alias resolution happens inside `resolveFilePath`, which only runs for non-absolute paths:
-
-```ts
-  if (!isAbsolute(filePath) && !(filePath in predefinedImports)) {
-    filePath = resolveFilePath(cwd, filePath, pathAliases);
-  }
-```
-
-This means relative path aliases like `@/*` → `src/*` work correctly, but absolute path aliases like `/*` → `src/*` fail since they never reach the resolution logic.
-
-The solution is straightforward: move path alias resolution before the absolute path check instead of after it.
+Path aliases configured with absolute paths (e.g., `/*` → `src/*`) now work correctly alongside relative aliases (e.g., `@/*` → `src/*`). This allows more flexible aliasing configurations when using [tsconfig.json#paths](https://www.typescriptlang.org/tsconfig/#paths) syntax for GraphQL imports.

--- a/.changeset/solid-loops-feel.md
+++ b/.changeset/solid-loops-feel.md
@@ -1,0 +1,17 @@
+---
+'@graphql-tools/import': patch
+---
+
+This change fixes a minor bug from #7310 that affects users of path aliases - a feature that lets GraphQL users leverage [tsconfig.json#paths](https://www.typescriptlang.org/tsconfig/#paths) aliasing syntax for GraphQL imports.
+
+The issue stems from the original implementation's execution order. Path alias resolution happens inside `resolveFilePath`, which only runs for non-absolute paths:
+
+```ts
+  if (!isAbsolute(filePath) && !(filePath in predefinedImports)) {
+    filePath = resolveFilePath(cwd, filePath, pathAliases);
+  }
+```
+
+This means relative path aliases like `@/*` → `src/*` work correctly, but absolute path aliases like `/*` → `src/*` fail since they never reach the resolution logic.
+
+The solution is straightforward: move path alias resolution before the absolute path check instead of after it.

--- a/packages/import/src/index.ts
+++ b/packages/import/src/index.ts
@@ -172,9 +172,11 @@ function visitFile(
   predefinedImports: Record<string, string>,
   pathAliases?: PathAliases,
 ): Map<string, Set<DefinitionNode>> {
-  filePath = applyPathAliases(filePath, pathAliases);
-  if (!isAbsolute(filePath) && !(filePath in predefinedImports)) {
-    filePath = resolveFilePath(cwd, filePath);
+  if (!(filePath in predefinedImports)) {
+    filePath = applyPathAliases(filePath, pathAliases);
+    if (!isAbsolute(filePath)) {
+      filePath = resolveFilePath(cwd, filePath);
+    }
   }
   if (!visitedFiles.has(filePath)) {
     const fileContent =

--- a/packages/import/src/index.ts
+++ b/packages/import/src/index.ts
@@ -172,8 +172,9 @@ function visitFile(
   predefinedImports: Record<string, string>,
   pathAliases?: PathAliases,
 ): Map<string, Set<DefinitionNode>> {
+  filePath = applyPathAliases(filePath, pathAliases);
   if (!isAbsolute(filePath) && !(filePath in predefinedImports)) {
-    filePath = resolveFilePath(cwd, filePath, pathAliases);
+    filePath = resolveFilePath(cwd, filePath);
   }
   if (!visitedFiles.has(filePath)) {
     const fileContent =
@@ -666,21 +667,7 @@ export function parseImportLine(importLine: string): { imports: string[]; from: 
   `);
 }
 
-function resolveFilePath(filePath: string, importFrom: string, pathAliases?: PathAliases): string {
-  // First, check if importFrom matches any path aliases.
-  if (pathAliases != null) {
-    for (const [prefixPattern, mapping] of Object.entries(pathAliases.mappings)) {
-      const matchedMapping = applyPathAlias(prefixPattern, mapping, importFrom);
-      if (matchedMapping == null) {
-        continue;
-      }
-
-      const resolvedMapping = resolveFrom(pathAliases.rootDir ?? process.cwd(), matchedMapping);
-      return realpathSync(resolvedMapping);
-    }
-  }
-
-  // Fall back to original resolution logic
+function resolveFilePath(filePath: string, importFrom: string): string {
   const dirName = dirname(filePath);
   try {
     const fullPath = join(dirName, importFrom);
@@ -691,6 +678,33 @@ function resolveFilePath(filePath: string, importFrom: string, pathAliases?: Pat
     }
     throw e;
   }
+}
+
+/**
+ * Rewrites the provided file path using the first matched path alias (or
+ * returns the file path with no changes if none match).
+ *
+ * @param filePath - The file path to rewrite.
+ * @param pathAliases - The path aliases to evaluate.
+ *
+ * @returns The rewritten file path.
+ */
+function applyPathAliases(filePath: string, pathAliases?: PathAliases): string {
+  if (pathAliases == null) {
+    return filePath;
+  }
+
+  for (const [prefixPattern, mapping] of Object.entries(pathAliases.mappings)) {
+    const matchedMapping = applyPathAlias(prefixPattern, mapping, filePath);
+    if (matchedMapping == null) {
+      continue;
+    }
+
+    const resolvedMapping = resolveFrom(pathAliases.rootDir ?? process.cwd(), matchedMapping);
+    return realpathSync(resolvedMapping);
+  }
+
+  return filePath;
 }
 
 /**

--- a/packages/import/tests/schema/fixtures/path-aliases/absolute/a.graphql
+++ b/packages/import/tests/schema/fixtures/path-aliases/absolute/a.graphql
@@ -1,0 +1,10 @@
+#import TypeB from "/b.graphql"
+
+type TypeA {
+  id: ID!
+  relatedB: TypeB!
+}
+
+type Query {
+  getA: TypeA
+}

--- a/packages/import/tests/schema/fixtures/path-aliases/absolute/b.graphql
+++ b/packages/import/tests/schema/fixtures/path-aliases/absolute/b.graphql
@@ -1,0 +1,3 @@
+type TypeB {
+  id: ID!
+}

--- a/packages/import/tests/schema/fixtures/path-aliases/node-subpath/a.graphql
+++ b/packages/import/tests/schema/fixtures/path-aliases/node-subpath/a.graphql
@@ -1,0 +1,10 @@
+#import TypeB from "#b.graphql"
+
+type TypeA {
+  id: ID!
+  relatedB: TypeB!
+}
+
+type Query {
+  getA: TypeA
+}

--- a/packages/import/tests/schema/fixtures/path-aliases/node-subpath/b.graphql
+++ b/packages/import/tests/schema/fixtures/path-aliases/node-subpath/b.graphql
@@ -1,0 +1,3 @@
+type TypeB {
+  id: ID!
+}

--- a/packages/import/tests/schema/import-schema.spec.ts
+++ b/packages/import/tests/schema/import-schema.spec.ts
@@ -1307,6 +1307,33 @@ describe('importSchema', () => {
     `);
   });
 
+  it('should handle node-style subpath imports path aliases', () => {
+    const document = importSchema(
+      './fixtures/path-aliases/node-subpath/a.graphql',
+      {},
+      {
+        mappings: {
+          '#*': path.join(__dirname, './fixtures/path-aliases/node-subpath/*'),
+        },
+      },
+    );
+
+    expect(document).toBeSimilarGqlDoc(/* GraphQL */ `
+      type Query {
+        getA: TypeA
+      }
+
+      type TypeA {
+        id: ID!
+        relatedB: TypeB!
+      }
+
+      type TypeB {
+        id: ID!
+      }
+    `);
+  });
+
   it('resolves mapped paths relative to root dir', () => {
     const document = importSchema(
       './fixtures/path-aliases/multiple-levels/level1.graphql',

--- a/packages/import/tests/schema/import-schema.spec.ts
+++ b/packages/import/tests/schema/import-schema.spec.ts
@@ -1280,6 +1280,33 @@ describe('importSchema', () => {
     `);
   });
 
+  it('should handle absolute path aliases', () => {
+    const document = importSchema(
+      './fixtures/path-aliases/absolute/a.graphql',
+      {},
+      {
+        mappings: {
+          '/*': path.join(__dirname, './fixtures/path-aliases/absolute/*'),
+        },
+      },
+    );
+
+    expect(document).toBeSimilarGqlDoc(/* GraphQL */ `
+      type Query {
+        getA: TypeA
+      }
+
+      type TypeA {
+        id: ID!
+        relatedB: TypeB!
+      }
+
+      type TypeB {
+        id: ID!
+      }
+    `);
+  });
+
   it('resolves mapped paths relative to root dir', () => {
     const document = importSchema(
       './fixtures/path-aliases/multiple-levels/level1.graphql',

--- a/packages/import/tests/schema/import-schema.spec.ts
+++ b/packages/import/tests/schema/import-schema.spec.ts
@@ -1374,4 +1374,37 @@ describe('importSchema', () => {
       }
     `);
   });
+
+  it('predefined imports take precedence over path aliases', () => {
+    const document = importSchema(
+      './fixtures/path-aliases/exact/a.graphql',
+      {
+        '@b-schema': `
+          type TypeB {
+            date: String!
+          }
+        `,
+      },
+      {
+        mappings: {
+          '@b-schema': path.join(__dirname, './fixtures/path-aliases/exact/b.graphql'),
+        },
+      },
+    );
+
+    expect(document).toBeSimilarGqlDoc(/* GraphQL */ `
+      type Query {
+        getA: TypeA
+      }
+
+      type TypeA {
+        id: ID!
+        relatedB: TypeB!
+      }
+
+      type TypeB {
+        date: String!
+      }
+    `);
+  });
 });


### PR DESCRIPTION
## Description

This change fixes a minor bug from #7310 that affects users of path aliases - a feature that lets GraphQL users leverage [tsconfig.json#paths](https://www.typescriptlang.org/tsconfig/#paths) aliasing syntax for GraphQL imports.

The issue stems from the original implementation's execution order. Path alias resolution happens inside `resolveFilePath`, which only runs for non-absolute paths:

```ts
  if (!isAbsolute(filePath) && !(filePath in predefinedImports)) {
    filePath = resolveFilePath(cwd, filePath, pathAliases);
  }
```

This means path aliases like `@/*` → `src/*` work correctly, but absolute path aliases like `/*` → `src/*` fail since they never reach the resolution logic.

The solution is straightforward: move path alias resolution before the absolute path check instead of after it.

Related #7311

## Risk

Low impact change that only affects path alias users (a recently released feature with limited adoption). Among those users, only absolute path aliases are broken - and workarounds exist. The fix maintains full backward compatibility and doesn't impact users without path aliases.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration

- [x] Added unit tests for absolute path aliases
- [x] Added unit tests for node.js-style subpath imports (this was not broken, but I didn't think absolute imports were broken either and given that this is a node.js builtin feature we should test for compatibility with it).
- [x] Added unit tests to ensure the status quo remains consistent that predefined imports take precedence over path aliases

To run the tests yourself: `npm test`

**Test Environment**:

- OS: OSX
- NodeJS: v22.14.0

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules