### PR TITLE
Fix `mergeDeep` returning `undefined` instead of `{}` when merging two or more empty objects.

### DIFF
--- a/.changeset/mergeDeep-empty-objects.md
+++ b/.changeset/mergeDeep-empty-objects.md
@@ -1,0 +1,11 @@
+---
+"@graphql-tools/utils": patch
+---
+
+Fix `mergeDeep` returning `undefined` instead of `{}` when merging two or more empty objects.
+
+Previously the output accumulator was only initialized inside the per-key loop, so merging
+sources with no own keys (e.g. `mergeDeep([{}, {}])`) left it `undefined`. This silently dropped
+empty-object values during nested merges (`{ data: {} }` became `{ data: undefined }`), which could
+surface as "Cannot return null for non-nullable field" errors when stitching schemas. The
+accumulator is now initialized as soon as an object source is encountered.

--- a/packages/utils/src/mergeDeep.ts
+++ b/packages/utils/src/mergeDeep.ts
@@ -66,6 +66,9 @@ export function mergeDeep<S extends any[]>(
       continue;
     }
     if (isObject(source)) {
+      if (output == null) {
+        output = {};
+      }
       if (firstObjectSource) {
         const outputPrototype = Object.getPrototypeOf(output);
         const sourcePrototype = Object.getPrototypeOf(source);
@@ -80,9 +83,6 @@ export function mergeDeep<S extends any[]>(
       }
 
       for (const key in source) {
-        if (output == null) {
-          output = {};
-        }
         if (key in output) {
           output[key] = mergeDeep(
             [output[key], source[key]],

--- a/packages/utils/tests/mergeDeep.test.ts
+++ b/packages/utils/tests/mergeDeep.test.ts
@@ -81,6 +81,14 @@ describe('mergeDeep', () => {
     expect(mergeDeep([{}])).toEqual({});
   });
 
+  it('respects multiple empty objects', () => {
+    expect(mergeDeep([{}, {}])).toEqual({});
+  });
+
+  it('preserves nested empty objects', () => {
+    expect(mergeDeep([{ data: {} }, { data: {} }])).toEqual({ data: {} });
+  });
+
   it('returns undefined when an empty sources array passed', () => {
     expect(mergeDeep([])).toEqual(undefined);
   });


### PR DESCRIPTION
## Edit by @enisdenjo 

Closes #8255

## Description

`mergeDeep` with empty objects incorrectly returned `undefined` instead of an empty object.

Related #8255

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tests inline.

## Checklist:

- [x] I have followed the
      [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the
      style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests and linter rules pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules