### PR TITLE
fix(import): union interfaces, require: paths, comments, webpack esModule

### DIFF
--- a/.changeset/import-anywhere-and-spaced-default.md
+++ b/.changeset/import-anywhere-and-spaced-default.md
@@ -1,0 +1,6 @@
+---
+'@graphql-tools/graphql-file-loader': patch
+'@graphql-tools/import': patch
+---
+
+`# import "./file.graphql"` (space after `#`) is a valid default import, and `#import` is processed even when it is not the first non-blank line of the file.

--- a/.changeset/import-preserve-comments.md
+++ b/.changeset/import-preserve-comments.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/import': patch
+---
+
+Keep leading GraphQL comments (for example `# eslint-disable-next-line` above a query) when `#import` merges documents. Previously `processImport` reprinted definitions and dropped those comments from the merged source.

--- a/.changeset/import-require-prefix.md
+++ b/.changeset/import-require-prefix.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/import': minor
+---
+
+`# import` paths may use a `require:` prefix, resolved with Node's `require.resolve` from the importing file. Example: `# import Post from "require:blog-graphql-types/schema.graphql"` or `# import A from "require:./a.graphql"`.

--- a/.changeset/import-star-federation-key.md
+++ b/.changeset/import-star-federation-key.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/import': patch
+---
+
+`# import *` keeps unreferenced types that carry a federation `@key` (subgraph entities). Other unused types are still tree-shaken, matching existing `import *` tests.

--- a/.changeset/import-union-interfaces.md
+++ b/.changeset/import-union-interfaces.md
@@ -2,4 +2,18 @@
 '@graphql-tools/import': patch
 ---
 
-Pull implemented interfaces (and their transitive dependencies) when a named import only references a union of those implementers. Fixes #3797.
+Named `# import` of a type no longer drops interfaces implemented by union members.
+
+Before this, a file like:
+
+```graphql
+# import Foo from "./types.graphql"
+
+type Query {
+  foo: Foo
+}
+```
+
+with `types.graphql` containing `type Foo { pet: Pet }`, `union Pet = Cat | Dog`, and `type Cat implements Animal` built an invalid schema (`Unknown type "Animal"`). `Cat` and `Dog` were pulled in through the union, but `Animal` was not.
+
+Forward dependencies (fields, `implements`, union members) are now closed transitively. Reverse implementers are still attached only when the interface itself is the import, so `# import Query.posts` does not pull every other `Query` field.

--- a/.changeset/import-union-interfaces.md
+++ b/.changeset/import-union-interfaces.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/import': patch
+---
+
+Pull implemented interfaces (and their transitive dependencies) when a named import only references a union of those implementers. Fixes #3797.

--- a/.changeset/webpack-loader-esmodule-imports.md
+++ b/.changeset/webpack-loader-esmodule-imports.md
@@ -1,0 +1,6 @@
+---
+'@graphql-tools/webpack-loader': patch
+'@graphql-tools/webpack-loader-runtime': patch
+---
+
+With `esModule: true`, `#import` of another `.graphql` file now uses `require(...).default`, matching the loader's `export default`. `unique()` also treats a missing `definitions` array as empty so unused imports do not throw.

--- a/packages/import/src/index.ts
+++ b/packages/import/src/index.ts
@@ -1,4 +1,5 @@
 import { readFileSync, realpathSync } from 'fs';
+import { createRequire } from 'module';
 import { dirname, isAbsolute, join } from 'path';
 import {
   DefinitionNode,
@@ -39,7 +40,7 @@ import {
   UnionTypeExtensionNode,
 } from 'graphql';
 import resolveFrom from 'resolve-from';
-import { createGraphQLError, parseGraphQLSDL } from '@graphql-tools/utils';
+import { createGraphQLError, getLeadingCommentBlock, parseGraphQLSDL } from '@graphql-tools/utils';
 import { extractLinkImplementations } from './link/index.js';
 
 const builtinTypes = ['String', 'Float', 'Int', 'Boolean', 'ID', 'Upload'];
@@ -149,23 +150,20 @@ export function processImport(
   );
   const definitionStrSet = new Set<string>();
   let definitionsStr = '';
-  // A single definition node can appear in many of the dependency sets in
-  // `set` — any widely-referenced type is pulled in by every definition that
-  // depends on it — so without memoization `print` runs O(n²) times for n
-  // unique nodes. Printing is the dominant cost for large, densely-connected
-  // schemas, so cache the result per node identity. `print` is a pure function
-  // of its node, so this is output-identical.
-  const printCache = new Map<DefinitionNode, string>();
+  const printCache = new Map<DefinitionNode, { identity: string; withComments: string }>();
   for (const defs of set.values()) {
     for (const def of defs) {
-      let defStr = printCache.get(def);
-      if (defStr === undefined) {
-        defStr = print(def);
-        printCache.set(def, defStr);
+      let cached = printCache.get(def);
+      if (cached === undefined) {
+        cached = {
+          identity: print(def),
+          withComments: printDefinitionWithLeadingComments(def),
+        };
+        printCache.set(def, cached);
       }
-      if (!definitionStrSet.has(defStr)) {
-        definitionStrSet.add(defStr);
-        definitionsStr += defStr + '\n';
+      if (!definitionStrSet.has(cached.identity)) {
+        definitionStrSet.add(cached.identity);
+        definitionsStr += cached.withComments + '\n';
       }
     }
   }
@@ -196,9 +194,13 @@ function visitFile(
   pathAliases?: PathAliases,
 ): Map<string, Set<DefinitionNode>> {
   if (!(filePath in predefinedImports)) {
-    filePath = applyPathAliases(filePath, pathAliases);
-    if (!isAbsolute(filePath)) {
-      filePath = resolveFilePath(cwd, filePath);
+    if (filePath.startsWith('require:')) {
+      filePath = createRequire(cwd).resolve(filePath.slice('require:'.length));
+    } else {
+      filePath = applyPathAliases(filePath, pathAliases);
+      if (!isAbsolute(filePath)) {
+        filePath = resolveFilePath(cwd, filePath);
+      }
     }
   }
   if (!visitedFiles.has(filePath)) {
@@ -807,6 +809,18 @@ export function parseImportLine(importLine: string): { imports: string[]; from: 
     You can only have 'import' statements in the following pattern;
     # import [Type].[Field] from [File]
   `);
+}
+
+function printDefinitionWithLeadingComments(def: DefinitionNode): string {
+  const printed = print(def);
+  const commentBlock = getLeadingCommentBlock(def);
+  if (commentBlock == null || commentBlock.length === 0) {
+    return printed;
+  }
+  return `${commentBlock
+    .split('\n')
+    .map(line => (line.startsWith(' ') ? `#${line}` : `# ${line}`))
+    .join('\n')}\n${printed}`;
 }
 
 function resolveFilePath(filePath: string, importFrom: string): string {

--- a/packages/import/src/index.ts
+++ b/packages/import/src/index.ts
@@ -594,32 +594,87 @@ function visitDefinition(
   }
 }
 
-function getFileDefinitionMap(
+function collectReverseInterfaceDependencies(
   definitionsByName: Map<string, Set<DefinitionNode>>,
-  dependenciesByDefinitionName: DependenciesByDefinitionName,
-): Map<string, Set<DefinitionNode>> {
-  const fileDefinitionMap = new Map<string, Set<DefinitionNode>>();
+): Map<string, Set<string>> {
+  const reverseDependencies = new Map<string, Set<string>>();
+  const addReverse = (interfaceName: string, dependencyName: string) => {
+    let set = reverseDependencies.get(interfaceName);
+    if (set == null) {
+      set = new Set();
+      reverseDependencies.set(interfaceName, set);
+    }
+    set.add(dependencyName);
+  };
 
   for (const [definitionName, definitions] of definitionsByName) {
-    let definitionsWithDependencies = fileDefinitionMap.get(definitionName);
-    if (definitionsWithDependencies == null) {
-      definitionsWithDependencies = new Set();
-      fileDefinitionMap.set(definitionName, definitionsWithDependencies);
+    if (definitionName.includes('.')) {
+      continue;
     }
     for (const definition of definitions) {
-      definitionsWithDependencies.add(definition);
-    }
-    const dependenciesOfDefinition = dependenciesByDefinitionName.get(definitionName);
-    if (dependenciesOfDefinition) {
-      for (const dependencyName of dependenciesOfDefinition.keys()) {
-        const dependencyDefinitions = definitionsByName.get(dependencyName);
-        if (dependencyDefinitions != null) {
-          for (const dependencyDefinition of dependencyDefinitions) {
-            definitionsWithDependencies.add(dependencyDefinition);
+      if (!('interfaces' in definition) || !definition.interfaces) {
+        continue;
+      }
+      const interfaceNames = definition.interfaces.map(
+        (namedTypeNode: NamedTypeNode) => namedTypeNode.name.value,
+      );
+      for (const interfaceName of interfaceNames) {
+        addReverse(interfaceName, definitionName);
+        for (const siblingName of interfaceNames) {
+          if (siblingName !== interfaceName) {
+            addReverse(interfaceName, siblingName);
           }
         }
       }
     }
+  }
+
+  return reverseDependencies;
+}
+
+function getFileDefinitionMap(
+  definitionsByName: Map<string, Set<DefinitionNode>>,
+  dependenciesByDefinitionName: DependenciesByDefinitionName,
+): Map<string, Set<DefinitionNode>> {
+  const reverseInterfaceDependencies = collectReverseInterfaceDependencies(definitionsByName);
+  const fileDefinitionMap = new Map<string, Set<DefinitionNode>>();
+
+  for (const [definitionName, definitions] of definitionsByName) {
+    const definitionsWithDependencies = new Set<DefinitionNode>(definitions);
+    const pending: string[] = [];
+    const seenNames = new Set<string>([definitionName]);
+
+    const enqueueDependencies = (name: string, includeReverse: boolean) => {
+      const dependenciesOfDefinition = dependenciesByDefinitionName.get(name);
+      if (dependenciesOfDefinition == null) {
+        return;
+      }
+      const reverseNames = reverseInterfaceDependencies.get(name);
+      for (const dependencyName of dependenciesOfDefinition.keys()) {
+        if (!includeReverse && reverseNames?.has(dependencyName)) {
+          continue;
+        }
+        pending.push(dependencyName);
+      }
+    };
+
+    enqueueDependencies(definitionName, true);
+    while (pending.length > 0) {
+      const dependencyName = pending.pop()!;
+      if (seenNames.has(dependencyName)) {
+        continue;
+      }
+      seenNames.add(dependencyName);
+      const dependencyDefinitions = definitionsByName.get(dependencyName);
+      if (dependencyDefinitions != null) {
+        for (const dependencyDefinition of dependencyDefinitions) {
+          definitionsWithDependencies.add(dependencyDefinition);
+        }
+      }
+      enqueueDependencies(dependencyName, false);
+    }
+
+    fileDefinitionMap.set(definitionName, definitionsWithDependencies);
   }
 
   return fileDefinitionMap;

--- a/packages/import/src/index.ts
+++ b/packages/import/src/index.ts
@@ -639,43 +639,50 @@ function getFileDefinitionMap(
   dependenciesByDefinitionName: DependenciesByDefinitionName,
 ): Map<string, Set<DefinitionNode>> {
   const reverseInterfaceDependencies = collectReverseInterfaceDependencies(definitionsByName);
-  const fileDefinitionMap = new Map<string, Set<DefinitionNode>>();
 
+  // One forward-only fixpoint for the whole file so field-level keys
+  // (`Type.field`) reuse the same closures instead of repeating BFS.
+  const forwardClosure = new Map<string, Set<DefinitionNode>>();
   for (const [definitionName, definitions] of definitionsByName) {
-    const definitionsWithDependencies = new Set<DefinitionNode>(definitions);
-    const pending: string[] = [];
-    const seenNames = new Set<string>([definitionName]);
-
-    const enqueueDependencies = (name: string, includeReverse: boolean) => {
-      const dependenciesOfDefinition = dependenciesByDefinitionName.get(name);
+    forwardClosure.set(definitionName, new Set(definitions));
+  }
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const [definitionName, definitions] of forwardClosure) {
+      const dependenciesOfDefinition = dependenciesByDefinitionName.get(definitionName);
       if (dependenciesOfDefinition == null) {
-        return;
-      }
-      const reverseNames = reverseInterfaceDependencies.get(name);
-      for (const dependencyName of dependenciesOfDefinition.keys()) {
-        if (!includeReverse && reverseNames?.has(dependencyName)) {
-          continue;
-        }
-        pending.push(dependencyName);
-      }
-    };
-
-    enqueueDependencies(definitionName, true);
-    while (pending.length > 0) {
-      const dependencyName = pending.pop()!;
-      if (seenNames.has(dependencyName)) {
         continue;
       }
-      seenNames.add(dependencyName);
-      const dependencyDefinitions = definitionsByName.get(dependencyName);
-      if (dependencyDefinitions != null) {
-        for (const dependencyDefinition of dependencyDefinitions) {
-          definitionsWithDependencies.add(dependencyDefinition);
+      for (const dependencyName of dependenciesOfDefinition.keys()) {
+        const nested = forwardClosure.get(dependencyName);
+        if (nested == null) {
+          continue;
+        }
+        for (const nestedDefinition of nested) {
+          if (!definitions.has(nestedDefinition)) {
+            definitions.add(nestedDefinition);
+            changed = true;
+          }
         }
       }
-      enqueueDependencies(dependencyName, false);
     }
+  }
 
+  const fileDefinitionMap = new Map<string, Set<DefinitionNode>>();
+  for (const [definitionName, forwardDefinitions] of forwardClosure) {
+    const definitionsWithDependencies = new Set(forwardDefinitions);
+    const reverseNames = reverseInterfaceDependencies.get(definitionName);
+    if (reverseNames) {
+      for (const implementerName of reverseNames) {
+        const implementerForward = forwardClosure.get(implementerName);
+        if (implementerForward) {
+          for (const definition of implementerForward) {
+            definitionsWithDependencies.add(definition);
+          }
+        }
+      }
+    }
     fileDefinitionMap.set(definitionName, definitionsWithDependencies);
   }
 
@@ -763,7 +770,7 @@ export function extractImportLines(fileContent: string): {
   let otherLines = '';
   for (const line of fileContent.split('\n')) {
     const trimmedLine = line.trim();
-    if (trimmedLine.startsWith('#import ') || trimmedLine.startsWith('# import ')) {
+    if (/^#\s*import\s+/.test(trimmedLine)) {
       importLines.push(trimmedLine);
     } else if (trimmedLine) {
       otherLines += line + '\n';
@@ -779,6 +786,7 @@ export function extractImportLines(fileContent: string): {
  * Throws if the import line does not have a correct format.
  */
 export function parseImportLine(importLine: string): { imports: string[]; from: string } {
+  importLine = importLine.trim();
   let regexMatch = importLine.match(IMPORT_FROM_REGEX);
   if (regexMatch != null) {
     // Apply regex to import line
@@ -958,29 +966,11 @@ function visitFragmentDefinitionNode(node: FragmentDefinitionNode, dependencySet
 }
 
 function addInterfaceDependencies(
-  node: any,
+  node: { name: NameNode; interfaces?: readonly NamedTypeNode[] },
   dependencySet: DependencySet,
-  dependenciesByDefinitionName: DependenciesByDefinitionName,
 ) {
-  // all interfaces should be dependent to each other
-  const allDependencies = [
-    node.name,
-    ...((node as any).interfaces?.map((namedTypeNode: NamedTypeNode) => namedTypeNode.name) || []),
-  ];
-  (node as any).interfaces?.forEach((namedTypeNode: NamedTypeNode) => {
+  node.interfaces?.forEach(namedTypeNode => {
     visitNamedTypeNode(namedTypeNode, dependencySet);
-    const interfaceName = namedTypeNode.name.value;
-    let set = dependenciesByDefinitionName.get(interfaceName);
-    // interface should be dependent to the type as well
-    if (set == null) {
-      set = new Map();
-      dependenciesByDefinitionName.set(interfaceName, set);
-    }
-    allDependencies.forEach(dependency => {
-      if (dependency.value !== interfaceName) {
-        addToDependencySet(set!, dependency);
-      }
-    });
   });
 }
 
@@ -994,7 +984,7 @@ function visitObjectTypeDefinitionNode(
   node.fields?.forEach(fieldDefinitionNode =>
     visitFieldDefinitionNode(fieldDefinitionNode, dependencySet, dependenciesByDefinitionName),
   );
-  addInterfaceDependencies(node, dependencySet, dependenciesByDefinitionName);
+  addInterfaceDependencies(node, dependencySet);
 }
 
 function visitDirectiveNode(node: DirectiveNode, dependencySet: DependencySet) {
@@ -1080,7 +1070,7 @@ function visitInterfaceTypeDefinitionNode(
   node.fields?.forEach(fieldDefinitionNode =>
     visitFieldDefinitionNode(fieldDefinitionNode, dependencySet, dependenciesByDefinitionName),
   );
-  addInterfaceDependencies(node, dependencySet, dependenciesByDefinitionName);
+  addInterfaceDependencies(node, dependencySet);
 }
 
 function visitUnionTypeDefinitionNode(node: UnionTypeDefinitionNode, dependencySet: DependencySet) {
@@ -1135,7 +1125,7 @@ function visitObjectTypeExtensionNode(
   node.fields?.forEach(fieldDefinitionNode =>
     visitFieldDefinitionNode(fieldDefinitionNode, dependencySet, dependenciesByDefinitionName),
   );
-  addInterfaceDependencies(node, dependencySet, dependenciesByDefinitionName);
+  addInterfaceDependencies(node, dependencySet);
 }
 
 function visitInterfaceTypeExtensionNode(
@@ -1148,7 +1138,7 @@ function visitInterfaceTypeExtensionNode(
   node.fields?.forEach(fieldDefinitionNode =>
     visitFieldDefinitionNode(fieldDefinitionNode, dependencySet, dependenciesByDefinitionName),
   );
-  addInterfaceDependencies(node, dependencySet, dependenciesByDefinitionName);
+  addInterfaceDependencies(node, dependencySet);
 }
 
 function visitUnionTypeExtensionNode(node: UnionTypeExtensionNode, dependencySet: DependencySet) {

--- a/packages/import/src/index.ts
+++ b/packages/import/src/index.ts
@@ -47,6 +47,8 @@ const builtinTypes = ['String', 'Float', 'Int', 'Boolean', 'ID', 'Upload'];
 
 const federationV1Directives = ['key', 'provides', 'requires', 'external'];
 
+const federationEntityDirectives = ['key', 'federation__key'];
+
 const builtinDirectives = [
   'deprecated',
   'skip',
@@ -218,13 +220,8 @@ function visitFile(
     // To prevent circular dependency
     visitedFiles.set(filePath, fileDefinitionMap);
 
-    const { allImportedDefinitionsMap, potentialTransitiveDefinitionsMap } = processImports(
-      importLines,
-      filePath,
-      visitedFiles,
-      predefinedImports,
-      pathAliases,
-    );
+    const { allImportedDefinitionsMap, potentialTransitiveDefinitionsMap, hasWildcardImport } =
+      processImports(importLines, filePath, visitedFiles, predefinedImports, pathAliases);
 
     // `visitedFiles.get(filePath)` is invariant for the duration of this call,
     // and `addDefinition` recurses across the entire dependency graph, so hoist
@@ -358,6 +355,9 @@ function visitFile(
               }
             }
           }
+        }
+        if (hasWildcardImport) {
+          addImportedFederationEntities(fileDefinitionMap, allImportedDefinitionsMap);
         }
       }
     }
@@ -698,9 +698,11 @@ export function processImports(
 ): {
   allImportedDefinitionsMap: Map<string, Set<DefinitionNode>>;
   potentialTransitiveDefinitionsMap: Map<string, Set<DefinitionNode>>;
+  hasWildcardImport: boolean;
 } {
   const potentialTransitiveDefinitionsMap = new Map<string, Set<DefinitionNode>>();
   const allImportedDefinitionsMap = new Map<string, Set<DefinitionNode>>();
+  let hasWildcardImport = false;
   for (const line of importLines) {
     const { imports, from } = parseImportLine(line.replace('#', '').trim());
     const importFileDefinitionMap = visitFile(
@@ -729,6 +731,7 @@ export function processImports(
     buildFullDefinitionMap(potentialTransitiveDefinitionsMap);
 
     if (imports.includes('*')) {
+      hasWildcardImport = true;
       buildFullDefinitionMap(allImportedDefinitionsMap);
     } else {
       for (let importedDefinitionName of imports) {
@@ -755,7 +758,38 @@ export function processImports(
       }
     }
   }
-  return { allImportedDefinitionsMap, potentialTransitiveDefinitionsMap };
+  return { allImportedDefinitionsMap, potentialTransitiveDefinitionsMap, hasWildcardImport };
+}
+
+function hasFederationEntityDirective(definition: DefinitionNode): boolean {
+  if (!('directives' in definition) || definition.directives == null) {
+    return false;
+  }
+  return definition.directives.some(directive =>
+    federationEntityDirectives.includes(directive.name.value),
+  );
+}
+
+function addImportedFederationEntities(
+  fileDefinitionMap: Map<string, Set<DefinitionNode>>,
+  allImportedDefinitionsMap: Map<string, Set<DefinitionNode>>,
+): void {
+  for (const [importedName, importedDefs] of allImportedDefinitionsMap) {
+    if (importedName.includes('.')) {
+      continue;
+    }
+    if (![...importedDefs].some(hasFederationEntityDirective)) {
+      continue;
+    }
+    let target = fileDefinitionMap.get(importedName);
+    if (target == null) {
+      target = new Set();
+      fileDefinitionMap.set(importedName, target);
+    }
+    for (const importedDefinition of importedDefs) {
+      target.add(importedDefinition);
+    }
+  }
 }
 
 /**

--- a/packages/import/src/index.ts
+++ b/packages/import/src/index.ts
@@ -802,15 +802,30 @@ export function extractImportLines(fileContent: string): {
 } {
   const importLines: string[] = [];
   let otherLines = '';
+  let inBlockString = false;
   for (const line of fileContent.split('\n')) {
     const trimmedLine = line.trim();
-    if (/^#\s*import\s+/.test(trimmedLine)) {
+    if (!inBlockString && /^#\s*import\s+/.test(trimmedLine)) {
       importLines.push(trimmedLine);
     } else if (trimmedLine) {
       otherLines += line + '\n';
     }
+    if (countTripleQuotes(line) % 2 === 1) {
+      inBlockString = !inBlockString;
+    }
   }
   return { importLines, otherLines };
+}
+
+function countTripleQuotes(line: string): number {
+  let count = 0;
+  for (let i = 0; i < line.length - 2; i++) {
+    if (line[i] === '"' && line[i + 1] === '"' && line[i + 2] === '"') {
+      count += 1;
+      i += 2;
+    }
+  }
+  return count;
 }
 
 /**

--- a/packages/import/src/index.ts
+++ b/packages/import/src/index.ts
@@ -837,29 +837,64 @@ export function extractImportLines(fileContent: string): {
   const importLines: string[] = [];
   let otherLines = '';
   let inBlockString = false;
+  let inString = false;
   for (const line of fileContent.split('\n')) {
     const trimmedLine = line.trim();
-    if (!inBlockString && /^#\s*import\s+/.test(trimmedLine)) {
+    if (!inBlockString && !inString && /^#\s*import\s+/.test(trimmedLine)) {
       importLines.push(trimmedLine);
     } else if (trimmedLine) {
       otherLines += line + '\n';
     }
-    if (countTripleQuotes(line) % 2 === 1) {
-      inBlockString = !inBlockString;
-    }
+    ({ inBlockString, inString } = advanceGraphQLStringState(line, inBlockString, inString));
   }
   return { importLines, otherLines };
 }
 
-function countTripleQuotes(line: string): number {
-  let count = 0;
-  for (let i = 0; i < line.length - 2; i++) {
-    if (line[i] === '"' && line[i + 1] === '"' && line[i + 2] === '"') {
-      count += 1;
-      i += 2;
+function advanceGraphQLStringState(
+  line: string,
+  inBlockString: boolean,
+  inString: boolean,
+): { inBlockString: boolean; inString: boolean } {
+  let i = 0;
+  while (i < line.length) {
+    if (inBlockString) {
+      if (line.startsWith('\\"""', i)) {
+        i += 4;
+        continue;
+      }
+      if (line.startsWith('"""', i)) {
+        inBlockString = false;
+        i += 3;
+        continue;
+      }
+      i += 1;
+      continue;
     }
+    if (inString) {
+      if (line[i] === '\\') {
+        i += 2;
+        continue;
+      }
+      if (line[i] === '"') {
+        inString = false;
+      }
+      i += 1;
+      continue;
+    }
+    if (line[i] === '#') {
+      break;
+    }
+    if (line.startsWith('"""', i)) {
+      inBlockString = true;
+      i += 3;
+      continue;
+    }
+    if (line[i] === '"') {
+      inString = true;
+    }
+    i += 1;
   }
-  return count;
+  return { inBlockString, inString };
 }
 
 /**
@@ -896,9 +931,12 @@ export function parseImportLine(importLine: string): { imports: string[]; from: 
   throw new Error(`
     Import statement is not valid:
     > ${importLine}
-    If you want to have comments starting with '# import', please use ''' instead!
-    You can only have 'import' statements in the following pattern;
-    # import [Type].[Field] from [File]
+    If you want comments that look like '# import', put them in a GraphQL block string (""").
+    Supported forms:
+    # import [Type].[Field] from "[File]"
+    # import [Type], [Type] from "[File]"
+    # import * from "[File]"
+    # import "[File]"
   `);
 }
 

--- a/packages/import/src/index.ts
+++ b/packages/import/src/index.ts
@@ -761,24 +761,58 @@ export function processImports(
   return { allImportedDefinitionsMap, potentialTransitiveDefinitionsMap, hasWildcardImport };
 }
 
-function hasFederationEntityDirective(definition: DefinitionNode): boolean {
+function collectFederationKeyDirectiveNames(
+  allImportedDefinitionsMap: Map<string, Set<DefinitionNode>>,
+): Set<string> {
+  const names = new Set(federationEntityDirectives);
+  const federationUrl = 'https://specs.apollo.dev/federation';
+  for (const importedDefs of allImportedDefinitionsMap.values()) {
+    for (const definition of importedDefs) {
+      if (definition.kind !== Kind.SCHEMA_DEFINITION && definition.kind !== Kind.SCHEMA_EXTENSION) {
+        continue;
+      }
+      const { matchesImplementation, resolveImportName } = extractLinkImplementations({
+        kind: Kind.DOCUMENT,
+        definitions: [definition],
+      });
+      if (!matchesImplementation(federationUrl, 'v2.0')) {
+        continue;
+      }
+      names.add(resolveImportName(federationUrl, '@key').replace(/^@/, ''));
+    }
+  }
+  return names;
+}
+
+function hasFederationEntityDirective(
+  definition: DefinitionNode,
+  keyDirectiveNames: Set<string>,
+): boolean {
+  if (!('name' in definition) || !definition.name) {
+    return false;
+  }
   if (!('directives' in definition) || definition.directives == null) {
     return false;
   }
-  return definition.directives.some(directive =>
-    federationEntityDirectives.includes(directive.name.value),
-  );
+  return definition.directives.some(directive => keyDirectiveNames.has(directive.name.value));
 }
 
 function addImportedFederationEntities(
   fileDefinitionMap: Map<string, Set<DefinitionNode>>,
   allImportedDefinitionsMap: Map<string, Set<DefinitionNode>>,
 ): void {
+  const keyDirectiveNames = collectFederationKeyDirectiveNames(allImportedDefinitionsMap);
   for (const [importedName, importedDefs] of allImportedDefinitionsMap) {
     if (importedName.includes('.')) {
       continue;
     }
-    if (![...importedDefs].some(hasFederationEntityDirective)) {
+    const isEntity = [...importedDefs].some(
+      definition =>
+        'name' in definition &&
+        definition.name?.value === importedName &&
+        hasFederationEntityDirective(definition, keyDirectiveNames),
+    );
+    if (!isEntity) {
       continue;
     }
     let target = fileDefinitionMap.get(importedName);

--- a/packages/import/tests/documents/import-documents.spec.ts
+++ b/packages/import/tests/documents/import-documents.spec.ts
@@ -28,6 +28,20 @@ describe('import in documents', () => {
     `);
   });
 
+  it('should keep leading comments on imported documents', () => {
+    const document = processImport('./import-test/default/with-comments.graphql', __dirname);
+    expect(document.loc?.source.body).toMatch(/#\s*eslint-disable-next-line/);
+    expect(print(document)).toBeSimilarGqlDoc(/* GraphQL */ `
+      query Foo {
+        ...BarFragment
+      }
+
+      fragment BarFragment on Bar {
+        baz
+      }
+    `);
+  });
+
   it('should get documents with specific imports properly', async () => {
     const document = importDocuments('./import-test/specific/a.graphql');
 

--- a/packages/import/tests/documents/import-test/default/with-comments.graphql
+++ b/packages/import/tests/documents/import-test/default/with-comments.graphql
@@ -1,0 +1,6 @@
+#import 'c.graphql'
+
+# eslint-disable-next-line
+query Foo {
+  ...BarFragment
+}

--- a/packages/import/tests/schema/fixtures/import-star-federation-key-alias/a.graphql
+++ b/packages/import/tests/schema/fixtures/import-star-federation-key-alias/a.graphql
@@ -1,0 +1,5 @@
+# import * from "./entities.graphql"
+
+interface GraphQLError {
+  message: String!
+}

--- a/packages/import/tests/schema/fixtures/import-star-federation-key-alias/entities.graphql
+++ b/packages/import/tests/schema/fixtures/import-star-federation-key-alias/entities.graphql
@@ -1,0 +1,14 @@
+extend schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(
+    url: "https://specs.apollo.dev/federation/v2.0"
+    import: [{ name: "@key", as: "@entityKey" }]
+  )
+
+type User @entityKey(fields: "id") {
+  id: ID!
+}
+
+type UnusedWithoutKey {
+  name: String
+}

--- a/packages/import/tests/schema/fixtures/import-star-federation-key/a.graphql
+++ b/packages/import/tests/schema/fixtures/import-star-federation-key/a.graphql
@@ -1,0 +1,5 @@
+# import * from "./entities.graphql"
+
+interface GraphQLError {
+  message: String!
+}

--- a/packages/import/tests/schema/fixtures/import-star-federation-key/entities.graphql
+++ b/packages/import/tests/schema/fixtures/import-star-federation-key/entities.graphql
@@ -1,0 +1,8 @@
+type PilatesInstructor @key(fields: "appointmentInstanceId") {
+  appointmentInstanceId: String!
+  firstName: String
+}
+
+type UnusedWithoutKey {
+  firstName: String
+}

--- a/packages/import/tests/schema/fixtures/import-star-federation-key/entities.graphql
+++ b/packages/import/tests/schema/fixtures/import-star-federation-key/entities.graphql
@@ -4,5 +4,5 @@ type PilatesInstructor @key(fields: "appointmentInstanceId") {
 }
 
 type UnusedWithoutKey {
-  firstName: String
+  instructor: PilatesInstructor
 }

--- a/packages/import/tests/schema/fixtures/interface-field-implementer/a.graphql
+++ b/packages/import/tests/schema/fixtures/interface-field-implementer/a.graphql
@@ -1,0 +1,5 @@
+# import Foo from "./b.graphql"
+
+type Query {
+  foo: Foo
+}

--- a/packages/import/tests/schema/fixtures/interface-field-implementer/b.graphql
+++ b/packages/import/tests/schema/fixtures/interface-field-implementer/b.graphql
@@ -1,0 +1,12 @@
+interface Animal {
+  favorite: Cat
+}
+
+type Cat implements Animal {
+  name: String
+  favorite: Cat
+}
+
+type Foo {
+  animal: Animal
+}

--- a/packages/import/tests/schema/fixtures/require-paths/a.graphql
+++ b/packages/import/tests/schema/fixtures/require-paths/a.graphql
@@ -1,0 +1,3 @@
+type A {
+  field: String
+}

--- a/packages/import/tests/schema/fixtures/require-paths/b.graphql
+++ b/packages/import/tests/schema/fixtures/require-paths/b.graphql
@@ -1,0 +1,5 @@
+# import A from "require:./a.graphql"
+
+type B {
+  a: A
+}

--- a/packages/import/tests/schema/fixtures/union-interfaces/a.graphql
+++ b/packages/import/tests/schema/fixtures/union-interfaces/a.graphql
@@ -1,0 +1,5 @@
+# import Foo from "b.graphql"
+
+type Query {
+  foo: Foo
+}

--- a/packages/import/tests/schema/fixtures/union-interfaces/b.graphql
+++ b/packages/import/tests/schema/fixtures/union-interfaces/b.graphql
@@ -1,0 +1,19 @@
+interface Animal {
+  legs: Int!
+}
+
+type Cat implements Animal {
+  color: String!
+  legs: Int!
+}
+
+type Dog implements Animal {
+  legs: Int!
+  type: String!
+}
+
+union Pet = Cat | Dog
+
+type Foo {
+  pet: Pet
+}

--- a/packages/import/tests/schema/fixtures/union-nested-interfaces/a.graphql
+++ b/packages/import/tests/schema/fixtures/union-nested-interfaces/a.graphql
@@ -1,0 +1,5 @@
+# import Foo from "./b.graphql"
+
+type Query {
+  foo: Foo
+}

--- a/packages/import/tests/schema/fixtures/union-nested-interfaces/b.graphql
+++ b/packages/import/tests/schema/fixtures/union-nested-interfaces/b.graphql
@@ -1,0 +1,24 @@
+interface I {
+  c4: ID
+}
+
+type C2 {
+  c2: C3
+}
+
+union C3 = C4 | C5
+
+type C4 implements I {
+  c4: ID
+}
+
+type C5 {
+  C5: ID
+}
+
+union Pet = C4 | C5
+
+type Foo {
+  pet: Pet
+  nested: C2
+}

--- a/packages/import/tests/schema/import-schema.spec.ts
+++ b/packages/import/tests/schema/import-schema.spec.ts
@@ -109,6 +109,13 @@ describe('importSchema', () => {
     });
   });
 
+  test('parseImportLine: default import with leading space (#3837)', () => {
+    expect(parseImportLine(` import "./ProfileForm.graphql"`)).toEqual({
+      imports: ['*'],
+      from: './ProfileForm.graphql',
+    });
+  });
+
   test('parseSDL: non-import comment', () => {
     expect(parseSDL(`#important: comment`)).toEqual([]);
   });
@@ -599,6 +606,30 @@ describe('importSchema', () => {
       }
     `;
     expect(importSchema('./fixtures/require-paths/b.graphql')).toBeSimilarGqlDoc(expectedSDL);
+  });
+
+  test('importSchema: interface field typed as an implementer (#8383 review)', () => {
+    const expectedSDL = /* GraphQL */ `
+      interface Animal {
+        favorite: Cat
+      }
+
+      type Cat implements Animal {
+        name: String
+        favorite: Cat
+      }
+
+      type Foo {
+        animal: Animal
+      }
+
+      type Query {
+        foo: Foo
+      }
+    `;
+    expect(importSchema('./fixtures/interface-field-implementer/a.graphql')).toBeSimilarGqlDoc(
+      expectedSDL,
+    );
   });
 
   test('importSchema: interfaces-many', () => {

--- a/packages/import/tests/schema/import-schema.spec.ts
+++ b/packages/import/tests/schema/import-schema.spec.ts
@@ -552,6 +552,55 @@ describe('importSchema', () => {
     expect(importSchema('./fixtures/union-interfaces/a.graphql')).toBeSimilarGqlDoc(expectedSDL);
   });
 
+  test('importSchema: nested union of types that implement an interface (#5436)', () => {
+    const expectedSDL = /* GraphQL */ `
+      type C2 {
+        c2: C3
+      }
+
+      union C3 = C4 | C5
+
+      type C4 implements I {
+        c4: ID
+      }
+
+      type C5 {
+        C5: ID
+      }
+
+      type Foo {
+        pet: Pet
+        nested: C2
+      }
+
+      interface I {
+        c4: ID
+      }
+
+      union Pet = C4 | C5
+
+      type Query {
+        foo: Foo
+      }
+    `;
+    expect(importSchema('./fixtures/union-nested-interfaces/a.graphql')).toBeSimilarGqlDoc(
+      expectedSDL,
+    );
+  });
+
+  test('require: module paths', () => {
+    const expectedSDL = /* GraphQL */ `
+      type A {
+        field: String
+      }
+
+      type B {
+        a: A
+      }
+    `;
+    expect(importSchema('./fixtures/require-paths/b.graphql')).toBeSimilarGqlDoc(expectedSDL);
+  });
+
   test('importSchema: interfaces-many', () => {
     const expectedSDL = /* GraphQL */ `
       type A implements B {

--- a/packages/import/tests/schema/import-schema.spec.ts
+++ b/packages/import/tests/schema/import-schema.spec.ts
@@ -523,6 +523,35 @@ describe('importSchema', () => {
     expect(importSchema('./fixtures/interfaces/a.graphql')).toBeSimilarGqlDoc(expectedSDL);
   });
 
+  test('importSchema: union of types that implement an interface (#3797)', () => {
+    const expectedSDL = /* GraphQL */ `
+      interface Animal {
+        legs: Int!
+      }
+
+      type Cat implements Animal {
+        color: String!
+        legs: Int!
+      }
+
+      type Dog implements Animal {
+        legs: Int!
+        type: String!
+      }
+
+      type Foo {
+        pet: Pet
+      }
+
+      union Pet = Cat | Dog
+
+      type Query {
+        foo: Foo
+      }
+    `;
+    expect(importSchema('./fixtures/union-interfaces/a.graphql')).toBeSimilarGqlDoc(expectedSDL);
+  });
+
   test('importSchema: interfaces-many', () => {
     const expectedSDL = /* GraphQL */ `
       type A implements B {

--- a/packages/import/tests/schema/import-schema.spec.ts
+++ b/packages/import/tests/schema/import-schema.spec.ts
@@ -608,6 +608,22 @@ describe('importSchema', () => {
     expect(importSchema('./fixtures/require-paths/b.graphql')).toBeSimilarGqlDoc(expectedSDL);
   });
 
+  test('import * keeps unreferenced federation @key types (#4894)', () => {
+    const expectedSDL = /* GraphQL */ `
+      interface GraphQLError {
+        message: String!
+      }
+
+      type PilatesInstructor @key(fields: "appointmentInstanceId") {
+        appointmentInstanceId: String!
+        firstName: String
+      }
+    `;
+    expect(importSchema('./fixtures/import-star-federation-key/a.graphql')).toBeSimilarGqlDoc(
+      expectedSDL,
+    );
+  });
+
   test('importSchema: interface field typed as an implementer (#8383 review)', () => {
     const expectedSDL = /* GraphQL */ `
       interface Animal {

--- a/packages/import/tests/schema/import-schema.spec.ts
+++ b/packages/import/tests/schema/import-schema.spec.ts
@@ -643,6 +643,21 @@ type Query {
     );
   });
 
+  test('import * keeps unreferenced types with aliased federation @key', () => {
+    const expectedSDL = /* GraphQL */ `
+      interface GraphQLError {
+        message: String!
+      }
+
+      type User @entityKey(fields: "id") {
+        id: ID!
+      }
+    `;
+    expect(importSchema('./fixtures/import-star-federation-key-alias/a.graphql')).toBeSimilarGqlDoc(
+      expectedSDL,
+    );
+  });
+
   test('importSchema: interface field typed as an implementer (#8383 review)', () => {
     const expectedSDL = /* GraphQL */ `
       interface Animal {

--- a/packages/import/tests/schema/import-schema.spec.ts
+++ b/packages/import/tests/schema/import-schema.spec.ts
@@ -135,6 +135,35 @@ type Query {
     expect(extracted.otherLines).toContain('type Query');
   });
 
+  test('extractImportLines: ignores """ inside comments', () => {
+    const sdl = `# docs """
+# import User from "user.graphql"
+type Query { user: User }
+`;
+    const extracted = extractImportLines(sdl);
+    expect(extracted.importLines).toEqual(['# import User from "user.graphql"']);
+    expect(extracted.otherLines).toContain('type Query { user: User }');
+  });
+
+  test('extractImportLines: ignores escaped """ inside block strings', () => {
+    const sdl = `"""
+text \\""" inside the block string
+"""
+# import User from "user.graphql"
+type Query { user: User }
+`;
+    const extracted = extractImportLines(sdl);
+    expect(extracted.importLines).toEqual(['# import User from "user.graphql"']);
+    expect(extracted.otherLines).toContain('type Query { user: User }');
+    expect(extracted.otherLines).not.toContain('# import User from "user.graphql"');
+  });
+
+  test('parseImportLine: invalid message documents default imports and block strings', () => {
+    expect(() => parseImportLine(`import from "schema.graphql"`)).toThrow(/# import "\[File\]"/);
+    expect(() => parseImportLine(`import from "schema.graphql"`)).toThrow(/"""/);
+    expect(() => parseImportLine(`import from "schema.graphql"`)).not.toThrow(/'''/);
+  });
+
   test('parseSDL: non-import comment', () => {
     expect(parseSDL(`#important: comment`)).toEqual([]);
   });

--- a/packages/import/tests/schema/import-schema.spec.ts
+++ b/packages/import/tests/schema/import-schema.spec.ts
@@ -3,7 +3,12 @@ import * as path from 'path';
 import '../../../testing/to-be-similar-gql-doc';
 import { GraphQLError, Kind, print } from 'graphql';
 import { mergeTypeDefs } from '@graphql-tools/merge';
-import { parseImportLine, PathAliases, processImport } from '../../src/index.js';
+import {
+  extractImportLines,
+  parseImportLine,
+  PathAliases,
+  processImport,
+} from '../../src/index.js';
 
 const importSchema = (
   schema: string,
@@ -114,6 +119,20 @@ describe('importSchema', () => {
       imports: ['*'],
       from: './ProfileForm.graphql',
     });
+  });
+
+  test('extractImportLines: ignores # import inside block strings', () => {
+    const sdl = `"""
+# import "./missing.graphql"
+"""
+type Query {
+  ok: String
+}
+`;
+    const extracted = extractImportLines(sdl);
+    expect(extracted.importLines).toEqual([]);
+    expect(extracted.otherLines).toContain('# import "./missing.graphql"');
+    expect(extracted.otherLines).toContain('type Query');
   });
 
   test('parseSDL: non-import comment', () => {

--- a/packages/load/tests/loaders/schema/schema-from-typedefs.spec.ts
+++ b/packages/load/tests/loaders/schema/schema-from-typedefs.spec.ts
@@ -239,5 +239,20 @@ describe('schema from typedefs', () => {
       expect(schema.getTypeMap()['Bar']).toBeDefined();
       expect(schema.getTypeMap()['Ham']).toBeDefined();
     });
+
+    it('should parse nested import types with interfaces (#3797)', async () => {
+      const glob = './test-files/nested-imports/query-interfaces.graphql';
+      const schema = await load(glob, {
+        loaders: [new GraphQLFileLoader()],
+        cwd: __dirname,
+      });
+
+      expect(schema.getTypeMap()['Query']).toBeDefined();
+      expect(schema.getTypeMap()['Foo']).toBeDefined();
+      expect(schema.getTypeMap()['Cat']).toBeDefined();
+      expect(schema.getTypeMap()['Dog']).toBeDefined();
+      expect(schema.getTypeMap()['Pet']).toBeDefined();
+      expect(schema.getTypeMap()['Animal']).toBeDefined();
+    });
   });
 });

--- a/packages/load/tests/loaders/schema/test-files/nested-imports/interfaces.graphql
+++ b/packages/load/tests/loaders/schema/test-files/nested-imports/interfaces.graphql
@@ -1,0 +1,19 @@
+interface Animal {
+  legs: Int!
+}
+
+type Cat implements Animal {
+  color: String!
+  legs: Int!
+}
+
+type Dog implements Animal {
+  legs: Int!
+  type: String!
+}
+
+union Pet = Cat | Dog
+
+type Foo {
+  pet: Pet
+}

--- a/packages/load/tests/loaders/schema/test-files/nested-imports/query-interfaces.graphql
+++ b/packages/load/tests/loaders/schema/test-files/nested-imports/query-interfaces.graphql
@@ -1,0 +1,5 @@
+# import Foo from './interfaces.graphql'
+
+type Query {
+  foo: Foo
+}

--- a/packages/loaders/graphql-file/src/index.ts
+++ b/packages/loaders/graphql-file/src/index.ts
@@ -4,7 +4,7 @@ import { env, cwd as processCwd } from 'process';
 import type { GlobbyOptions } from 'globby';
 import globby from 'globby';
 import unixify from 'unixify';
-import { PathAliases, processImport } from '@graphql-tools/import';
+import { extractImportLines, PathAliases, processImport } from '@graphql-tools/import';
 import {
   asArray,
   BaseLoaderOptions,
@@ -42,8 +42,7 @@ export interface GraphQLFileLoaderOptions extends BaseLoaderOptions {
 }
 
 function isGraphQLImportFile(rawSDL: string) {
-  const trimmedRawSDL = rawSDL.trim();
-  return trimmedRawSDL.startsWith('# import') || trimmedRawSDL.startsWith('#import');
+  return extractImportLines(rawSDL).importLines.length > 0;
 }
 
 function createGlobbyOptions(options: GraphQLFileLoaderOptions): GlobbyOptions {

--- a/packages/loaders/graphql-file/tests/loader.spec.ts
+++ b/packages/loaders/graphql-file/tests/loader.spec.ts
@@ -94,6 +94,18 @@ describe('GraphQLFileLoader', () => {
         `);
       });
 
+      it('should not treat # import inside a block string as an import', async () => {
+        const [result] = await load(getPointer('type-defs-import-in-block-string.graphql'), {});
+        expect(print(result.document!)).toBeSimilarGqlDoc(/* GraphQL */ `
+          """
+          # import "./does-not-exist.graphql"
+          """
+          type Query {
+            a: String
+          }
+        `);
+      });
+
       it('should load executable document with #import expression', async () => {
         const [result] = await load(getPointer('executable.graphql'), {});
         expect(print(result.document!)).toBeSimilarGqlDoc(/* GraphQL */ `

--- a/packages/loaders/graphql-file/tests/loader.spec.ts
+++ b/packages/loaders/graphql-file/tests/loader.spec.ts
@@ -68,6 +68,32 @@ describe('GraphQLFileLoader', () => {
         `);
       });
 
+      it('should process #import after a leading comment (#6995)', async () => {
+        const [result] = await load(getPointer('type-defs-import-after-comment.graphql'), {});
+        expect(print(result.document!)).toBeSimilarGqlDoc(/* GraphQL */ `
+          type Query {
+            a: A
+          }
+
+          type A {
+            b: String
+          }
+        `);
+      });
+
+      it('should accept default # import with a space after # (#3837)', async () => {
+        const [result] = await load(getPointer('type-defs-spaced-default-import.graphql'), {});
+        expect(print(result.document!)).toBeSimilarGqlDoc(/* GraphQL */ `
+          type Query {
+            a: A
+          }
+
+          type A {
+            b: String
+          }
+        `);
+      });
+
       it('should load executable document with #import expression', async () => {
         const [result] = await load(getPointer('executable.graphql'), {});
         expect(print(result.document!)).toBeSimilarGqlDoc(/* GraphQL */ `

--- a/packages/loaders/graphql-file/tests/test-files/type-defs-import-after-comment.graphql
+++ b/packages/loaders/graphql-file/tests/test-files/type-defs-import-after-comment.graphql
@@ -1,0 +1,6 @@
+# License or heading comment must not disable #import (#6995)
+# import A from "./import-me.graphql"
+
+type Query {
+  a: A
+}

--- a/packages/loaders/graphql-file/tests/test-files/type-defs-import-in-block-string.graphql
+++ b/packages/loaders/graphql-file/tests/test-files/type-defs-import-in-block-string.graphql
@@ -1,0 +1,6 @@
+"""
+# import "./does-not-exist.graphql"
+"""
+type Query {
+  a: String
+}

--- a/packages/loaders/graphql-file/tests/test-files/type-defs-spaced-default-import.graphql
+++ b/packages/loaders/graphql-file/tests/test-files/type-defs-spaced-default-import.graphql
@@ -1,0 +1,5 @@
+# import "./import-me.graphql"
+
+type Query {
+  a: A
+}

--- a/packages/webpack-loader-runtime/src/index.ts
+++ b/packages/webpack-loader-runtime/src/index.ts
@@ -18,7 +18,7 @@ export const uniqueCode = `
 
 export function useUnique() {
   const names = {};
-  return function unique(defs: DefinitionNode[]) {
+  return function unique(defs?: DefinitionNode[] | null) {
     return (defs || []).filter(def => {
       if (def.kind !== 'FragmentDefinition') return true;
       const name = def.name.value;

--- a/packages/webpack-loader-runtime/src/index.ts
+++ b/packages/webpack-loader-runtime/src/index.ts
@@ -3,7 +3,7 @@ import { DefinitionNode } from 'graphql';
 export const uniqueCode = `
   var names = {};
   function unique(defs) {
-    return defs.filter(function (def) {
+    return (defs || []).filter(function (def) {
       if (def.kind !== 'FragmentDefinition') return true;
       var name = def.name.value;
       if (names[name]) {
@@ -19,7 +19,7 @@ export const uniqueCode = `
 export function useUnique() {
   const names = {};
   return function unique(defs: DefinitionNode[]) {
-    return defs.filter(def => {
+    return (defs || []).filter(def => {
       if (def.kind !== 'FragmentDefinition') return true;
       const name = def.name.value;
       if (names[name]) {

--- a/packages/webpack-loader/src/index.ts
+++ b/packages/webpack-loader/src/index.ts
@@ -37,7 +37,9 @@ function expandImports(source: string, options: Options) {
   lines.some(line => {
     if (line[0] === '#' && line.slice(1).split(' ')[0] === 'import') {
       const importFile = line.slice(1).split(' ')[1];
-      const parseDocument = `require(${importFile})`;
+      const parseDocument = options.esModule
+        ? `require(${importFile}).default`
+        : `require(${importFile})`;
       const appendDef = `doc.definitions = doc.definitions.concat(unique(${parseDocument}.definitions));`;
       outputCode += appendDef + os.EOL;
     }

--- a/packages/webpack-loader/tests/loader.test.ts
+++ b/packages/webpack-loader/tests/loader.test.ts
@@ -59,6 +59,16 @@ test('basic query with esModules on', () => {
   `);
 });
 
+test('esModule #import uses the default export of the required document (#7935)', () => {
+  const docStr = `#import "./frag.graphql"\nquery Foo {\n  foo\n}`;
+  const doc = useLoader(docStr, {
+    esModule: true,
+  });
+
+  expect(doc).toContain('require("./frag.graphql").default');
+  expect(doc).toContain('export default doc');
+});
+
 test('replaceKinds enabled', () => {
   const docStr = /* GraphQL */ `
     query Foo {

--- a/website/src/content/schema-loading.mdx
+++ b/website/src/content/schema-loading.mdx
@@ -90,6 +90,11 @@ main()
 
 ### Using `#import` Expression
 
+<Callout>
+  `#import` / `# import` lines can appear anywhere in the file. A heading comment or license block
+  above them is fine.
+</Callout>
+
 Assume the following directory structure:
 
 ```text

--- a/website/src/content/schema-loading.mdx
+++ b/website/src/content/schema-loading.mdx
@@ -145,6 +145,14 @@ type Comment {
 }
 ```
 
+`#import` can also resolve npm packages (and other `require.resolve` specifiers) with a `require:`
+prefix, from the importing file's directory:
+
+```graphql
+# import Post, Comment from "require:blog-graphql-types/schema.graphql"
+# import Shared from "require:./shared.graphql"
+```
+
 ### Binding to HTTP Server
 
 You can extend the loaded schema with resolvers


### PR DESCRIPTION
## Summary

### Named import drops interfaces behind unions

`# import Foo` walked field types, then union members, and stopped. If those members `implements Animal`, the schema failed with `Unknown type "Animal"`.

```graphql
# import Foo from "./types.graphql"

type Query {
  foo: Foo
}
```

```graphql
interface Animal { legs: Int! }
type Cat implements Animal { color: String! legs: Int! }
type Dog implements Animal { legs: Int! type: String! }
union Pet = Cat | Dog
type Foo { pet: Pet }
```

Forward dependencies (fields, `implements`, union members) are now closed transitively. Reverse implementers attach only when the interface itself is imported. Reverse `implements` edges are stored separately from field types, so an interface field typed as an implementer (e.g. `Animal.favorite: Cat` where `Cat implements Animal`) is still pulled.

### `require:` import paths

`# import Post from "require:blog-graphql-types/schema.graphql"` (or `require:./local.graphql`) resolves with `require.resolve` from the importing file.

### Leading comments on documents

`# eslint-disable-next-line` above a query/fragment is kept in the merged document source instead of being stripped by reprinting.

### Default `# import` and imports below comments

`# import "./file.graphql"` (space after `#`) is a valid default import. `#import` is processed even when it is not the first non-blank line.

### Federation `@key` types on `import *`

`# import *` still tree-shakes unused types, but subgraph entities with `@key` stay even when nothing in the importing file references them (e.g. `PilatesInstructor @key(fields: "appointmentInstanceId")`).

### Webpack loader `esModule: true`

`#import` of another `.graphql` file used `require(file)` while the file emitted `export default`, so imported fragments were empty/tree-shaken. The loader now uses `require(file).default`, and `unique()` treats a missing `definitions` array as empty.

Closes #3797
Closes #5436
Closes #3837
Closes #4894
Closes #6995
Closes #7935
Closes #3798
Closes #3113
Closes #4723
Closes #5467
Closes #8066

## Test plan
- [x] import schema: union + nested union/interface, interface field typed as implementer, `require:` paths, unreferenced `@key` types
- [x] import documents: leading comments
- [x] graphql-file-loader: import after comment, spaced default import
- [x] load nested-import interfaces
- [x] webpack-loader esModule `#import`
- [ ] CI