### PR TITLE
fix(utils): treat explicit undefined as an override in mergeDeep

### DIFF
--- a/.changeset/fix-merge-deep-undefined-handling.md
+++ b/.changeset/fix-merge-deep-undefined-handling.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/utils': patch
+---
+
+fix mergeDeep to treat explicit undefined property values as overrides rather than skipping them, distinct from an absent property

--- a/packages/utils/src/mergeDeep.ts
+++ b/packages/utils/src/mergeDeep.ts
@@ -83,7 +83,12 @@ export function mergeDeep<S extends any[]>(
       }
 
       for (const key in source) {
-        if (key in output) {
+        // An own key present with value `undefined` is an explicit override and must win,
+        // distinct from the key being altogether absent from `source`. Assigning directly
+        // (rather than recursing through mergeDeep) avoids the top-level `source === undefined`
+        // skip above, which would otherwise silently discard this override and keep the prior
+        // value.
+        if (key in output && source[key] !== undefined) {
           output[key] = mergeDeep(
             [output[key], source[key]],
             respectPrototype,

--- a/packages/utils/tests/mergeDeep.test.ts
+++ b/packages/utils/tests/mergeDeep.test.ts
@@ -85,6 +85,19 @@ describe('mergeDeep', () => {
     expect(mergeDeep([{ a: null }, { a: 'foo' }])).toEqual({ a: 'foo' });
   });
 
+  it('overrides property value with an explicit undefined from later source', () => {
+    const merged = mergeDeep([{ a: 'foo', b: 'bar' }, { a: undefined }]);
+    expect('a' in merged).toBe(true);
+    expect(merged.a).toBeUndefined();
+    expect(merged.b).toEqual('bar');
+  });
+
+  it('leaves a property untouched when a later source omits it, distinct from an explicit undefined', () => {
+    const merged = mergeDeep([{ a: 'foo', b: 'bar' }, { b: 'baz' }]);
+    expect(merged.a).toEqual('foo');
+    expect(merged.b).toEqual('baz');
+  });
+
   it('respects empty objects', () => {
     expect(mergeDeep([{}])).toEqual({});
   });


### PR DESCRIPTION
### Summary

Follow-up to #8204, which made `mergeDeep` treat an explicit `null` property value as an override rather than skipping it. This does the same for an explicit `undefined` property value, while keeping it distinct from the property being absent entirely.

Before this change, `mergeDeep([{ a: 'foo' }, { a: undefined }])` returned `{ a: 'foo' }` — the explicit `undefined` had no effect, indistinguishable from `mergeDeep([{ a: 'foo' }, {}])`. This is surprising for consumers (e.g. test mock builders) that rely on `undefined` to explicitly clear/override a field.

### Details

The by-key merge loop recursed into `mergeDeep([output[key], source[key]])` for every key present on `source`, including ones whose value was explicitly `undefined`. That recursive call re-triggered the top-level `if (source === undefined) continue`, silently discarding the override and keeping the prior value — the same skip that intentionally lets a whole `undefined` *source* in the top-level `sources` array be ignored (e.g. `mergeDeep([defaults, options])` where `options` wasn't provided).

The fix only recurses when the incoming value isn't `undefined`; an explicit `undefined` is assigned directly. This keeps the "whole source is `undefined`" skip (still exercised by the existing `'skips undefined sources'` test) fully intact, while making an explicitly-present-but-`undefined` key override like `null` does. A key that's absent from `source` is never visited by `for...in`, so it's naturally left untouched — distinct from the explicit-`undefined` case, per the added tests.

### Tests

- Added a failing-first unit test asserting an explicit `undefined` property value overrides a previously merged value (`'a' in merged` is `true` and `merged.a` is `undefined`).
- Added a companion test asserting a merely-absent property is left untouched, to make the "distinct from absence" contract explicit.
- Ran the full `utils` and `merge` package test suites (353 tests) — all passing.