### PR TITLE
[graphql-tools/merge] graphql 17 compatibility

### DIFF
--- a/.changeset/upset-spiders-scream.md
+++ b/.changeset/upset-spiders-scream.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/merge': minor
+---
+
+Support graphql@17

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -157,7 +157,7 @@ jobs:
         with:
           timeout_minutes: 10
           max_attempts: 5
-          command: npm run test --ci -- packages/\(utils|merge\) # TODO: add more packages once compatible
+          command: npm run test --ci -- "packages/(utils|merge)" # TODO: add more packages once compatible
 
   test-bun:
     name: Unit Test on Bun

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -157,7 +157,7 @@ jobs:
         with:
           timeout_minutes: 10
           max_attempts: 5
-          command: npm run test --ci -- packages/utils # TODO: add more packages once compatible
+          command: npm run test --ci -- packages/\(utils|merge\) # TODO: add more packages once compatible
 
   test-bun:
     name: Unit Test on Bun

--- a/packages/merge/src/typedefs-mergers/merge-typedefs.ts
+++ b/packages/merge/src/typedefs-mergers/merge-typedefs.ts
@@ -268,7 +268,7 @@ export function mergeGraphQLTypes(typeSource: TypeSource, config: Config): Defin
       kind: Kind.SCHEMA_DEFINITION,
       operationTypes: [],
     };
-    const operationTypes = schemaDef.operationTypes as OperationTypeDefinitionNode[];
+    const operationTypes = (schemaDef.operationTypes as OperationTypeDefinitionNode[]) || [];
     for (const opTypeDefNodeType in DEFAULT_OPERATION_TYPE_NAME_MAP) {
       const opTypeDefNode = operationTypes.find(
         operationType => operationType.operation === opTypeDefNodeType,


### PR DESCRIPTION
## Description

`graphql@17` has [made operationTypes (along with a few others) optional](https://www.graphql-js.org/upgrade-guides/v16-v17/#ast-constants-and-visitors). 

This PR coerces optional value to be an empty array (similar to how we do it if schemaDef doesn't exist)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
