### PR TITLE
fix: optimize descriptions, isValidPath %, and mock resolverValidationOptions

### DIFF
--- a/.changeset/@graphql-tools_documents-8364-dependencies.md
+++ b/.changeset/@graphql-tools_documents-8364-dependencies.md
@@ -1,5 +1,0 @@
----
-"@graphql-tools/documents": patch
----
-dependencies updates:
-  - Removed dependency [`lodash.sortby@^4.7.0` ↗︎](https://www.npmjs.com/package/lodash.sortby/v/4.7.0) (from `dependencies`)

--- a/.changeset/mock-resolver-validation-options.md
+++ b/.changeset/mock-resolver-validation-options.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/mock': patch
+---
+
+Pass `resolverValidationOptions` through from `addMocksToSchema` to `addResolversToSchema`.

--- a/.changeset/optimize-remove-descriptions-executable.md
+++ b/.changeset/optimize-remove-descriptions-executable.md
@@ -2,4 +2,4 @@
 '@graphql-tools/optimize': patch
 ---
 
-Remove descriptions from operation, variable, and fragment definitions in `removeDescriptions`.
+Remove descriptions from operation, variable, fragment, schema definition, and schema extension nodes in `removeDescriptions`.

--- a/.changeset/optimize-remove-descriptions-executable.md
+++ b/.changeset/optimize-remove-descriptions-executable.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/optimize': patch
+---
+
+Remove descriptions from operation, variable, and fragment definitions in `removeDescriptions`.

--- a/.changeset/utils-isvalidpath-percent.md
+++ b/.changeset/utils-isvalidpath-percent.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/utils': patch
+---
+
+Allow `%` in paths checked by `isValidPath` (e.g. directories from URL-encoded repo names).

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,13 +79,12 @@ jobs:
         run: npx bob check
   test:
     name:
-      ${{matrix.name}} Test on Node ${{matrix.node-version}} (${{matrix.os}}) and GraphQL
+      Test on Node ${{matrix.node-version}} (${{matrix.os}}) and GraphQL
       v${{matrix.graphql_version}}
     runs-on: ${{matrix.os}}
     strategy:
       fail-fast: false
       matrix:
-        name: [Unit, Leak]
         os: [windows-latest, ubuntu-latest] # remove windows to speed up the tests
         node-version: [18, 22, 24]
         graphql_version:
@@ -128,12 +127,19 @@ jobs:
             ${{ runner.os }}-${{matrix.node-version}}-${{matrix.graphql_version}}-jest-
       - name: Build
         run: npm run build
-      - name: ${{matrix.name}} Tests
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
-        with:
-          timeout_minutes: 10
-          max_attempts: 5
-          command: npm run ${{matrix.name == 'Leak' && 'test:leaks' || 'test'}} --ci
+      - parallel:
+          - name: Unit Tests
+            uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+            with:
+              timeout_minutes: 10
+              max_attempts: 5
+              command: npm run test --ci
+          - name: Leak Tests
+            uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+            with:
+              timeout_minutes: 10
+              max_attempts: 5
+              command: npm run test:leaks --ci
 
   test-bun:
     name: Unit Test on Bun

--- a/packages/documents/src/sort-executable-nodes.ts
+++ b/packages/documents/src/sort-executable-nodes.ts
@@ -76,13 +76,25 @@ export function sortExecutableNodes(
     }
 
     return cacheResult(
-      [...nodes].sort((a, b) => {
-        const kindComparison = compareKeys(a.kind, b.kind);
-        if (kindComparison !== 0) {
-          return kindComparison;
-        }
-        return compareKeys(getNodeNameValue(a), getNodeNameValue(b));
-      }),
+      nodes
+        .map((node, index) => ({
+          node,
+          index,
+          kind: node.kind,
+          name: getNodeNameValue(node),
+        }))
+        .sort((a, b) => {
+          const kindComparison = compareKeys(a.kind, b.kind);
+          if (kindComparison !== 0) {
+            return kindComparison;
+          }
+          const nameComparison = compareKeys(a.name, b.name);
+          if (nameComparison !== 0) {
+            return nameComparison;
+          }
+          return a.index - b.index;
+        })
+        .map(item => item.node),
     );
   }
 }
@@ -106,7 +118,16 @@ function sortNodesByStringKey<TNode extends ASTNode>(
   nodes: readonly TNode[],
   getKey: (node: TNode) => string | undefined,
 ): readonly TNode[] {
-  return [...nodes].sort((a, b) => compareKeys(getKey(a), getKey(b)));
+  return nodes
+    .map((node, index) => ({ node, index, key: getKey(node) }))
+    .sort((a, b) => {
+      const keyComparison = compareKeys(a.key, b.key);
+      if (keyComparison !== 0) {
+        return keyComparison;
+      }
+      return a.index - b.index;
+    })
+    .map(item => item.node);
 }
 
 function compareKeys(a: string | undefined, b: string | undefined): number {

--- a/packages/mock/src/addMocksToSchema.ts
+++ b/packages/mock/src/addMocksToSchema.ts
@@ -9,7 +9,12 @@ import {
   isUnionType,
 } from 'graphql';
 import { addResolversToSchema } from '@graphql-tools/schema';
-import { IResolvers, MapperKind, mapSchema } from '@graphql-tools/utils';
+import {
+  IResolvers,
+  IResolverValidationOptions,
+  MapperKind,
+  mapSchema,
+} from '@graphql-tools/utils';
 import { createMockStore } from './MockStore.js';
 import { IMocks, IMockStore, isRef, MockGenerationBehavior, TypePolicy } from './types.js';
 import { copyOwnProps, isObject, isRootType } from './utils.js';
@@ -29,6 +34,11 @@ type IMockOptions<TResolvers = IResolvers> = {
    * server and not others.
    */
   preserveResolvers?: boolean;
+  /**
+   * Additional options for validating the provided resolvers.
+   * Passed through to `addResolversToSchema`.
+   */
+  resolverValidationOptions?: IResolverValidationOptions;
 };
 
 // todo: add option to preserve resolver
@@ -98,6 +108,7 @@ export function addMocksToSchema<TResolvers = IResolvers>({
   typePolicies,
   resolvers: resolversOrFnResolvers,
   preserveResolvers = false,
+  resolverValidationOptions,
 }: IMockOptions<TResolvers>): GraphQLSchema {
   if (!schema) {
     throw new Error('Must provide schema to mock');
@@ -258,6 +269,7 @@ export function addMocksToSchema<TResolvers = IResolvers>({
         resolvers: resolvers as any,
         // This option ensures that schemas are not cloned multiple times, which can be very expensive
         updateResolversInPlace: true,
+        resolverValidationOptions,
       })
     : schemaWithMocks;
 }

--- a/packages/mock/tests/addMocksToSchema.spec.ts
+++ b/packages/mock/tests/addMocksToSchema.spec.ts
@@ -491,6 +491,33 @@ describe('addMocksToSchema', () => {
     expect(viewer.name).toEqual('custom mock for String');
   });
 
+  it('passes resolverValidationOptions through to addResolversToSchema', () => {
+    expect(() =>
+      addMocksToSchema({
+        schema,
+        resolvers: {
+          Query: {
+            doesNotExist: () => null,
+          },
+        },
+      }),
+    ).toThrow(/defined in resolvers, but not in schema/);
+
+    expect(() =>
+      addMocksToSchema({
+        schema,
+        resolvers: {
+          Query: {
+            doesNotExist: () => null,
+          },
+        },
+        resolverValidationOptions: {
+          requireResolversToMatchSchema: 'ignore',
+        },
+      }),
+    ).not.toThrow();
+  });
+
   it('creates a new schema whether or not resolvers are passed in', () => {
     expect(
       Object.is(

--- a/packages/optimize/src/optimizers/remove-description.ts
+++ b/packages/optimize/src/optimizers/remove-description.ts
@@ -2,7 +2,7 @@ import { visit } from 'graphql';
 import { DocumentOptimizer } from '../types.js';
 
 /**
- * This optimizer removes "description" field from schema AST definitions.
+ * This optimizer removes "description" fields from schema and executable AST nodes.
  * @param input
  */
 export const removeDescriptions: DocumentOptimizer = input => {
@@ -25,5 +25,10 @@ export const removeDescriptions: DocumentOptimizer = input => {
     InputValueDefinition: transformNode,
     FieldDefinition: transformNode,
     DirectiveDefinition: transformNode,
+    OperationDefinition: transformNode,
+    VariableDefinition: transformNode,
+    FragmentDefinition: transformNode,
+    SchemaDefinition: transformNode,
+    SchemaExtension: transformNode,
   });
 };

--- a/packages/optimize/src/optimizers/remove-description.ts
+++ b/packages/optimize/src/optimizers/remove-description.ts
@@ -7,11 +7,12 @@ import { DocumentOptimizer } from '../types.js';
  */
 export const removeDescriptions: DocumentOptimizer = input => {
   function transformNode(node: any) {
-    if (node.description) {
-      node.description = undefined;
+    if (!node.description) {
+      return node;
     }
 
-    return node;
+    const { description, ...rest } = node;
+    return rest;
   }
 
   return visit(input, {

--- a/packages/optimize/tests/remove-description.spec.ts
+++ b/packages/optimize/tests/remove-description.spec.ts
@@ -108,31 +108,43 @@ scalar TestScalar
   });
 
   it('should remove descriptions from operations, variables, and fragments', () => {
+    // Attach description nodes manually so the fixture works on GraphQL versions
+    // that cannot parse executable descriptions in SDL (e.g. graphql@15).
     const doc = parse(/* GraphQL */ `
-      """
-      OPERATION DESCRIPTION
-      """
-      query user(
-        """
-        VARIABLE DESCRIPTION
-        """
-        $id: ID!
-      ) {
+      query user($id: ID!) {
         user(id: $id) {
           ...userFields
         }
       }
 
-      """
-      FRAGMENT DESCRIPTION
-      """
       fragment userFields on User {
         id
         username
       }
     `);
 
+    const operation = doc.definitions[0] as any;
+    const fragment = doc.definitions[1] as any;
+    operation.description = {
+      kind: 'StringValue',
+      value: 'OPERATION DESCRIPTION',
+      block: true,
+    };
+    operation.variableDefinitions[0].description = {
+      kind: 'StringValue',
+      value: 'VARIABLE DESCRIPTION',
+      block: true,
+    };
+    fragment.description = {
+      kind: 'StringValue',
+      value: 'FRAGMENT DESCRIPTION',
+      block: true,
+    };
+
     const out = removeDescriptions(doc);
+    expect((out.definitions[0] as any).description).toBeUndefined();
+    expect((out.definitions[0] as any).variableDefinitions[0].description).toBeUndefined();
+    expect((out.definitions[1] as any).description).toBeUndefined();
     expect(print(out).trim()).toBe(
       /* GraphQL */ `
 query user($id: ID!) {

--- a/packages/optimize/tests/remove-description.spec.ts
+++ b/packages/optimize/tests/remove-description.spec.ts
@@ -106,4 +106,46 @@ scalar TestScalar
     `.trim(),
     );
   });
+
+  it('should remove descriptions from operations, variables, and fragments', () => {
+    const doc = parse(/* GraphQL */ `
+      """
+      OPERATION DESCRIPTION
+      """
+      query user(
+        """
+        VARIABLE DESCRIPTION
+        """
+        $id: ID!
+      ) {
+        user(id: $id) {
+          ...userFields
+        }
+      }
+
+      """
+      FRAGMENT DESCRIPTION
+      """
+      fragment userFields on User {
+        id
+        username
+      }
+    `);
+
+    const out = removeDescriptions(doc);
+    expect(print(out).trim()).toBe(
+      /* GraphQL */ `
+query user($id: ID!) {
+  user(id: $id) {
+    ...userFields
+  }
+}
+
+fragment userFields on User {
+  id
+  username
+}
+    `.trim(),
+    );
+  });
 });

--- a/packages/utils/src/helpers.ts
+++ b/packages/utils/src/helpers.ts
@@ -78,7 +78,7 @@ export function isDocumentString(str: any): boolean {
   return false;
 }
 
-const invalidPathRegex = /[‘“!%^<>`\n]/;
+const invalidPathRegex = /[‘“!^<>`\n]/;
 /**
  * Checkes whether the `str` contains any path illegal characters.
  *

--- a/packages/utils/src/helpers.ts
+++ b/packages/utils/src/helpers.ts
@@ -80,7 +80,7 @@ export function isDocumentString(str: any): boolean {
 
 const invalidPathRegex = /[‘“!^<>`\n]/;
 /**
- * Checkes whether the `str` contains any path illegal characters.
+ * Checks whether the `str` contains any path illegal characters.
  *
  * A string may sometimes look like a path but is not (like an SDL of a simple
  * GraphQL schema). To make sure we don't yield false-positives in such cases,

--- a/packages/utils/tests/helpers.test.ts
+++ b/packages/utils/tests/helpers.test.ts
@@ -24,12 +24,17 @@ describe('helpers', () => {
     expect(isValidPath(str)).toBeFalsy();
   });
 
-  it.each(['file', 'file.tsx', 'some/where/file.tsx', '/some/where/file.tsx'])(
-    'should detect "%s" as a valid path',
-    str => {
-      expect(isValidPath(str)).toBeTruthy();
-    },
-  );
+  it.each([
+    'file',
+    'file.tsx',
+    'some/where/file.tsx',
+    '/some/where/file.tsx',
+    'Repo%20Name/src/App.tsx',
+    'C:/dev/Repo%20Name/project/src/App.tsx',
+    'src/invalid%20path/InvalidFile.ts',
+  ])('should detect "%s" as a valid path', str => {
+    expect(isValidPath(str)).toBeTruthy();
+  });
 });
 
 describe('isUrl', () => {


### PR DESCRIPTION
## Summary
- Fixes #7658: `removeDescriptions` also strips descriptions from operations, variables, fragments, and schema nodes
- Fixes #6454: allow `%` in `isValidPath` (e.g. URL-encoded directory names)
- Fixes #6339, Fixes #4434: pass `resolverValidationOptions` from `addMocksToSchema` through to `addResolversToSchema`
- Follow-up to #8364: precompute sort keys once per node, and keep a single `@graphql-tools/documents` changeset
- CI: run unit and leak tests in parallel within each matrix job (same pattern as whatwg-node)

## Test plan
- [x] `packages/optimize/tests/remove-description.spec.ts`
- [x] `packages/utils/tests/helpers.test.ts`
- [x] `packages/mock/tests/addMocksToSchema.spec.ts`
- [x] `packages/documents/tests/print-executable-graphql-document.spec.ts`
- [ ] Confirm CI matrix runs unit + leak as parallel steps per Node/OS/GraphQL combo