### PR TITLE
perf(import): memoize print() in processImport (O(n²) → O(n) on large schemas)

### DIFF
--- a/.changeset/import-memoize-print.md
+++ b/.changeset/import-memoize-print.md
@@ -1,0 +1,17 @@
+---
+'@graphql-tools/import': patch
+---
+
+perf(import): memoize `print` per node when assembling imported definitions
+
+`processImport` de-duplicates the collected definitions by printing each one to
+SDL and comparing the strings. A single definition node appears in many of the
+dependency sets (any widely-referenced type is pulled in by every definition
+that depends on it), so `print` was called roughly O(n²) times for n unique
+nodes. For large, densely-connected schemas this print/visit work dominates
+import time.
+
+Memoizing `print` by node identity makes each unique node print at most once.
+`print` is a pure function of its node, so the output is identical; this is a
+pure performance change. On a ~12k-line schema imported across three projects,
+this reduced a downstream codegen pass from ~133s to ~17s.

--- a/packages/import/src/index.ts
+++ b/packages/import/src/index.ts
@@ -149,9 +149,20 @@ export function processImport(
   );
   const definitionStrSet = new Set<string>();
   let definitionsStr = '';
+  // A single definition node can appear in many of the dependency sets in
+  // `set` — any widely-referenced type is pulled in by every definition that
+  // depends on it — so without memoization `print` runs O(n²) times for n
+  // unique nodes. Printing is the dominant cost for large, densely-connected
+  // schemas, so cache the result per node identity. `print` is a pure function
+  // of its node, so this is output-identical.
+  const printCache = new Map<DefinitionNode, string>();
   for (const defs of set.values()) {
     for (const def of defs) {
-      const defStr = print(def);
+      let defStr = printCache.get(def);
+      if (defStr === undefined) {
+        defStr = print(def);
+        printCache.set(def, defStr);
+      }
       if (!definitionStrSet.has(defStr)) {
         definitionStrSet.add(defStr);
         definitionsStr += defStr + '\n';


### PR DESCRIPTION
## Problem

`processImport` de-duplicates the collected definitions by printing each one to SDL and comparing the strings:

```ts
for (const defs of set.values()) {
  for (const def of defs) {
    const defStr = print(def);          // <-- here
    if (!definitionStrSet.has(defStr)) { ... }
  }
}
```

A single definition node appears in **many** of the dependency sets in `set` — any widely-referenced type (a root `Query`, a shared `Node`/`User`, etc.) is pulled into the dependency set of every definition that depends on it. So `print()` is called roughly **O(n²)** times for `n` unique nodes.

Because `print(ast)` in graphql-js is implemented as `visit(ast, printDocASTReducer)`, this is a full AST walk each time, and on large, densely-connected schemas it dominates import time.

## Profile (real-world schema)

A downstream codegen pass over a ~12,000-line schema imported across three projects spent **~133s**, of which CPU profiling attributed **~63% to graphql-js `visit` + ~13% to `print`** — i.e. almost all of it to this one `print(def)` line. The tool's own type generation was ~0%.

## Fix

Memoize `print` by node identity, so each unique node is printed at most once:

```ts
const printCache = new Map<DefinitionNode, string>();
for (const defs of set.values()) {
  for (const def of defs) {
    let defStr = printCache.get(def);
    if (defStr === undefined) {
      defStr = print(def);
      printCache.set(def, defStr);
    }
    if (!definitionStrSet.has(defStr)) { ... }
  }
}
```

`print` is a pure function of its node, so the de-duplication is byte-for-byte identical — this is a pure performance change.

## Result

- Same real-world codegen pass: **~133s → ~17s** (~7.6×). (The remainder is a separate O(n²) in the per-definition dependency-closure construction; I'll open a follow-up.)
- **All 80 existing `@graphql-tools/import` tests pass** unchanged.

## Notes

- No public API change; `patch` changeset included.
- The same node objects are shared across dependency sets (they reference the parsed AST), so `Map` identity keys are exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)