### PR TITLE
Add reference to addInterfaceFieldResolverTypes for inheritResolversFromInterfaces

### DIFF
--- a/website/src/content/generate-schema.mdx
+++ b/website/src/content/generate-schema.mdx
@@ -272,4 +272,8 @@ const jsSchema = makeExecutableSchema({
     a GraphQL entity within the schema. Defaults to `error`, to help catch common errors.
 
 - `inheritResolversFromInterfaces` GraphQL Objects that implement interfaces will inherit missing
-  resolvers from their interface types defined in the `resolvers` object.
+  resolvers from their interface types defined in the `resolvers` object. If this option is set to
+  `true` and you are using [GraphQL Code Generator](https://the-guild.dev/graphql/codegen), you can
+  enable
+  [addInterfaceFieldResolverTypes: true](https://the-guild.dev/graphql/codegen/plugins/typescript/typescript-resolvers#addinterfacefieldresolvertypes)
+  to ensure that the generated types correctly reflect this resolver inheritance behavior.


### PR DESCRIPTION
## Description

[@graphql-codegen/typescript-resolvers v5](https://github.com/dotansimha/graphql-code-generator/releases/tag/release-1757264511789) has a breaking change that no longer generates interface field resolvers. The default GraphQL behaviour is these resolvers are not called.

However, `makeExecutableSchema`'s `inheritResolversFromInterfaces: true` can change this behaviour. Therefore, I think it's important to link these two options together to help guide the users (the one from Codegen doc is already done [here](https://the-guild.dev/graphql/codegen/plugins/typescript/typescript-resolvers#addinterfacefieldresolvertypes))

## Type of change

- [x] This change requires a documentation update
