### PR TITLE
chore: use HTTPS repository metadata across packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Useful tools to create and manipulate GraphQL schemas.",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools"
+    "url": "git+https://github.com/ardatan/graphql-tools.git"
   },
   "homepage": "https://github.com/ardatan/graphql-tools#readme",
   "bugs": {

--- a/packages/documents/package.json
+++ b/packages/documents/package.json
@@ -5,7 +5,7 @@
   "description": "Utilities for GraphQL documents.",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/documents"
   },
   "license": "MIT",

--- a/packages/executor/package.json
+++ b/packages/executor/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/executor"
   },
   "author": "Saihajpreet Singh <saihajpreet.singh@gmail.com>",

--- a/packages/executors/apollo-link/package.json
+++ b/packages/executors/apollo-link/package.json
@@ -5,7 +5,7 @@
   "description": "A set of utils for faster development of GraphQL tools",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/executors/apollo-link"
   },
   "author": "Arda TANRIKULU <ardatanrikulu@gmail.com>",

--- a/packages/executors/envelop/package.json
+++ b/packages/executors/envelop/package.json
@@ -5,7 +5,7 @@
   "description": "A set of utils for faster development of GraphQL tools",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/executors/envelop"
   },
   "author": "Arda TANRIKULU <ardatanrikulu@gmail.com>",

--- a/packages/executors/legacy-ws/package.json
+++ b/packages/executors/legacy-ws/package.json
@@ -5,7 +5,7 @@
   "description": "A set of utils for faster development of GraphQL tools",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/executors/legacy-ws"
   },
   "author": "Arda TANRIKULU <ardatanrikulu@gmail.com>",

--- a/packages/executors/urql-exchange/package.json
+++ b/packages/executors/urql-exchange/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/executors/urql-exchange"
   },
   "author": "Arda TANRIKULU <ardatanrikulu@gmail.com>",

--- a/packages/executors/yoga/package.json
+++ b/packages/executors/yoga/package.json
@@ -5,7 +5,7 @@
   "description": "A set of utils for faster development of GraphQL tools",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/executors/yoga"
   },
   "author": "Arda TANRIKULU <ardatanrikulu@gmail.com>",

--- a/packages/graphql-tag-pluck/package.json
+++ b/packages/graphql-tag-pluck/package.json
@@ -5,7 +5,7 @@
   "description": "Pluck graphql-tag template literals",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/graphql-tag-pluck"
   },
   "license": "MIT",

--- a/packages/graphql-tools/package.json
+++ b/packages/graphql-tools/package.json
@@ -5,7 +5,7 @@
   "description": "Useful tools to create and manipulate GraphQL schemas.",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/graphql-tools"
   },
   "license": "MIT",

--- a/packages/import/package.json
+++ b/packages/import/package.json
@@ -5,7 +5,7 @@
   "description": "A set of utils for faster development of GraphQL tools",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/import"
   },
   "author": "Dotan Simha <dotansimha@gmail.com>",

--- a/packages/inspect/package.json
+++ b/packages/inspect/package.json
@@ -5,7 +5,7 @@
   "description": "Cross platform implementation of Node's util.inspect",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/inspect"
   },
   "author": "Arda TANRIKULU <ardatanrikulu@gmail.com>",

--- a/packages/jest-transform/package.json
+++ b/packages/jest-transform/package.json
@@ -5,7 +5,7 @@
   "description": "Jest Plugin to load and parse imported GraphQL files",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/jest-transform"
   },
   "license": "MIT",

--- a/packages/links/package.json
+++ b/packages/links/package.json
@@ -5,7 +5,7 @@
   "description": "A set of utils for faster development of GraphQL tools",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/links"
   },
   "license": "MIT",

--- a/packages/load-files/package.json
+++ b/packages/load-files/package.json
@@ -5,7 +5,7 @@
   "description": "A set of utils for faster development of GraphQL tools",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/load-files"
   },
   "author": "Dotan Simha <dotansimha@gmail.com>",

--- a/packages/load/package.json
+++ b/packages/load/package.json
@@ -5,7 +5,7 @@
   "description": "A set of utils for faster development of GraphQL tools",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/load"
   },
   "author": "Dotan Simha <dotansimha@gmail.com>",

--- a/packages/loaders/apollo-engine/package.json
+++ b/packages/loaders/apollo-engine/package.json
@@ -5,7 +5,7 @@
   "description": "A set of utils for faster development of GraphQL tools",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/loaders/apollo-engine"
   },
   "author": "Dotan Simha <dotansimha@gmail.com>",

--- a/packages/loaders/code-file/package.json
+++ b/packages/loaders/code-file/package.json
@@ -5,7 +5,7 @@
   "description": "A set of utils for faster development of GraphQL tools",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/loaders/code-file"
   },
   "author": "Dotan Simha <dotansimha@gmail.com>",

--- a/packages/loaders/git/package.json
+++ b/packages/loaders/git/package.json
@@ -5,7 +5,7 @@
   "description": "A set of utils for faster development of GraphQL tools",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/loaders/git"
   },
   "author": "Dotan Simha <dotansimha@gmail.com>",

--- a/packages/loaders/github/package.json
+++ b/packages/loaders/github/package.json
@@ -5,7 +5,7 @@
   "description": "A set of utils for faster development of GraphQL tools",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/loaders/github"
   },
   "author": "Dotan Simha <dotansimha@gmail.com>",

--- a/packages/loaders/graphql-file/package.json
+++ b/packages/loaders/graphql-file/package.json
@@ -5,7 +5,7 @@
   "description": "A set of utils for faster development of GraphQL tools",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/loaders/graphql-file"
   },
   "author": "Dotan Simha <dotansimha@gmail.com>",

--- a/packages/loaders/json-file/package.json
+++ b/packages/loaders/json-file/package.json
@@ -5,7 +5,7 @@
   "description": "A set of utils for faster development of GraphQL tools",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/loaders/json-file"
   },
   "author": "Dotan Simha <dotansimha@gmail.com>",

--- a/packages/loaders/module/package.json
+++ b/packages/loaders/module/package.json
@@ -5,7 +5,7 @@
   "description": "A set of utils for faster development of GraphQL tools",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/loaders/module"
   },
   "author": "Dotan Simha <dotansimha@gmail.com>",

--- a/packages/loaders/url/package.json
+++ b/packages/loaders/url/package.json
@@ -5,7 +5,7 @@
   "description": "A set of utils for faster development of GraphQL tools",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/loaders/url"
   },
   "author": "Dotan Simha <dotansimha@gmail.com>",

--- a/packages/merge/package.json
+++ b/packages/merge/package.json
@@ -5,7 +5,7 @@
   "description": "A set of utils for faster development of GraphQL tools",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/merge"
   },
   "author": "Dotan Simha <dotansimha@gmail.com>",

--- a/packages/mock/package.json
+++ b/packages/mock/package.json
@@ -5,7 +5,7 @@
   "description": "A set of utils for faster development of GraphQL tools",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/mock"
   },
   "license": "MIT",

--- a/packages/node-require/package.json
+++ b/packages/node-require/package.json
@@ -5,7 +5,7 @@
   "description": "A set of utils for faster development of GraphQL tools",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/node-require"
   },
   "license": "MIT",

--- a/packages/optimize/package.json
+++ b/packages/optimize/package.json
@@ -5,7 +5,7 @@
   "description": "A set of utils for faster development of GraphQL tools",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/optimize"
   },
   "license": "MIT",

--- a/packages/relay-compiler/package.json
+++ b/packages/relay-compiler/package.json
@@ -4,7 +4,7 @@
   "description": "Fork of `relay-compiler`",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/relay-compiler"
   },
   "homepage": "https://relay.dev",

--- a/packages/relay-operation-optimizer/package.json
+++ b/packages/relay-operation-optimizer/package.json
@@ -5,7 +5,7 @@
   "description": "Package for optimizing your GraphQL operations relay style.",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/relay-operation-optimizer"
   },
   "author": {

--- a/packages/resolvers-composition/package.json
+++ b/packages/resolvers-composition/package.json
@@ -5,7 +5,7 @@
   "description": "Common package containing utils and types for GraphQL tools",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/resolvers-composition"
   },
   "author": "Dotan Simha <dotansimha@gmail.com>",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -5,7 +5,7 @@
   "description": "A set of utils for faster development of GraphQL tools",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/schema"
   },
   "license": "MIT",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -5,7 +5,7 @@
   "description": "Common package containing utils and types for GraphQL tools",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/utils"
   },
   "author": "Dotan Simha <dotansimha@gmail.com>",

--- a/packages/webpack-loader-runtime/package.json
+++ b/packages/webpack-loader-runtime/package.json
@@ -5,7 +5,7 @@
   "description": "A set of utils for GraphQL Webpack Loader",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/webpack-loader-runtime"
   },
   "license": "MIT",

--- a/packages/webpack-loader/package.json
+++ b/packages/webpack-loader/package.json
@@ -5,7 +5,7 @@
   "description": "A set of utils for faster development of GraphQL tools",
   "repository": {
     "type": "git",
-    "url": "ardatan/graphql-tools",
+    "url": "git+https://github.com/ardatan/graphql-tools.git",
     "directory": "packages/webpack-loader"
   },
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Keep the HTTPS git URL form from #8247 (`git+https://github.com/ardatan/graphql-tools.git`)
- Apply it to every package that still used the `ardatan/graphql-tools` shorthand