### PR TITLE
chore: temporarily pin snapshot workflow for changesets CLI v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,8 @@ jobs:
     if:
       ${{ github.event.pull_request.head.repo.fork != true && github.event.pull_request.title !=
       'Upcoming Release Changes' }}
-    uses: the-guild-org/shared-config/.github/workflows/release-snapshot.yml@v1
+    # Temporary: v3 publish output parsing until the-guild-org/shared-config#755 merges
+    uses: ardatan/shared-config/.github/workflows/release-snapshot.yml@6073226382355aa6ae65a9cee76d491f7f85233b
     with:
       npmTag: alpha
       buildScript: build
@@ -63,7 +64,8 @@ jobs:
     if:
       ${{ github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.title == 'Upcoming Release Changes' }}
-    uses: the-guild-org/shared-config/.github/workflows/release-snapshot.yml@v1
+    # Temporary: v3 publish output parsing until the-guild-org/shared-config#755 merges
+    uses: ardatan/shared-config/.github/workflows/release-snapshot.yml@6073226382355aa6ae65a9cee76d491f7f85233b
     with:
       npmTag: rc
       buildScript: build


### PR DESCRIPTION
## Summary
- Alpha snapshot comments incorrectly say there are no linked changesets after the `@changesets/cli` v3 upgrade (publish succeeds; stdout parsing fails).
- Temporarily point `alpha` / `release-candidate` at `ardatan/shared-config` @ `6073226` ([the-guild-org/shared-config#755](https://github.com/the-guild-org/shared-config/pull/755), which pins the fix from [the-guild-org/changesets-snapshot-action#3](https://github.com/the-guild-org/changesets-snapshot-action/pull/3)).
- Revert to `the-guild-org/shared-config/...@v1` once [the-guild-org/shared-config#755](https://github.com/the-guild-org/shared-config/pull/755) is merged.

## Test plan
- [ ] Confirm alpha job on this PR lists published packages in the snapshot comment (not the "no linked changesets" message).
- [ ] After [the-guild-org/shared-config#755](https://github.com/the-guild-org/shared-config/pull/755) merges, open a follow-up reverting this pin.