### PR TITLE
fix(merge): preserve multi-instance directives when extending types

### DIFF
--- a/.changeset/merge-infer-repeatable-directives.md
+++ b/.changeset/merge-infer-repeatable-directives.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/merge': patch
+---
+
+Preserve multiple applications of the same directive when extending a type even if the repeatable directive definition is not present in the merge inputs.

--- a/packages/merge/src/typedefs-mergers/directives.ts
+++ b/packages/merge/src/typedefs-mergers/directives.ts
@@ -9,14 +9,35 @@ import {
 } from 'graphql';
 import { Config } from './merge-typedefs.js';
 
+function collectMultiInstanceDirectiveNames(
+  directiveNodes: ReadonlyArray<DirectiveNode>,
+): Set<string> {
+  const seen = new Set<string>();
+  const multi = new Set<string>();
+  for (const directive of directiveNodes) {
+    const name = directive.name.value;
+    if (seen.has(name)) {
+      multi.add(name);
+    } else {
+      seen.add(name);
+    }
+  }
+  return multi;
+}
+
 function isRepeatableDirective(
   directive: DirectiveNode,
   directives?: Record<string, DirectiveDefinitionNode>,
   repeatableLinkImports?: Set<string>,
+  inferredRepeatable?: Set<string>,
 ): boolean {
+  const directiveDef = directives?.[directive.name.value];
+  if (directiveDef) {
+    return !!directiveDef.repeatable;
+  }
   return !!(
-    directives?.[directive.name.value]?.repeatable ??
-    repeatableLinkImports?.has(directive.name.value)
+    repeatableLinkImports?.has(directive.name.value) ||
+    inferredRepeatable?.has(directive.name.value)
   );
 }
 
@@ -117,9 +138,33 @@ export function mergeDirectives(
   const reverseOrder: boolean | undefined = config && config.reverseDirectives;
   const asNext = reverseOrder ? d1 : d2;
   const asFirst = reverseOrder ? d2 : d1;
+  // When a type already has multiple applications of the same directive name and the
+  // other merge input has none (typical when extending a type), treat that name as
+  // repeatable if no directive definition is available — otherwise those applications
+  // are collapsed while re-merging the type's own directives (#6505).
+  // Only infer when the other side has zero applications so legitimate merges of the
+  // same directive from two documents (e.g. @link import lists) still combine.
+  const inferredRepeatable = new Set<string>();
+  for (const name of collectMultiInstanceDirectiveNames(d1)) {
+    if (!d2.some(directive => directive.name.value === name)) {
+      inferredRepeatable.add(name);
+    }
+  }
+  for (const name of collectMultiInstanceDirectiveNames(d2)) {
+    if (!d1.some(directive => directive.name.value === name)) {
+      inferredRepeatable.add(name);
+    }
+  }
   const result: DirectiveNode[] = [];
   for (const directive of [...asNext, ...asFirst]) {
-    if (isRepeatableDirective(directive, directives, config?.repeatableLinkImports)) {
+    if (
+      isRepeatableDirective(
+        directive,
+        directives,
+        config?.repeatableLinkImports,
+        inferredRepeatable,
+      )
+    ) {
       // look for repeated, identical directives that come before this instance
       // if those exist, return null so that this directive gets removed.
       const exactDuplicate = result.find(d => matchDirectives(directive, d));

--- a/packages/merge/src/typedefs-mergers/directives.ts
+++ b/packages/merge/src/typedefs-mergers/directives.ts
@@ -144,14 +144,16 @@ export function mergeDirectives(
   // are collapsed while re-merging the type's own directives (#6505).
   // Only infer when the other side has zero applications so legitimate merges of the
   // same directive from two documents (e.g. @link import lists) still combine.
+  const d1Names = new Set(d1.map(directive => directive.name.value));
+  const d2Names = new Set(d2.map(directive => directive.name.value));
   const inferredRepeatable = new Set<string>();
   for (const name of collectMultiInstanceDirectiveNames(d1)) {
-    if (!d2.some(directive => directive.name.value === name)) {
+    if (!d2Names.has(name)) {
       inferredRepeatable.add(name);
     }
   }
   for (const name of collectMultiInstanceDirectiveNames(d2)) {
-    if (!d1.some(directive => directive.name.value === name)) {
+    if (!d1Names.has(name)) {
       inferredRepeatable.add(name);
     }
   }

--- a/packages/merge/tests/merge-typedefs.spec.ts
+++ b/packages/merge/tests/merge-typedefs.spec.ts
@@ -553,6 +553,35 @@ describe('Merge TypeDefs', () => {
       );
     });
 
+    it('preserves multiple same-name directives when extending without the directive definition', () => {
+      const td1 = /* GraphQL */ `
+        type Foo @foo(person: "alice") @foo(person: "bob") {
+          hello: String
+        }
+      `;
+      const td2 = /* GraphQL */ `
+        extend type Foo {
+          goodbye: String
+        }
+      `;
+
+      const mergedWithoutDefinition = mergeTypeDefs([td1, td2]);
+      const fooWithoutDefinition = mergedWithoutDefinition.definitions.find(
+        d => d.kind === 'ObjectTypeDefinition' && d.name.value === 'Foo',
+      ) as any;
+      expect(fooWithoutDefinition.directives).toHaveLength(2);
+
+      const mergedWithDefinition = mergeTypeDefs([
+        `directive @foo(person: String) repeatable on OBJECT`,
+        td1,
+        td2,
+      ]);
+      const fooWithDefinition = mergedWithDefinition.definitions.find(
+        d => d.kind === 'ObjectTypeDefinition' && d.name.value === 'Foo',
+      ) as any;
+      expect(fooWithDefinition.directives).toHaveLength(2);
+    });
+
     it('should merge args if inputs of the same directive are different from each other', () => {
       const result = mergeTypeDefs([
         `directive @id on FIELD_DEFINITION`,

--- a/packages/merge/tests/merge-typedefs.spec.ts
+++ b/packages/merge/tests/merge-typedefs.spec.ts
@@ -569,7 +569,12 @@ describe('Merge TypeDefs', () => {
       const fooWithoutDefinition = mergedWithoutDefinition.definitions.find(
         d => d.kind === 'ObjectTypeDefinition' && d.name.value === 'Foo',
       ) as any;
+      expect(fooWithoutDefinition).toBeDefined();
       expect(fooWithoutDefinition.directives).toHaveLength(2);
+      expect(fooWithoutDefinition.directives).toMatchObject([
+        { name: { value: 'foo' }, arguments: [{ value: { value: 'alice' } }] },
+        { name: { value: 'foo' }, arguments: [{ value: { value: 'bob' } }] },
+      ]);
 
       const mergedWithDefinition = mergeTypeDefs([
         `directive @foo(person: String) repeatable on OBJECT`,
@@ -579,7 +584,12 @@ describe('Merge TypeDefs', () => {
       const fooWithDefinition = mergedWithDefinition.definitions.find(
         d => d.kind === 'ObjectTypeDefinition' && d.name.value === 'Foo',
       ) as any;
+      expect(fooWithDefinition).toBeDefined();
       expect(fooWithDefinition.directives).toHaveLength(2);
+      expect(fooWithDefinition.directives).toMatchObject([
+        { name: { value: 'foo' }, arguments: [{ value: { value: 'alice' } }] },
+        { name: { value: 'foo' }, arguments: [{ value: { value: 'bob' } }] },
+      ]);
     });
 
     it('should merge args if inputs of the same directive are different from each other', () => {


### PR DESCRIPTION
## Summary
- When extending a type that already has multiple applications of the same directive, keep those applications even if the repeatable directive definition is not present in the merge inputs
- Inference only applies when the other side has no applications of that directive name (avoids collapsing intentional single-instance directives / `@link` regressions)

Closes #6505

## Test plan
- [x] `packages/merge/tests/merge-typedefs.spec.ts` — multi-instance directives preserved with and without the directive definition present