### PR TITLE
fix(utils): omit pruned root operations from printSchemaWithDirectives

### DIFF
--- a/.changeset/print-schema-omit-pruned-roots.md
+++ b/.changeset/print-schema-omit-pruned-roots.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/utils': patch
+---
+
+Omit mutation/subscription from `printSchemaWithDirectives` when those root types are no longer present on the schema (e.g. after `pruneSchema`).

--- a/packages/utils/src/print-schema-with-directives.ts
+++ b/packages/utils/src/print-schema-with-directives.ts
@@ -168,6 +168,9 @@ export function astFromSchema(
           type: rootTypeAST,
         } as OperationTypeDefinitionNode);
       }
+    } else {
+      // Drop operation types that no longer exist on the schema (e.g. after pruneSchema).
+      operationTypeMap.set(operationTypeNode, undefined);
     }
   }
 

--- a/packages/utils/tests/print-schema-with-directives.spec.ts
+++ b/packages/utils/tests/print-schema-with-directives.spec.ts
@@ -18,7 +18,7 @@ import {
 import { makeExecutableSchema } from '@graphql-tools/schema';
 import { stitchSchemas } from '@graphql-tools/stitch';
 import { RenameTypes, wrapSchema } from '@graphql-tools/wrap';
-import { printSchemaWithDirectives } from '../src/index.js';
+import { printSchemaWithDirectives, pruneSchema } from '../src/index.js';
 
 describe('printSchemaWithDirectives', () => {
   it(`Should print with directives, while printSchema doesn't`, () => {
@@ -492,5 +492,42 @@ describe('printSchemaWithDirectives', () => {
 
     const output = printSchemaWithDirectives(schema);
     expect(output).toContain('me: String @scope(name: TEAMS_WRITE)');
+  });
+
+  it('omits pruned mutation and subscription from the schema definition', () => {
+    const schema = makeExecutableSchema({
+      typeDefs: /* GraphQL */ `
+        schema {
+          query: Query
+          mutation: Mutation
+          subscription: Subscription
+        }
+
+        type Query {
+          foo: Boolean
+        }
+
+        type Mutation
+
+        type Subscription
+      `,
+    });
+
+    const pruned = pruneSchema(schema);
+    expect(pruned.getMutationType()).toBeUndefined();
+    expect(pruned.getSubscriptionType()).toBeUndefined();
+
+    const output = stripIgnoredCharacters(printSchemaWithDirectives(pruned));
+    expect(output).toBe(
+      stripIgnoredCharacters(/* GraphQL */ `
+        schema {
+          query: Query
+        }
+
+        type Query {
+          foo: Boolean
+        }
+      `),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- After `pruneSchema` removes unused mutation/subscription root types, `printSchemaWithDirectives` no longer keeps printing them from stale `schema.astNode` operation types

Closes #6115

## Test plan
- [x] `packages/utils/tests/print-schema-with-directives.spec.ts`