### PR TITLE
fix(utils): treat null as explicit value in mergeDeep, only skip undefined

### DIFF
--- a/.changeset/fix-merge-deep-null-handling.md
+++ b/.changeset/fix-merge-deep-null-handling.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/utils': patch
+---
+
+fix mergeDeep to treat null property values as explicit overrides rather than skipping them

--- a/packages/utils/src/mergeDeep.ts
+++ b/packages/utils/src/mergeDeep.ts
@@ -62,7 +62,7 @@ export function mergeDeep<S extends any[]>(
     }
   }
   for (const source of sources) {
-    if (source == null) {
+    if (source === undefined) {
       continue;
     }
     if (isObject(source)) {

--- a/packages/utils/tests/mergeDeep.test.ts
+++ b/packages/utils/tests/mergeDeep.test.ts
@@ -73,7 +73,7 @@ describe('mergeDeep', () => {
     expect(mergeDeep([a, b], undefined, true, true)).toEqual({ options: ['$A', '$B'] });
   });
 
-  it('filters nullish values', () => {
+  it('skips undefined sources', () => {
     expect(mergeDeep([{ a: 'dsa' }, { a: 'dd', b: 1 }, undefined])).toEqual({ a: 'dd', b: 1 });
   });
 

--- a/packages/utils/tests/mergeDeep.test.ts
+++ b/packages/utils/tests/mergeDeep.test.ts
@@ -77,6 +77,14 @@ describe('mergeDeep', () => {
     expect(mergeDeep([{ a: 'dsa' }, { a: 'dd', b: 1 }, undefined])).toEqual({ a: 'dd', b: 1 });
   });
 
+  it('overrides property value with null from later source', () => {
+    expect(mergeDeep([{ a: 'foo' }, { a: null }])).toEqual({ a: null });
+  });
+
+  it('overrides null property value with non-null from later source', () => {
+    expect(mergeDeep([{ a: null }, { a: 'foo' }])).toEqual({ a: 'foo' });
+  });
+
   it('respects empty objects', () => {
     expect(mergeDeep([{}])).toEqual({});
   });


### PR DESCRIPTION
## Summary

Fixes #8197

`mergeDeep([{ a: 'foo' }, { a: null }])` now correctly returns `{ a: null }` instead of `{ a: 'foo' }`.

### Root cause

The guard `if (source == null) { continue; }` uses loose equality (`==`), which skips both `null` and `undefined` sources. The intent was to skip `undefined` (meaning "not provided"), but `null` is an explicit value and should override earlier values.

### Fix

Change `source == null` to `source === undefined`. One-line change in `packages/utils/src/mergeDeep.ts`.

**Note on behavior change:** `mergeDeep([{a: 2}, null])` now returns `null` rather than `{a: 2}`. This is the correct semantic — `null` is an explicit "replace with nothing", distinct from `undefined` which means "no value provided".

## Tests

- Added two new regression tests in `packages/utils/tests/mergeDeep.test.ts`
- All 220 existing utils tests continue to pass

Generated with [Claude Code](https://claude.com/claude-code)