### PR TITLE
Add tests for directive arg with defaults

### DIFF
--- a/packages/utils/tests/mapSchema.directive-with-defaults.spec.ts
+++ b/packages/utils/tests/mapSchema.directive-with-defaults.spec.ts
@@ -29,7 +29,7 @@ function noopDirective({
 }
 
 describe('mapSchema - directives with defaults', () => {
-  it('handles Boolean with default correctly', async () => {
+  it('handles Boolean with default correctly', () => {
     const { typeDefs, transformer } = noopDirective({
       declaration: '@noop(arg: Boolean = true)',
       expectedDefault: true,
@@ -50,7 +50,7 @@ describe('mapSchema - directives with defaults', () => {
     transformer(schemaWithResolvers);
   });
 
-  it('handles String with default correctly', async () => {
+  it('handles String with default correctly', () => {
     const { typeDefs, transformer } = noopDirective({
       declaration: '@noop(arg: String = "DEFAULT")',
       expectedDefault: 'DEFAULT',
@@ -71,7 +71,7 @@ describe('mapSchema - directives with defaults', () => {
     transformer(schemaWithResolvers);
   });
 
-  it('handles Enum with default correctly', async () => {
+  it('handles Enum with default correctly', () => {
     const { typeDefs, transformer } = noopDirective({
       declaration: '@noop(arg: ALPHABET = D)',
       expectedDefault: 'D',
@@ -99,7 +99,7 @@ describe('mapSchema - directives with defaults', () => {
     transformer(schemaWithResolvers);
   });
 
-  it('handles Int with default correctly', async () => {
+  it('handles Int with default correctly', () => {
     const { typeDefs, transformer } = noopDirective({
       declaration: '@noop(arg: Int = 100)',
       expectedDefault: 100,
@@ -120,7 +120,7 @@ describe('mapSchema - directives with defaults', () => {
     transformer(schemaWithResolvers);
   });
 
-  it('handles Float with default correctly', async () => {
+  it('handles Float with default correctly', () => {
     const { typeDefs, transformer } = noopDirective({
       declaration: '@noop(arg: Float = 0.888)',
       expectedDefault: 0.888,
@@ -141,7 +141,7 @@ describe('mapSchema - directives with defaults', () => {
     transformer(schemaWithResolvers);
   });
 
-  it('handles null default correctly', async () => {
+  it('handles null default correctly', () => {
     const { typeDefs, transformer } = noopDirective({
       declaration: '@noop(arg: String = null)',
       expectedDefault: null,
@@ -162,7 +162,7 @@ describe('mapSchema - directives with defaults', () => {
     transformer(schemaWithResolvers);
   });
 
-  it('handles a list correctly', async () => {
+  it('handles a list correctly', () => {
     const { typeDefs, transformer } = noopDirective({
       declaration: '@noop(arg: [String!]! = ["A", "B"])',
       expectedDefault: ['A', 'B'],
@@ -183,7 +183,7 @@ describe('mapSchema - directives with defaults', () => {
     transformer(schemaWithResolvers);
   });
 
-  it('handles an object correctly', async () => {
+  it('handles an object correctly', () => {
     const { typeDefs, transformer } = noopDirective({
       declaration: '@noop(arg: Test = { a: "A", b: "B" })',
       expectedDefault: { a: 'A', b: 'B' },

--- a/packages/utils/tests/mapSchema.directive-with-defaults.spec.ts
+++ b/packages/utils/tests/mapSchema.directive-with-defaults.spec.ts
@@ -17,12 +17,8 @@ function noopDirective({
           const directive = getDirective(schema, fieldConfig, 'noop')?.[0];
           if (directive) {
             expect(directive).toEqual({ arg: expectedDefault });
-            const { resolve = defaultFieldResolver } = fieldConfig;
-            fieldConfig.resolve = async function (source, args, context, info) {
-              return await resolve(source, args, context, info);
-            };
-            return fieldConfig;
           }
+          return fieldConfig;
         },
       }),
   };

--- a/packages/utils/tests/mapSchema.directive-with-defaults.spec.ts
+++ b/packages/utils/tests/mapSchema.directive-with-defaults.spec.ts
@@ -1,0 +1,214 @@
+import { defaultFieldResolver, GraphQLSchema } from 'graphql';
+import { makeExecutableSchema } from '@graphql-tools/schema';
+import { getDirective, MapperKind, mapSchema } from '../src/index.js';
+
+function noopDirective({
+  declaration,
+  expectedDefault,
+}: {
+  declaration: string;
+  expectedDefault: unknown;
+}) {
+  return {
+    typeDefs: `directive ${declaration} on FIELD_DEFINITION`,
+    transformer: (schema: GraphQLSchema): GraphQLSchema =>
+      mapSchema(schema, {
+        [MapperKind.OBJECT_FIELD]: fieldConfig => {
+          const directive = getDirective(schema, fieldConfig, 'noop')?.[0];
+          if (directive) {
+            expect(directive).toEqual({ arg: expectedDefault });
+            const { resolve = defaultFieldResolver } = fieldConfig;
+            fieldConfig.resolve = async function (source, args, context, info) {
+              return await resolve(source, args, context, info);
+            };
+            return fieldConfig;
+          }
+        },
+      }),
+  };
+}
+
+describe('mapSchema - directives with defaults', () => {
+  it('handles Boolean with default correctly', async () => {
+    const { typeDefs, transformer } = noopDirective({
+      declaration: '@noop(arg: Boolean = true)',
+      expectedDefault: true,
+    });
+
+    const schemaWithResolvers = makeExecutableSchema({
+      typeDefs: [
+        typeDefs,
+        /* GraphQL */ `
+          type Query {
+            hello: String @noop
+          }
+        `,
+      ],
+      resolvers: { Query: { hello: () => 'hello world' } },
+    });
+
+    transformer(schemaWithResolvers);
+  });
+
+  it('handles String with default correctly', async () => {
+    const { typeDefs, transformer } = noopDirective({
+      declaration: '@noop(arg: String = "DEFAULT")',
+      expectedDefault: 'DEFAULT',
+    });
+
+    const schemaWithResolvers = makeExecutableSchema({
+      typeDefs: [
+        typeDefs,
+        /* GraphQL */ `
+          type Query {
+            hello: String @noop
+          }
+        `,
+      ],
+      resolvers: { Query: { hello: () => 'hello world' } },
+    });
+
+    transformer(schemaWithResolvers);
+  });
+
+  it('handles Enum with default correctly', async () => {
+    const { typeDefs, transformer } = noopDirective({
+      declaration: '@noop(arg: ALPHABET = D)',
+      expectedDefault: 'D',
+    });
+
+    const schemaWithResolvers = makeExecutableSchema({
+      typeDefs: [
+        typeDefs,
+        /* GraphQL */ `
+          type Query {
+            hello: String @noop
+          }
+
+          enum ALPHABET {
+            A
+            B
+            C
+            D
+          }
+        `,
+      ],
+      resolvers: { Query: { hello: () => 'hello world' } },
+    });
+
+    transformer(schemaWithResolvers);
+  });
+
+  it('handles Int with default correctly', async () => {
+    const { typeDefs, transformer } = noopDirective({
+      declaration: '@noop(arg: Int = 100)',
+      expectedDefault: 100,
+    });
+
+    const schemaWithResolvers = makeExecutableSchema({
+      typeDefs: [
+        typeDefs,
+        /* GraphQL */ `
+          type Query {
+            hello: String @noop
+          }
+        `,
+      ],
+      resolvers: { Query: { hello: () => 'hello world' } },
+    });
+
+    transformer(schemaWithResolvers);
+  });
+
+  it('handles Float with default correctly', async () => {
+    const { typeDefs, transformer } = noopDirective({
+      declaration: '@noop(arg: Float = 0.888)',
+      expectedDefault: 0.888,
+    });
+
+    const schemaWithResolvers = makeExecutableSchema({
+      typeDefs: [
+        typeDefs,
+        /* GraphQL */ `
+          type Query {
+            hello: String @noop
+          }
+        `,
+      ],
+      resolvers: { Query: { hello: () => 'hello world' } },
+    });
+
+    transformer(schemaWithResolvers);
+  });
+
+  it('handles null default correctly', async () => {
+    const { typeDefs, transformer } = noopDirective({
+      declaration: '@noop(arg: String = null)',
+      expectedDefault: null,
+    });
+
+    const schemaWithResolvers = makeExecutableSchema({
+      typeDefs: [
+        typeDefs,
+        /* GraphQL */ `
+          type Query {
+            hello: String @noop
+          }
+        `,
+      ],
+      resolvers: { Query: { hello: () => 'hello world' } },
+    });
+
+    transformer(schemaWithResolvers);
+  });
+
+  it('handles a list correctly', async () => {
+    const { typeDefs, transformer } = noopDirective({
+      declaration: '@noop(arg: [String!]! = ["A", "B"])',
+      expectedDefault: ['A', 'B'],
+    });
+
+    const schemaWithResolvers = makeExecutableSchema({
+      typeDefs: [
+        typeDefs,
+        /* GraphQL */ `
+          type Query {
+            hello: String @noop
+          }
+        `,
+      ],
+      resolvers: { Query: { hello: () => 'hello world' } },
+    });
+
+    transformer(schemaWithResolvers);
+  });
+
+  it('handles an object correctly', async () => {
+    const { typeDefs, transformer } = noopDirective({
+      declaration: '@noop(arg: Test = { a: "A", b: "B" })',
+      expectedDefault: { a: 'A', b: 'B' },
+    });
+
+    const schemaWithResolvers = makeExecutableSchema({
+      typeDefs: [
+        typeDefs,
+        /* GraphQL */ `
+          type Query {
+            hello: String @noop
+          }
+          input Test {
+            a: String
+            b: String
+          }
+        `,
+      ],
+      resolvers: {
+        Query: {
+          hello: () => 'hello world',
+        },
+      },
+    });
+
+    transformer(schemaWithResolvers);
+  });
+});

--- a/packages/utils/tests/mapSchema.directive-with-defaults.spec.ts
+++ b/packages/utils/tests/mapSchema.directive-with-defaults.spec.ts
@@ -1,4 +1,4 @@
-import { defaultFieldResolver, GraphQLSchema } from 'graphql';
+import { GraphQLSchema } from 'graphql';
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { getDirective, MapperKind, mapSchema } from '../src/index.js';
 
@@ -15,9 +15,7 @@ function noopDirective({
       mapSchema(schema, {
         [MapperKind.OBJECT_FIELD]: fieldConfig => {
           const directive = getDirective(schema, fieldConfig, 'noop')?.[0];
-          if (directive) {
-            expect(directive).toEqual({ arg: expectedDefault });
-          }
+          expect(directive).toEqual({ arg: expectedDefault });
           return fieldConfig;
         },
       }),


### PR DESCRIPTION
## Description

This PR adds baseline tests for default value when args are used in directives.
GraphQL 17 changes how `defaultValue` are handled: they are no longer coerced by default.
This will help guide the implementation 

Related https://github.com/ardatan/graphql-tools/pull/8226/

## Type of change

- [ ] Add baseline test

## How Has This Been Tested?

- [x] Unit test

