### PR TITLE
perf(import): remove redundant work in addDefinition's dependency traversal

### DIFF
--- a/.changeset/import-closure-traversal.md
+++ b/.changeset/import-closure-traversal.md
@@ -1,0 +1,24 @@
+---
+'@graphql-tools/import': patch
+---
+
+perf(import): remove redundant work in `addDefinition`'s dependency traversal
+
+`addDefinition` recurses across the whole dependency graph while assembling each
+definition's imported dependencies. Two things were repeated on every call:
+
+- `visitedFiles.get(filePath)` — invariant for the duration of the
+  `processImport` call, so it's now looked up once and hoisted out of the
+  recursion.
+- the per-field dependency-name derivation (`visitFieldDefinitionNode` /
+  `visitInputValueDefinitionNode` into a fresh `Map`) — a pure function of the
+  field node and the file's static dependency map, so it's now memoized by field
+  identity instead of recomputed every time the owning definition is added to a
+  set.
+
+Pure performance change; output is unchanged (the existing import tests pass and
+a real-world ~12k-line schema produces byte-identical results). Building on the
+`print` memoization, this took the same codegen pass from ~17s to ~13s. The
+remaining cost is the O(n²) shape of the closure traversal itself (each
+definition's transitive set is still rebuilt independently); reducing that is
+left for a follow-up as it's a more invasive change.

--- a/packages/import/src/index.ts
+++ b/packages/import/src/index.ts
@@ -167,6 +167,16 @@ export function processImport(
       };
 }
 
+/**
+ * Resolves a single GraphQL file and returns a map from each definition name to
+ * the set of definitions that make it up, including everything pulled in
+ * transitively through the file's `#import` statements.
+ *
+ * Results are memoized in `visitedFiles`, keyed by the resolved absolute path.
+ * This both avoids re-processing files shared by multiple imports and breaks
+ * circular imports (a file is recorded in `visitedFiles` before its own imports
+ * are followed).
+ */
 function visitFile(
   filePath: string,
   cwd: string,
@@ -203,12 +213,29 @@ function visitFile(
       pathAliases,
     );
 
+    // `visitedFiles.get(filePath)` is invariant for the duration of this call,
+    // and `addDefinition` recurses across the entire dependency graph, so hoist
+    // the lookup out of the hot path instead of repeating it on every call.
+    const hoistedFileDefinitionMap = visitedFiles.get(filePath);
+    // A field's dependency set is a pure function of the field node (and the
+    // file's static `dependenciesByDefinitionName`), but it was re-derived every
+    // time the owning definition was added to a set. Cache it by field identity.
+    const fieldDependencyCache = new Map<
+      FieldDefinitionNode | InputValueDefinitionNode,
+      Map<string, Set<NameNode>>
+    >();
+    /**
+     * Adds `definition` and everything it transitively depends on — referenced
+     * types, imported documents, and per-field dependencies — into
+     * `definitionSet`. Definitions already present in the set are skipped, which
+     * both dedupes shared dependencies and terminates the traversal on cycles.
+     */
     const addDefinition = (
       definition: DefinitionNode,
       definitionName: string,
       definitionSet: Set<DefinitionNode>,
     ) => {
-      const fileDefinitionMap = visitedFiles.get(filePath);
+      const fileDefinitionMap = hoistedFileDefinitionMap;
       if (fileDefinitionMap && !definitionSet.has(definition)) {
         definitionSet.add(definition);
 
@@ -238,18 +265,22 @@ function visitFile(
                 addDefinition(importedDefinition, fieldDefinitionName, definitionsWithDeps);
               }
             });
-            const newDependencySet = new Map<string, Set<NameNode>>();
-            switch (field.kind) {
-              case Kind.FIELD_DEFINITION:
-                visitFieldDefinitionNode(field, newDependencySet, dependenciesByDefinitionName);
-                break;
-              case Kind.INPUT_VALUE_DEFINITION:
-                visitInputValueDefinitionNode(
-                  field,
-                  newDependencySet,
-                  dependenciesByDefinitionName,
-                );
-                break;
+            let newDependencySet = fieldDependencyCache.get(field);
+            if (newDependencySet === undefined) {
+              newDependencySet = new Map<string, Set<NameNode>>();
+              switch (field.kind) {
+                case Kind.FIELD_DEFINITION:
+                  visitFieldDefinitionNode(field, newDependencySet, dependenciesByDefinitionName);
+                  break;
+                case Kind.INPUT_VALUE_DEFINITION:
+                  visitInputValueDefinitionNode(
+                    field,
+                    newDependencySet,
+                    dependenciesByDefinitionName,
+                  );
+                  break;
+              }
+              fieldDependencyCache.set(field, newDependencySet);
             }
             Array.from(newDependencySet.keys()).forEach(dependencyName => {
               const definitionsInCurrentFile = fileDefinitionMap.get(dependencyName);


### PR DESCRIPTION
## Problem

When `processImport` assembles a definition's imported dependencies, the inner `addDefinition` closure recurses across the entire dependency graph. Two things were recomputed on **every** recursive call:

1. `const fileDefinitionMap = visitedFiles.get(filePath)` — `filePath` is invariant for the lifetime of the `visitFile` call, so this `Map.get` (over a long absolute-path key) was repeated across the whole — potentially very large — recursion.
2. The per-field dependency-name derivation — for every field of every definition added to a set, a fresh `Map` was built and the field re-visited (`visitFieldDefinitionNode` / `visitInputValueDefinitionNode`) to collect dependency names. That result is a pure function of the field node and the file's static `dependenciesByDefinitionName`, but it was recomputed every time the owning definition was added to *any* set.

On a large, densely-connected schema these two lines dominate what remains of import time after the `print` memoization in #8258 (CPU profiling attributed ~85% of the post-#8258 time to `addDefinition` and its field loop).

## Fix

- Hoist the invariant `visitedFiles.get(filePath)` lookup out of `addDefinition`.
- Memoize the per-field dependency-name list by field-node identity.

Both are pure performance changes — no algorithmic/output change.

## Validation

- **All 80 existing `@graphql-tools/import` tests pass.**
- On a real-world ~12k-line schema imported across three projects, the generated output is **byte-for-byte identical** before/after.
- Combined with #8258 (`print` memoization), the same downstream codegen pass went from **~133s → ~13s**. This PR contributes the ~17s → ~13s step on top of #8258. (It composes with #8258 but is independent — they touch different functions.)

## Not addressed here

The deeper cost is structural: each definition's transitive closure is still rebuilt independently (an O(n²) traversal). Reducing that needs a shared closure cache and is more invasive, so I've left it out of this PR to keep it small and obviously-safe. Happy to follow up if there's interest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)