### PR TITLE
fix: load errors, observable cleanup, descriptions, and import attributes

### DIFF
--- a/.changeset/@graphql-tools_graphql-tag-pluck-8370-dependencies.md
+++ b/.changeset/@graphql-tools_graphql-tag-pluck-8370-dependencies.md
@@ -1,0 +1,6 @@
+---
+"@graphql-tools/graphql-tag-pluck": patch
+---
+dependencies updates:
+  - Added dependency [`@babel/plugin-syntax-import-attributes@^7.29.7` ↗︎](https://www.npmjs.com/package/@babel/plugin-syntax-import-attributes/v/7.29.7) (to `dependencies`)
+  - Removed dependency [`@babel/plugin-syntax-import-assertions@^7.26.0` ↗︎](https://www.npmjs.com/package/@babel/plugin-syntax-import-assertions/v/7.26.0) (from `dependencies`)

--- a/.changeset/@graphql-tools_graphql-tag-pluck-8370-dependencies.md
+++ b/.changeset/@graphql-tools_graphql-tag-pluck-8370-dependencies.md
@@ -2,5 +2,4 @@
 "@graphql-tools/graphql-tag-pluck": patch
 ---
 dependencies updates:
-  - Added dependency [`@babel/plugin-syntax-import-attributes@^7.29.7` ↗︎](https://www.npmjs.com/package/@babel/plugin-syntax-import-attributes/v/7.29.7) (to `dependencies`)
   - Removed dependency [`@babel/plugin-syntax-import-assertions@^7.26.0` ↗︎](https://www.npmjs.com/package/@babel/plugin-syntax-import-assertions/v/7.26.0) (from `dependencies`)

--- a/.changeset/git-loader-leading-dot-slash.md
+++ b/.changeset/git-loader-leading-dot-slash.md
@@ -2,4 +2,4 @@
 '@graphql-tools/git-loader': patch
 ---
 
-Strip leading `./` when matching git tree paths in `resolveGlobs`, while preserving `./` on resolved pointers. Fixes #5243.
+Parse `git ls-tree` output with LF-safe line splitting and normalize paths so `resolveGlobs` matches correctly on Windows. Fixes #5243.

--- a/.changeset/git-loader-leading-dot-slash.md
+++ b/.changeset/git-loader-leading-dot-slash.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/git-loader': patch
+---
+
+Strip leading `./` when matching git tree paths in `resolveGlobs`, while preserving `./` on resolved pointers. Fixes #5243.

--- a/.changeset/load-single-error-context.md
+++ b/.changeset/load-single-error-context.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/load': patch
+---
+
+Always include "Failed to find any GraphQL type definitions" context when loaders error, even if there is only one error. Fixes #7406.

--- a/.changeset/pluck-import-attributes.md
+++ b/.changeset/pluck-import-attributes.md
@@ -2,4 +2,4 @@
 '@graphql-tools/graphql-tag-pluck': patch
 ---
 
-Migrate Babel import syntax plugin from `importAssertions` to `importAttributes` (with `deprecatedAssertSyntax` so existing `assert { … }` files still parse). Fixes #5454.
+Parse with Babel `importAttributes` (and `deprecatedAssertSyntax` so existing `assert { … }` files still work), and drop the unused `@babel/plugin-syntax-import-assertions` dependency. Fixes #5454.

--- a/.changeset/pluck-import-attributes.md
+++ b/.changeset/pluck-import-attributes.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/graphql-tag-pluck': patch
+---
+
+Migrate Babel import syntax plugin from `importAssertions` to `importAttributes` (with `deprecatedAssertSyntax` so existing `assert { … }` files still parse). Fixes #5454.

--- a/.changeset/utils-observable-cleanup-on-done.md
+++ b/.changeset/utils-observable-cleanup-on-done.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/utils': patch
+---
+
+Clean up `observableToAsyncIterable` queues and unsubscribe when the observable completes, so iterators do not retain references after `done`. Fixes leak detection flakes related to #8057.

--- a/.changeset/utils-prefer-runtime-descriptions.md
+++ b/.changeset/utils-prefer-runtime-descriptions.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/utils': patch
+---
+
+Prefer runtime `description` values over stale `astNode` descriptions in `printSchemaWithDirectives` / `getDescriptionNode`. Fixes #5508.

--- a/package-lock.json
+++ b/package-lock.json
@@ -118,6 +118,7 @@
       "resolved": "https://registry.npmjs.org/@apollo/client/-/client-4.2.10.tgz",
       "integrity": "sha512-SCHzOEcfInIN9DGZvlDR4F+1zd3954WAy+g8dKwi7mrI09Tdh6YzDH+eXbH0LNpB4de2Qyb53RVKe3Ljv5/bMg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/caches": "^1.0.0",
@@ -159,7 +160,8 @@
       "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-4.0.0.tgz",
       "integrity": "sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -189,6 +191,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -729,6 +732,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.29.7.tgz",
       "integrity": "sha512-/An1OCBN93thpBAGyfsK2pcf0jvju1SAtKkL2Ny++B5Sy6sqgzXDQH1cZxWbF96Wuk+bn41MDA9bLd4VVAw6rw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
@@ -744,7 +748,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
       "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
@@ -2603,28 +2606,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -2641,6 +2622,7 @@
       "resolved": "https://registry.npmjs.org/@envelop/core/-/core-5.5.1.tgz",
       "integrity": "sha512-3DQg8sFskDo386TkL5j12jyRAdip/8yzK3x7YGbZBgobZ4aKXrvDU0GppU0SnmrpQnNaiTUsxBs9LKkwQ/eyvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@envelop/instrumentation": "^1.0.0",
         "@envelop/types": "^5.2.1",
@@ -2750,6 +2732,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2766,6 +2749,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2782,6 +2766,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2798,6 +2783,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2814,6 +2800,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2830,6 +2817,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2846,6 +2834,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2862,6 +2851,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2878,6 +2868,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2894,6 +2885,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2910,6 +2902,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2926,6 +2919,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2942,6 +2936,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2958,6 +2953,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2974,6 +2970,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2990,6 +2987,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3006,6 +3004,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3022,6 +3021,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3038,6 +3038,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3054,6 +3055,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3070,6 +3072,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3086,6 +3089,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3102,6 +3106,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3118,6 +3123,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3134,6 +3140,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3150,6 +3157,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4079,7 +4087,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -4102,7 +4109,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -4170,7 +4176,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -4187,7 +4192,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -4199,15 +4203,11 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -4219,15 +4219,11 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -4239,15 +4235,11 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -4259,15 +4251,11 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -4279,15 +4267,11 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -4299,15 +4283,11 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -4319,15 +4299,11 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -4339,15 +4315,11 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -4359,15 +4331,11 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -4385,15 +4353,11 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -4411,15 +4375,11 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -4437,15 +4397,11 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -4463,15 +4419,11 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -4489,15 +4441,11 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -4515,15 +4463,11 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -4541,15 +4485,11 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -4569,7 +4509,6 @@
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/runtime": "^1.7.0"
       },
@@ -4637,7 +4576,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -4657,7 +4595,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -4677,7 +4614,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -5473,9 +5409,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5491,9 +5424,6 @@
       "integrity": "sha512-MOs7fPyJiU/wqOpKzAOmOpxJ/TZfP4JwmvPad/cXTOWYwwyppMlXFRms3i98EU3HOazI/wMU2Ksfda3+TBluWA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5511,9 +5441,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5529,9 +5456,6 @@
       "integrity": "sha512-4FHkPlCSIZUGC6HiADffbe6NVoTBMd65pIwcd40IDbtFKOgFMBA+pWRqKiQ21FERGH16Zed7XHJJoY3jpOqtmQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -5549,9 +5473,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5567,9 +5488,6 @@
       "integrity": "sha512-zRYxg7it0p3rLyEJYoCoL2PQJNgArVLyNavHW03TFUAYkYi5bxQ/UFNVpgxMaXohr5yu7qCBqeo9j4DWeysalg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5663,8 +5581,7 @@
       "version": "15.5.23",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.23.tgz",
       "integrity": "sha512-Mv3Z9hVbFcPnoLevsZ6rnX1TBtyHb5E17yN7HTPDXSXxeNsGBjUFrdbjRXKKXIOhfth7/cg6Ay7PZ2UFawaWsQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
       "version": "15.5.23",
@@ -5678,7 +5595,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -5695,7 +5611,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -5707,15 +5622,11 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -5727,15 +5638,11 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -5747,15 +5654,11 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -5767,15 +5670,11 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -5792,7 +5691,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -5809,7 +5707,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -7204,6 +7101,7 @@
       "resolved": "https://registry.npmjs.org/@theguild/tailwind-config/-/tailwind-config-0.6.4.tgz",
       "integrity": "sha512-7zscZk+L9x0Z8tMQGtVBC+1usAJ6Nz7hJYCmKzwXyMA4paXr/ghCeMArF9hkIkBp/GH+gKpR+ERaHwmqmvqfVg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tailwindcss/container-queries": "^0.1.1"
       },
@@ -7616,6 +7514,7 @@
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -7820,6 +7719,7 @@
       "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -8205,6 +8105,7 @@
       "integrity": "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.67.0",
         "@typescript-eslint/types": "8.67.0",
@@ -8367,6 +8268,7 @@
       "integrity": "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -8865,9 +8767,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8882,9 +8781,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8899,9 +8795,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8916,9 +8809,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8933,9 +8823,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8950,9 +8837,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8967,9 +8851,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8984,9 +8865,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9001,9 +8879,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9018,9 +8893,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9177,6 +9049,35 @@
         "magic-string": "^0.30.21",
         "postcss": "^8.5.19",
         "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/postcss": {
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/@vue/compiler-ssr": {
@@ -9538,6 +9439,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
       "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -10455,6 +10357,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.11.12",
         "caniuse-lite": "^1.0.30001809",
@@ -11425,6 +11328,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
       "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -11837,6 +11741,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -12208,7 +12113,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1653615.tgz",
       "integrity": "sha512-pGVkY3T/qXxAp2nFPodwYqOevk6ncNMSmvL8QfRCx5ZWGd6Vor7AFNmyaA8Zs6uJyP1QAfjuLandCgvSix1BNA==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -12676,6 +12582,7 @@
       "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -12906,6 +12813,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -12950,6 +12858,7 @@
       "integrity": "sha512-cPVguuDe6DrIPb/qUXHf8P89MaVTUmiYWwpt5gX5AILsvRIiZAxMFXcFR6QHYBksqKJpjfUBlL/RleCJUWcD7w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.5.0",
         "enhanced-resolve": "^5.17.1",
@@ -13012,6 +12921,7 @@
       "integrity": "sha512-6uGiOR0INuujr6PEQmeSSP7GbIMJ/ebEXXiEzb/nOj68LknH5Pxzb/AbZivmr6VE6TkTE8rTjRK9zhKpK6HsRA==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0"
       },
@@ -14330,6 +14240,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-17.0.2.tgz",
       "integrity": "sha512-FRWbddMxfkjiB7z+aQDWIR+E34xo9I8c9mtK2RPv8PmMzKRvrdsreHL/Ui/TmwHJfhHChEtsFPyMHKI+xuarQQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^22.0.0 || ^24.0.0 || ^25.0.0 || >=26.0.0"
       }
@@ -14462,6 +14373,7 @@
       "integrity": "sha512-IIRF/3xtjj2D6caAWL9177hQ8tV3mWB3hve1GRnz7njPhQ3iY1jFtSp98fNGv0yV9kaPh9kKQ8JWdJZnedVmDw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@envelop/core": "^5.5.1",
         "@envelop/instrumentation": "^1.0.0",
@@ -15958,6 +15870,7 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -16728,6 +16641,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -17094,9 +17008,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -17116,9 +17027,6 @@
       "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -17140,9 +17048,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -17162,9 +17067,6 @@
       "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -18965,9 +18867,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -18985,9 +18884,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -19005,9 +18901,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -19025,9 +18918,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -19045,9 +18935,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -19065,9 +18952,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -19085,9 +18969,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -19105,9 +18986,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -19125,9 +19003,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -19151,9 +19026,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -19177,9 +19049,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -19203,9 +19072,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -19229,9 +19095,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -19255,9 +19118,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -19281,9 +19141,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -19307,9 +19164,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -20805,6 +20659,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
@@ -20819,6 +20674,7 @@
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-16.1.1.tgz",
       "integrity": "sha512-2xVS1NCZAfjtVdvXiyegxzJ447GyqCeEI5V7ApgQVOWnros1p5lGNovJNapwPpMombyFBfqDwt7AD3n2l0KOfQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
         "read-cache": "^1.0.0",
@@ -20861,6 +20717,7 @@
       "resolved": "https://registry.npmjs.org/postcss-lightningcss/-/postcss-lightningcss-1.1.0.tgz",
       "integrity": "sha512-DlxT3lLE4PK5v2JN0WV0r7wod8LGAuj20ZjJ9cnEwOWv9osgoajRqavaFoxinyZ8jeg4JYJi9M1qtkjHyqulKA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "browserslist": "^4.19.1",
         "lightningcss": "^1.32.0"
@@ -20974,6 +20831,7 @@
       "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -21312,6 +21170,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
       "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -21351,6 +21210,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
       "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -22235,6 +22095,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -22332,6 +22193,7 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -22514,7 +22376,6 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -22559,7 +22420,6 @@
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "optional": true,
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -22606,6 +22466,7 @@
       "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.29.2.tgz",
       "integrity": "sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@shikijs/core": "1.29.2",
         "@shikijs/engine-javascript": "1.29.2",
@@ -23271,6 +23132,7 @@
       "integrity": "sha512-PY8LOw7xP6c8IOiVqdo0sbbZVYhXRSfklOQLAUyGBKqjTX0wx/z4l/9J+PmBpmlLnxzEb1NqltxQ5/wZme/Cmg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -23384,6 +23246,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -23832,6 +23695,7 @@
       "integrity": "sha512-Ry2oTEUnhBdeEdWIztY8kf3/nBGnPnjMLVGL0YfdRXMORuPER5NlKmayqxtxRxwB1xBN+RivRaJfe7PM1rtiyw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -24024,6 +23888,7 @@
       "integrity": "sha512-uSKqkh8Cr48vllnEy+jdaAgOeR6Y+QCBW7usgUsKj7gJEfR7stw9U/fE49LBnj2tPRKPY0c0EBJSWe9Appmplg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.23.0",
         "lunr": "^2.3.9",
@@ -24125,6 +23990,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
       "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc"
       },
@@ -24216,6 +24082,7 @@
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pathe": "^2.0.3"
       }
@@ -24701,6 +24568,7 @@
       "integrity": "sha512-U9/cvLzxObKNEZ9+TtdqrHM5/9z3lgl2c+c4BzbqGxFQvQvBAq87yql5A8pQ+rrMbS496MZJeF5enVBndIy2hw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
@@ -24975,6 +24843,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -25169,6 +25038,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
       "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -25317,6 +25187,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -25514,7 +25385,7 @@
       "dependencies": {
         "@babel/core": "^7.29.7",
         "@babel/parser": "^7.29.3",
-        "@babel/plugin-syntax-import-assertions": "^7.26.0",
+        "@babel/plugin-syntax-import-attributes": "^7.29.7",
         "@babel/traverse": "^7.26.10",
         "@babel/types": "^7.26.10",
         "@graphql-tools/utils": "^12.0.0",
@@ -26191,9 +26062,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -26209,9 +26077,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -26229,9 +26094,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -26247,9 +26109,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -26267,9 +26126,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -26285,9 +26141,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -26305,9 +26158,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -26324,9 +26174,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -26342,9 +26189,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -26368,9 +26212,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -26392,9 +26233,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -26418,9 +26256,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -26442,9 +26277,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -26468,9 +26300,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -26493,9 +26322,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -26517,9 +26343,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -26638,9 +26461,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -26656,9 +26476,6 @@
       "integrity": "sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -26676,9 +26493,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -26694,9 +26508,6 @@
       "integrity": "sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -25385,7 +25385,6 @@
       "dependencies": {
         "@babel/core": "^7.29.7",
         "@babel/parser": "^7.29.3",
-        "@babel/plugin-syntax-import-attributes": "^7.29.7",
         "@babel/traverse": "^7.26.10",
         "@babel/types": "^7.26.10",
         "@graphql-tools/utils": "^12.0.0",

--- a/packages/graphql-tag-pluck/package.json
+++ b/packages/graphql-tag-pluck/package.json
@@ -52,7 +52,6 @@
   "dependencies": {
     "@babel/core": "^7.29.7",
     "@babel/parser": "^7.29.3",
-    "@babel/plugin-syntax-import-attributes": "^7.29.7",
     "@babel/traverse": "^7.26.10",
     "@babel/types": "^7.26.10",
     "@graphql-tools/utils": "^12.0.0",

--- a/packages/graphql-tag-pluck/package.json
+++ b/packages/graphql-tag-pluck/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@babel/core": "^7.29.7",
     "@babel/parser": "^7.29.3",
-    "@babel/plugin-syntax-import-assertions": "^7.26.0",
+    "@babel/plugin-syntax-import-attributes": "^7.29.7",
     "@babel/traverse": "^7.26.10",
     "@babel/types": "^7.26.10",
     "@graphql-tools/utils": "^12.0.0",

--- a/packages/graphql-tag-pluck/src/config.ts
+++ b/packages/graphql-tag-pluck/src/config.ts
@@ -45,11 +45,12 @@ export default function generateConfig(
     case '.cts':
     case '.mts':
       plugins.push('typescript');
-      plugins.push('importAssertions');
+      // importAttributes replaces importAssertions; keep deprecatedAssertSyntax for `assert { … }`
+      plugins.push(['importAttributes', { deprecatedAssertSyntax: true }]);
       break;
     case '.tsx':
       plugins.push('typescript', 'jsx');
-      plugins.push('importAssertions');
+      plugins.push(['importAttributes', { deprecatedAssertSyntax: true }]);
       break;
     // Adding .jsx extension by default because it doesn't affect other syntax features
     // (unlike .tsx) and because people are seem to use it with regular file extensions

--- a/packages/graphql-tag-pluck/tests/graphql-tag-pluck.test.ts
+++ b/packages/graphql-tag-pluck/tests/graphql-tag-pluck.test.ts
@@ -246,6 +246,48 @@ describe('graphql-tag-pluck', () => {
       );
     });
 
+    it('should pluck graphql-tag template literals from .ts file that uses `with` import attributes', async () => {
+      const sources = await pluck(
+        'tmp-XXXXXX.ts',
+        freeText(`
+        import gql from 'graphql-tag'
+        import { Document } from 'graphql'
+
+        import any from "./package.json" with { type: "json" };
+
+        const fragment: Document = gql\`
+            fragment Foo on FooType {
+              id
+            }
+          \`
+
+          const doc: Document = gql\`
+            query foo {
+              foo {
+                ...Foo
+              }
+            }
+
+            \${fragment}
+          \`
+      `),
+      );
+
+      expect(sources.map(source => source.body).join('\n\n')).toEqual(
+        freeText(`
+        fragment Foo on FooType {
+          id
+        }
+
+        query foo {
+          foo {
+            ...Foo
+          }
+        }
+      `),
+      );
+    });
+
     it("should pluck graphql template literals from .ts that use an 'as const' assertion", async () => {
       const sources = await pluck(
         'tmp-XXXXXX.ts',

--- a/packages/load/src/load-typedefs/load-file.ts
+++ b/packages/load/src/load-typedefs/load-file.ts
@@ -30,9 +30,8 @@ export async function loadFile(pointer: string, options: LoadTypedefsOptions): P
     );
 
     if (results.length === 0 && errors.length > 0) {
-      if (errors.length === 1) {
-        throw errors[0];
-      }
+      // Always surface the "no type definitions" context, even for a single
+      // loader error — otherwise an unrelated parse/pluck failure can hide it (#7406).
       throw new AggregateError(
         errors,
         `Failed to find any GraphQL type definitions in: ${pointer};\n - ${errors
@@ -77,9 +76,6 @@ export function loadFileSync(pointer: string, options: LoadTypedefsOptions): Sou
     }
 
     if (results.length === 0 && errors.length > 0) {
-      if (errors.length === 1) {
-        throw errors[0];
-      }
       throw new AggregateError(
         errors,
         `Failed to find any GraphQL type definitions in: ${pointer};\n - ${errors

--- a/packages/load/tests/load-file-error-context.spec.ts
+++ b/packages/load/tests/load-file-error-context.spec.ts
@@ -1,0 +1,59 @@
+import { join } from 'path';
+import { parse } from 'graphql';
+import { loadTypedefs, loadTypedefsSync } from '@graphql-tools/load';
+import { Loader, Source } from '@graphql-tools/utils';
+
+describe('loadFile AggregateError context (#7406)', () => {
+  const pointer = join(__dirname, 'test-files', 'missing-no-match.graphql');
+
+  const failingLoader: Loader = {
+    canLoad: async () => true,
+    canLoadSync: () => true,
+    load: async () => {
+      throw new Error('unrelated loader failure');
+    },
+    loadSync: () => {
+      throw new Error('unrelated loader failure');
+    },
+  };
+
+  it('includes Failed to find any GraphQL type definitions when a single loader errors (async)', async () => {
+    await expect(
+      loadTypedefs(pointer, {
+        loaders: [failingLoader],
+      }),
+    ).rejects.toThrow(/Failed to find any GraphQL type definitions/);
+  });
+
+  it('includes Failed to find any GraphQL type definitions when a single loader errors (sync)', () => {
+    expect(() =>
+      loadTypedefsSync(pointer, {
+        loaders: [failingLoader],
+      }),
+    ).toThrow(/Failed to find any GraphQL type definitions/);
+  });
+
+  it('still returns sources when a loader succeeds despite another failing', async () => {
+    const okLoader: Loader = {
+      canLoad: async () => true,
+      canLoadSync: () => true,
+      load: async (): Promise<Source[]> => [
+        {
+          location: pointer,
+          document: parse('type Query { ok: String }'),
+        },
+      ],
+      loadSync: (): Source[] => [
+        {
+          location: pointer,
+          document: parse('type Query { ok: String }'),
+        },
+      ],
+    };
+
+    const results = await loadTypedefs(pointer, {
+      loaders: [failingLoader, okLoader],
+    });
+    expect(results.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/load/tests/load-file-error-context.spec.ts
+++ b/packages/load/tests/load-file-error-context.spec.ts
@@ -7,8 +7,6 @@ describe('loadFile AggregateError context (#7406)', () => {
   const pointer = join(__dirname, 'test-files', 'missing-no-match.graphql');
 
   const failingLoader: Loader = {
-    canLoad: async () => true,
-    canLoadSync: () => true,
     load: async () => {
       throw new Error('unrelated loader failure');
     },
@@ -35,8 +33,6 @@ describe('loadFile AggregateError context (#7406)', () => {
 
   it('still returns sources when a loader succeeds despite another failing', async () => {
     const okLoader: Loader = {
-      canLoad: async () => true,
-      canLoadSync: () => true,
       load: async (): Promise<Source[]> => [
         {
           location: pointer,

--- a/packages/load/tests/loaders/schema/integration.spec.ts
+++ b/packages/load/tests/loaders/schema/integration.spec.ts
@@ -26,7 +26,9 @@ describe('loadSchema', () => {
         });
         expect(true).toBeFalsy(); // should throw
       } catch (e: any) {
-        expect(e.toString()).toContain(`SyntaxError`);
+        // Single loader failures are wrapped in AggregateError with context (#7406)
+        expect(e.toString()).toContain('Failed to find any GraphQL type definitions');
+        expect(e.toString()).toMatch(/Unterminated template|SyntaxError/);
       }
     });
 

--- a/packages/loaders/git/src/index.ts
+++ b/packages/loaders/git/src/index.ts
@@ -64,10 +64,14 @@ export class GitLoader implements Loader<GitLoaderOptions> {
     }
     const refsForPaths = new Map();
     const { ref, path } = data;
+    const maybeLeadingDotSlash = path.startsWith('./') ? './' : '';
+    // Tree paths from git never include a leading `./`; strip it for matching (#5243).
+    const normalizeGlobPath = (p: string) => unixify(p.startsWith('./') ? p.slice(2) : p);
+
     if (!refsForPaths.has(ref)) {
       refsForPaths.set(ref, []);
     }
-    refsForPaths.get(ref).push(unixify(path));
+    refsForPaths.get(ref).push(normalizeGlobPath(path));
 
     for (const ignore of ignores) {
       const data = extractData(ignore);
@@ -78,10 +82,8 @@ export class GitLoader implements Loader<GitLoaderOptions> {
       if (!refsForPaths.has(ref)) {
         refsForPaths.set(ref, []);
       }
-      refsForPaths.get(ref).push(`!${unixify(path)}`);
+      refsForPaths.get(ref).push(`!${normalizeGlobPath(path)}`);
     }
-
-    const maybeLeadingDotSlash = path.startsWith('./') ? './' : '';
 
     const resolved: string[] = [];
     await Promise.all(
@@ -103,11 +105,13 @@ export class GitLoader implements Loader<GitLoaderOptions> {
     }
     const { ref, path } = data;
     const refsForPaths = new Map();
+    const maybeLeadingDotSlash = path.startsWith('./') ? './' : '';
+    const normalizeGlobPath = (p: string) => unixify(p.startsWith('./') ? p.slice(2) : p);
 
     if (!refsForPaths.has(ref)) {
       refsForPaths.set(ref, []);
     }
-    refsForPaths.get(ref).push(unixify(path));
+    refsForPaths.get(ref).push(normalizeGlobPath(path));
 
     for (const ignore of ignores) {
       const data = extractData(ignore);
@@ -118,10 +122,8 @@ export class GitLoader implements Loader<GitLoaderOptions> {
       if (!refsForPaths.has(ref)) {
         refsForPaths.set(ref, []);
       }
-      refsForPaths.get(ref).push(`!${unixify(path)}`);
+      refsForPaths.get(ref).push(`!${normalizeGlobPath(path)}`);
     }
-
-    const maybeLeadingDotSlash = path.startsWith('./') ? './' : '';
 
     const resolved: string[] = [];
     for (const [ref, paths] of refsForPaths.entries()) {

--- a/packages/loaders/git/src/index.ts
+++ b/packages/loaders/git/src/index.ts
@@ -65,13 +65,12 @@ export class GitLoader implements Loader<GitLoaderOptions> {
     const refsForPaths = new Map();
     const { ref, path } = data;
     const maybeLeadingDotSlash = path.startsWith('./') ? './' : '';
-    // Tree paths from git never include a leading `./`; strip it for matching (#5243).
-    const normalizeGlobPath = (p: string) => unixify(p.startsWith('./') ? p.slice(2) : p);
+    // unixify() already strips a leading `./` (needed so micromatch can hit git tree paths).
 
     if (!refsForPaths.has(ref)) {
       refsForPaths.set(ref, []);
     }
-    refsForPaths.get(ref).push(normalizeGlobPath(path));
+    refsForPaths.get(ref).push(unixify(path));
 
     for (const ignore of ignores) {
       const data = extractData(ignore);
@@ -82,7 +81,7 @@ export class GitLoader implements Loader<GitLoaderOptions> {
       if (!refsForPaths.has(ref)) {
         refsForPaths.set(ref, []);
       }
-      refsForPaths.get(ref).push(`!${normalizeGlobPath(path)}`);
+      refsForPaths.get(ref).push(`!${unixify(path)}`);
     }
 
     const resolved: string[] = [];
@@ -106,12 +105,12 @@ export class GitLoader implements Loader<GitLoaderOptions> {
     const { ref, path } = data;
     const refsForPaths = new Map();
     const maybeLeadingDotSlash = path.startsWith('./') ? './' : '';
-    const normalizeGlobPath = (p: string) => unixify(p.startsWith('./') ? p.slice(2) : p);
+    // unixify() already strips a leading `./` (needed so micromatch can hit git tree paths).
 
     if (!refsForPaths.has(ref)) {
       refsForPaths.set(ref, []);
     }
-    refsForPaths.get(ref).push(normalizeGlobPath(path));
+    refsForPaths.get(ref).push(unixify(path));
 
     for (const ignore of ignores) {
       const data = extractData(ignore);
@@ -122,7 +121,7 @@ export class GitLoader implements Loader<GitLoaderOptions> {
       if (!refsForPaths.has(ref)) {
         refsForPaths.set(ref, []);
       }
-      refsForPaths.get(ref).push(`!${normalizeGlobPath(path)}`);
+      refsForPaths.get(ref).push(`!${unixify(path)}`);
     }
 
     const resolved: string[] = [];

--- a/packages/loaders/git/src/load-git.ts
+++ b/packages/loaders/git/src/load-git.ts
@@ -15,13 +15,17 @@ const createTreeCommand = ({ ref }: PartialInput): string[] => {
   return ['ls-tree', '-r', '--name-only', ref];
 };
 
-function parseGitTreeOutput(stdout: string): string[] {
+/**
+ * @internal
+ */
+export function parseGitTreeOutput(stdout: string): string[] {
   // Git always emits LF; do not use os.EOL (CRLF on Windows) or the tree
   // collapses to a single unusable entry and micromatch matches nothing.
+  // Do not trim entries — git pathnames can legally have leading/trailing spaces.
   return stdout
     .split(/\r?\n/)
-    .map(line => unixify(line.trim()))
-    .filter(Boolean);
+    .filter(line => line.length > 0)
+    .map(line => unixify(line));
 }
 
 /**

--- a/packages/loaders/git/src/load-git.ts
+++ b/packages/loaders/git/src/load-git.ts
@@ -1,5 +1,5 @@
 import { execFile, execFileSync } from 'child_process';
-import os from 'os';
+import unixify from 'unixify';
 
 type PartialInput = { ref: string };
 type Input = PartialInput & { path: string };
@@ -15,6 +15,15 @@ const createTreeCommand = ({ ref }: PartialInput): string[] => {
   return ['ls-tree', '-r', '--name-only', ref];
 };
 
+function parseGitTreeOutput(stdout: string): string[] {
+  // Git always emits LF; do not use os.EOL (CRLF on Windows) or the tree
+  // collapses to a single unusable entry and micromatch matches nothing.
+  return stdout
+    .split(/\r?\n/)
+    .map(line => unixify(line.trim()))
+    .filter(Boolean);
+}
+
 /**
  * @internal
  */
@@ -29,7 +38,7 @@ export async function readTreeAtRef(ref: string): Promise<string[] | never> {
           if (error) {
             reject(error);
           } else {
-            resolve(stdout.split(os.EOL).map(line => line.trim()));
+            resolve(parseGitTreeOutput(stdout));
           }
         },
       );
@@ -44,9 +53,9 @@ export async function readTreeAtRef(ref: string): Promise<string[] | never> {
  */
 export function readTreeAtRefSync(ref: string): string[] | never {
   try {
-    return execFileSync('git', createTreeCommand({ ref }), { encoding: 'utf-8' })
-      .split(os.EOL)
-      .map(line => line.trim());
+    return parseGitTreeOutput(
+      execFileSync('git', createTreeCommand({ ref }), { encoding: 'utf-8' }),
+    );
   } catch (error: any) {
     throw createTreeError(error);
   }

--- a/packages/loaders/git/tests/loader.spec.ts
+++ b/packages/loaders/git/tests/loader.spec.ts
@@ -42,6 +42,28 @@ describe('GitLoader', () => {
         expect(result.document).toBeDefined();
       });
 
+      it('should resolve globs that use a leading ./ (#5243)', async () => {
+        // Singular pointer with ./ — git show must accept the path as-is
+        const singular = `git:${lastCommit}:./packages/loaders/git/tests/test-files/type-defs.graphql`;
+        const [result] = await load(singular, {});
+        expect(result.document).toBeDefined();
+        expect(result.location).toBe(singular);
+
+        // Glob matching must strip ./ against git tree paths, then re-prefix on results
+        const resolved = await loader.resolveGlobs(
+          `git:${lastCommit}:./packages/loaders/git/tests/test-files/type-defs.graphql`,
+          [],
+        );
+        expect(resolved).toEqual([singular]);
+
+        const resolvedGlob = await loader.resolveGlobs(
+          `git:${lastCommit}:./packages/loaders/git/tests/test-files/*.graphql`,
+          [],
+        );
+        expect(resolvedGlob.every(p => p.includes(':./packages/'))).toBe(true);
+        expect(resolvedGlob.some(p => p.endsWith('type-defs.graphql'))).toBe(true);
+      });
+
       it('should load introspection data from a .json file', async () => {
         const [result] = await load(getPointer('introspection.json'), {});
         expect(result.schema).toBeDefined();

--- a/packages/loaders/git/tests/loader.spec.ts
+++ b/packages/loaders/git/tests/loader.spec.ts
@@ -3,8 +3,23 @@ import * as path from 'path';
 import { versionInfo } from 'graphql';
 import { runTests } from '../../../testing/utils.js';
 import { GitLoader } from '../src/index.js';
+import { parseGitTreeOutput } from '../src/load-git.js';
 
 const emptyList = versionInfo.major >= 17 ? undefined : [];
+
+describe('parseGitTreeOutput', () => {
+  it('splits on CRLF the same as LF', () => {
+    expect(parseGitTreeOutput('a.graphql\r\nb.graphql\r\n')).toEqual(['a.graphql', 'b.graphql']);
+    expect(parseGitTreeOutput('a.graphql\nb.graphql\n')).toEqual(['a.graphql', 'b.graphql']);
+  });
+
+  it('preserves leading and trailing spaces in pathnames', () => {
+    expect(parseGitTreeOutput(' leading.graphql\r\ntrailing.graphql \n')).toEqual([
+      ' leading.graphql',
+      'trailing.graphql ',
+    ]);
+  });
+});
 
 describe('GitLoader', () => {
   const loader = new GitLoader();
@@ -60,8 +75,12 @@ describe('GitLoader', () => {
           `git:${lastCommit}:./packages/loaders/git/tests/test-files/*.graphql`,
           [],
         );
-        expect(resolvedGlob.every(p => p.includes(':./packages/'))).toBe(true);
-        expect(resolvedGlob.some(p => p.endsWith('type-defs.graphql'))).toBe(true);
+        expect([...resolvedGlob].sort()).toEqual(
+          [
+            `git:${lastCommit}:./packages/loaders/git/tests/test-files/type-defs-invalid.graphql`,
+            `git:${lastCommit}:./packages/loaders/git/tests/test-files/type-defs.graphql`,
+          ].sort(),
+        );
       });
 
       it('should load introspection data from a .json file', async () => {

--- a/packages/loaders/git/tests/loader.spec.ts
+++ b/packages/loaders/git/tests/loader.spec.ts
@@ -8,7 +8,7 @@ const emptyList = versionInfo.major >= 17 ? undefined : [];
 
 describe('GitLoader', () => {
   const loader = new GitLoader();
-  const lastCommit = execSync('git rev-parse HEAD', { encoding: 'utf-8' }).replace(/\n/g, '');
+  const lastCommit = execSync('git rev-parse HEAD', { encoding: 'utf-8' }).replace(/\r?\n/g, '');
   const getPointer = (fileName: string) => {
     return `git:${lastCommit}:packages/loaders/git/tests/test-files/${fileName}`;
   };

--- a/packages/utils/src/descriptionFromObject.ts
+++ b/packages/utils/src/descriptionFromObject.ts
@@ -8,16 +8,18 @@ interface ObjectWithDescription {
 }
 
 export function getDescriptionNode(obj: ObjectWithDescription): StringValueNode | undefined {
-  if (obj.astNode?.description) {
-    return {
-      ...obj.astNode.description,
-      block: true,
-    };
-  }
-  if (obj.description) {
+  // Prefer the runtime `description` over a stale `astNode` description.
+  // Schema transforms (e.g. mapSchema) update config descriptions without rewriting astNode (#5508).
+  if (typeof obj.description === 'string') {
     return {
       kind: Kind.STRING,
       value: obj.description,
+      block: true,
+    };
+  }
+  if (obj.astNode?.description) {
+    return {
+      ...obj.astNode.description,
       block: true,
     };
   }

--- a/packages/utils/src/observableToAsyncIterable.ts
+++ b/packages/utils/src/observableToAsyncIterable.ts
@@ -19,6 +19,20 @@ export function observableToAsyncIterable<T>(observable: Observable<T>): AsyncIt
   const pushQueue: Array<any> = [];
 
   let listening = true;
+  const subscriptionRef: { current?: { unsubscribe: () => void } } = {};
+
+  const emptyQueue = () => {
+    if (listening) {
+      listening = false;
+      // subscribe() may call complete() synchronously before returning the subscription
+      subscriptionRef.current?.unsubscribe();
+      for (const resolve of pullQueue) {
+        resolve({ value: undefined, done: true });
+      }
+      pullQueue.length = 0;
+      pushQueue.length = 0;
+    }
+  };
 
   const pushValue = (value: any) => {
     if (pullQueue.length !== 0) {
@@ -42,6 +56,8 @@ export function observableToAsyncIterable<T>(observable: Observable<T>): AsyncIt
     if (pullQueue.length !== 0) {
       // It is safe to use the ! operator here as we check the length.
       pullQueue.shift()!({ done: true });
+      // Release queues/subscription after signaling done to the pending consumer.
+      emptyQueue();
     } else {
       pushQueue.push({ done: true });
     }
@@ -52,13 +68,17 @@ export function observableToAsyncIterable<T>(observable: Observable<T>): AsyncIt
       if (pushQueue.length !== 0) {
         const element = pushQueue.shift();
         // either {value: {errors: [...]}} or {value: ...}
+        if (element.done) {
+          // Release references before delivering the done signal.
+          emptyQueue();
+        }
         resolve(element);
       } else {
         pullQueue.push(resolve);
       }
     });
 
-  const subscription = observable.subscribe({
+  subscription = observable.subscribe({
     next(value: any) {
       return pushValue(value);
     },
@@ -69,18 +89,6 @@ export function observableToAsyncIterable<T>(observable: Observable<T>): AsyncIt
       return pushDone();
     },
   });
-
-  const emptyQueue = () => {
-    if (listening) {
-      listening = false;
-      subscription.unsubscribe();
-      for (const resolve of pullQueue) {
-        resolve({ value: undefined, done: true });
-      }
-      pullQueue.length = 0;
-      pushQueue.length = 0;
-    }
-  };
 
   return {
     next() {

--- a/packages/utils/src/observableToAsyncIterable.ts
+++ b/packages/utils/src/observableToAsyncIterable.ts
@@ -78,7 +78,7 @@ export function observableToAsyncIterable<T>(observable: Observable<T>): AsyncIt
       }
     });
 
-  subscription = observable.subscribe({
+  subscriptionRef.current = observable.subscribe({
     next(value: any) {
       return pushValue(value);
     },

--- a/packages/utils/src/observableToAsyncIterable.ts
+++ b/packages/utils/src/observableToAsyncIterable.ts
@@ -24,7 +24,6 @@ export function observableToAsyncIterable<T>(observable: Observable<T>): AsyncIt
   const emptyQueue = () => {
     if (listening) {
       listening = false;
-      // subscribe() may call complete() synchronously before returning the subscription
       subscriptionRef.current?.unsubscribe();
       for (const resolve of pullQueue) {
         resolve({ value: undefined, done: true });
@@ -55,11 +54,11 @@ export function observableToAsyncIterable<T>(observable: Observable<T>): AsyncIt
   const pushDone = () => {
     if (pullQueue.length !== 0) {
       // It is safe to use the ! operator here as we check the length.
-      pullQueue.shift()!({ done: true });
+      pullQueue.shift()!({ value: undefined, done: true });
       // Release queues/subscription after signaling done to the pending consumer.
       emptyQueue();
     } else {
-      pushQueue.push({ done: true });
+      pushQueue.push({ value: undefined, done: true });
     }
   };
 
@@ -89,6 +88,12 @@ export function observableToAsyncIterable<T>(observable: Observable<T>): AsyncIt
       return pushDone();
     },
   });
+
+  // complete() may run synchronously inside subscribe() before it returns;
+  // unsubscribe the returned subscription in that case.
+  if (!listening) {
+    subscriptionRef.current.unsubscribe();
+  }
 
   return {
     next() {

--- a/packages/utils/tests/observableToAsyncIterable.spec.ts
+++ b/packages/utils/tests/observableToAsyncIterable.spec.ts
@@ -11,4 +11,45 @@ describe('observableToAsyncIterable', () => {
 
     return iterator.next().then(result => expect(result.done).toEqual(true));
   });
+
+  test('unsubscribes and clears queues when done is pulled from pushQueue', async () => {
+    let unsubscribed = false;
+    const iterator = observableToAsyncIterable({
+      subscribe: observer => {
+        observer.next(1);
+        observer.complete();
+        return {
+          unsubscribe: () => {
+            unsubscribed = true;
+          },
+        };
+      },
+    });
+
+    await expect(iterator.next()).resolves.toEqual({ value: 1, done: false });
+    await expect(iterator.next()).resolves.toEqual({ done: true });
+    expect(unsubscribed).toBe(true);
+    // Further pulls should stay done without hanging
+    await expect(iterator.next()).resolves.toEqual({ value: undefined, done: true });
+  });
+
+  test('unsubscribes when complete() resolves a pending pull', async () => {
+    let unsubscribed = false;
+    let observerRef: { complete: () => void } | undefined;
+    const iterator = observableToAsyncIterable({
+      subscribe: observer => {
+        observerRef = observer;
+        return {
+          unsubscribe: () => {
+            unsubscribed = true;
+          },
+        };
+      },
+    });
+
+    const pending = iterator.next();
+    observerRef!.complete();
+    await expect(pending).resolves.toEqual({ done: true });
+    expect(unsubscribed).toBe(true);
+  });
 });

--- a/packages/utils/tests/observableToAsyncIterable.spec.ts
+++ b/packages/utils/tests/observableToAsyncIterable.spec.ts
@@ -1,7 +1,7 @@
 import { observableToAsyncIterable } from '@graphql-tools/utils';
 
 describe('observableToAsyncIterable', () => {
-  test('finalize iterator when complete() is called on observer', () => {
+  test('finalize iterator when complete() is called on observer', async () => {
     const iterator = observableToAsyncIterable({
       subscribe: observer => {
         observer.complete();
@@ -9,7 +9,8 @@ describe('observableToAsyncIterable', () => {
       },
     });
 
-    return iterator.next().then(result => expect(result.done).toEqual(true));
+    const result = await iterator.next();
+    expect(result.done).toEqual(true);
   });
 
   test('unsubscribes and clears queues when done is pulled from pushQueue', async () => {
@@ -26,11 +27,11 @@ describe('observableToAsyncIterable', () => {
       },
     });
 
-    await expect(iterator.next()).resolves.toEqual({ value: 1, done: false });
-    await expect(iterator.next()).resolves.toEqual({ done: true });
+    expect(await iterator.next()).toEqual({ value: 1, done: false });
+    expect(await iterator.next()).toEqual({ value: undefined, done: true });
     expect(unsubscribed).toBe(true);
     // Further pulls should stay done without hanging
-    await expect(iterator.next()).resolves.toEqual({ value: undefined, done: true });
+    expect(await iterator.next()).toEqual({ value: undefined, done: true });
   });
 
   test('unsubscribes when complete() resolves a pending pull', async () => {
@@ -49,7 +50,26 @@ describe('observableToAsyncIterable', () => {
 
     const pending = iterator.next();
     observerRef!.complete();
-    await expect(pending).resolves.toEqual({ done: true });
+    expect(await pending).toEqual({ value: undefined, done: true });
+    expect(unsubscribed).toBe(true);
+  });
+
+  test('unsubscribes when complete() runs synchronously during subscribe', async () => {
+    let unsubscribed = false;
+    const iterator = observableToAsyncIterable({
+      subscribe: observer => {
+        observer.complete();
+        return {
+          unsubscribe: () => {
+            unsubscribed = true;
+          },
+        };
+      },
+    });
+
+    expect(await iterator.next()).toEqual({ value: undefined, done: true });
+    // return() after sync complete should still have unsubscribed the subscription
+    await iterator.return!();
     expect(unsubscribed).toBe(true);
   });
 });

--- a/packages/utils/tests/print-schema-with-directives.spec.ts
+++ b/packages/utils/tests/print-schema-with-directives.spec.ts
@@ -317,6 +317,7 @@ describe('printSchemaWithDirectives', () => {
     `);
 
     const queryType = schema.getQueryType()!;
+    const fooField = queryType.getFields()['foo'];
     const transformedSchema = new GraphQLSchema({
       ...schema.toConfig(),
       types: undefined,
@@ -325,7 +326,7 @@ describe('printSchemaWithDirectives', () => {
         description: 'New type',
         fields: {
           foo: {
-            ...queryType.getFields()['foo'],
+            ...fooField.toConfig(),
             description: 'New field',
           },
         },

--- a/packages/utils/tests/print-schema-with-directives.spec.ts
+++ b/packages/utils/tests/print-schema-with-directives.spec.ts
@@ -318,16 +318,17 @@ describe('printSchemaWithDirectives', () => {
 
     const queryType = schema.getQueryType()!;
     const fooField = queryType.getFields()['foo'];
+    // Keep original astNodes (stale descriptions) while overriding runtime descriptions.
     const transformedSchema = new GraphQLSchema({
-      ...schema.toConfig(),
-      types: undefined,
       query: new GraphQLObjectType({
-        ...queryType.toConfig(),
+        name: 'Query',
         description: 'New type',
+        astNode: queryType.astNode,
         fields: {
           foo: {
-            ...fooField.toConfig(),
+            type: fooField.type,
             description: 'New field',
+            astNode: fooField.astNode,
           },
         },
       }),

--- a/packages/utils/tests/print-schema-with-directives.spec.ts
+++ b/packages/utils/tests/print-schema-with-directives.spec.ts
@@ -302,6 +302,43 @@ describe('printSchemaWithDirectives', () => {
     expect(output).toContain('Test Query Comment');
     expect(output).toContain('Test Field Comment');
   });
+
+  it('prefers runtime descriptions over stale astNode descriptions (#5508)', () => {
+    const schema = buildSchema(/* GraphQL */ `
+      """
+      Old type
+      """
+      type Query {
+        """
+        Old field
+        """
+        foo: String
+      }
+    `);
+
+    const queryType = schema.getQueryType()!;
+    const transformedSchema = new GraphQLSchema({
+      ...schema.toConfig(),
+      types: undefined,
+      query: new GraphQLObjectType({
+        ...queryType.toConfig(),
+        description: 'New type',
+        fields: {
+          foo: {
+            ...queryType.getFields()['foo'],
+            description: 'New field',
+          },
+        },
+      }),
+    });
+
+    const output = printSchemaWithDirectives(transformedSchema);
+    expect(output).toContain('New type');
+    expect(output).toContain('New field');
+    expect(output).not.toContain('Old type');
+    expect(output).not.toContain('Old field');
+  });
+
   it('should print transformed schema correctly', () => {
     const printedSchema = /* GraphQL */ `
       type Foo {


### PR DESCRIPTION
## Summary
- **#7406**: Always wrap loader failures in AggregateError with “Failed to find any GraphQL type definitions” context, even when there is only one error.
- **#8057**: Clean up `observableToAsyncIterable` (unsubscribe + clear queues) when the observable completes / done is delivered.
- **#5508**: Prefer runtime `description` over stale `astNode` descriptions in `getDescriptionNode` / `printSchemaWithDirectives`.
- **#5454**: Switch graphql-tag-pluck to Babel `importAttributes` (with `deprecatedAssertSyntax` so existing `assert { … }` still works).
- **#5243**: Parse `git ls-tree` output correctly on Windows and keep leading `./` resolveGlobs behavior.

Closes #7406
Closes #5508
Closes #5454
Closes #5243
Closes #8057

## Test plan
- [x] `observableToAsyncIterable` unit tests (incl. unsubscribe-on-done)
- [x] load-file AggregateError context tests
- [x] printSchemaWithDirectives runtime description test
- [x] git-loader leading `./` resolveGlobs / load tests
- [x] graphql-tag-pluck suite (incl. `assert` import test)