### PR TITLE
fix(utils): use `specifiedDirectives` directly to check if it is a native directive

### DIFF
--- a/.changeset/jolly-drinks-sip.md
+++ b/.changeset/jolly-drinks-sip.md
@@ -1,0 +1,20 @@
+---
+'@graphql-tools/utils': patch
+---
+
+Use `specifiedDirectives.some` instead of `isSpecifiedDirective` to check if the directive is a
+native directive
+
+In case of overriding a native directive like `@deprecated`, `isSpecifiedDirective` only checks the name like;
+
+```ts
+isSpecifiedDirective(directive) {
+  return specifiedDirectives.some(specifiedDirective => directive.name === specifiedDirective.name);
+}
+```
+
+But we need to check the actual reference equality to avoid rewiring native directives like below;
+
+```ts
+specifiedDirectives.some(specifiedDirective => directive === specifiedDirective)
+```

--- a/packages/schema/tests/reproductions.test.ts
+++ b/packages/schema/tests/reproductions.test.ts
@@ -1,0 +1,27 @@
+import { stripIgnoredCharacters } from 'graphql';
+import { printSchemaWithDirectives } from '@graphql-tools/utils';
+import { makeExecutableSchema } from '../src/makeExecutableSchema';
+
+test('works', () => {
+  const typeDefs = stripIgnoredCharacters(/* GraphQL */ `
+    schema {
+      query: Query
+    }
+
+    directive @deprecated(
+      owner: String!
+      expiry: Date!
+      reason: String!
+    ) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+    scalar Date
+
+    type Query {
+      myField: String! @deprecated(owner: "Test Squad", expiry: "2025-12-31", reason: "test")
+    }
+  `);
+  const schema = makeExecutableSchema({
+    typeDefs,
+  });
+  expect(stripIgnoredCharacters(printSchemaWithDirectives(schema))).toBe(typeDefs);
+});

--- a/packages/utils/src/mapSchema.ts
+++ b/packages/utils/src/mapSchema.ts
@@ -77,7 +77,6 @@ export function mapSchema(schema: GraphQLSchema, schemaMapper: SchemaMapper = {}
   const newDirectives = mapDirectives(originalDirectives, schema, schemaMapper);
 
   const { typeMap, directives } = rewireTypes(newTypeMap, newDirectives);
-
   return new GraphQLSchema({
     ...schema.toConfig(),
     query: getObjectTypeFromTypeMap(

--- a/packages/utils/src/print-schema-with-directives.ts
+++ b/packages/utils/src/print-schema-with-directives.ts
@@ -29,7 +29,6 @@ import {
   isIntrospectionType,
   isObjectType,
   isScalarType,
-  isSpecifiedDirective,
   isSpecifiedScalarType,
   isUnionType,
   Kind,
@@ -75,7 +74,7 @@ export function getDocumentNodeFromSchema(
 
   const directives = schema.getDirectives();
   for (const directive of directives) {
-    if (isSpecifiedDirective(directive)) {
+    if (specifiedDirectives.some(specifiedDirective => specifiedDirective === directive)) {
       continue;
     }
 

--- a/packages/utils/src/rewire.ts
+++ b/packages/utils/src/rewire.ts
@@ -21,9 +21,9 @@ import {
   isNonNullType,
   isObjectType,
   isScalarType,
-  isSpecifiedDirective,
   isSpecifiedScalarType,
   isUnionType,
+  specifiedDirectives,
 } from 'graphql';
 import { getBuiltInForStub, isNamedStub } from './stub.js';
 
@@ -74,7 +74,7 @@ export function rewireTypes(
   };
 
   function rewireDirective(directive: GraphQLDirective): GraphQLDirective {
-    if (isSpecifiedDirective(directive)) {
+    if (specifiedDirectives.some(specifiedDirective => specifiedDirective === directive)) {
       return directive;
     }
     const directiveConfig = directive.toConfig();


### PR DESCRIPTION
Workaround for a bug in the upstream graphql-js https://github.com/graphql/graphql-js/pull/4511

Use `specifiedDirectives.some` instead of `isSpecifiedDirective` to check if the directive is a
native directive

In case of overriding a native directive like `@deprecated`, `isSpecifiedDirective` only checks the name like;

```ts
isSpecifiedDirective(directive) {
  return specifiedDirectives.some(specifiedDirective => directive.name === specifiedDirective.name);
}
```

But we need to check the actual reference equality to avoid rewiring native directives like below;

```ts
specifiedDirectives.some(specifiedDirective => directive === specifiedDirective)
```