### PR TITLE
[graphql-tools/merge] don't drop the synthesized operation types on graphql 17

### DIFF
--- a/.changeset/merge-keep-synthesized-operation-types.md
+++ b/.changeset/merge-keep-synthesized-operation-types.md
@@ -1,0 +1,5 @@
+---
+'@graphql-tools/merge': patch
+---
+
+Write the synthesized default operation types back onto the schema definition node, so merging a `schema` extension that has no operation block (federation SDL, for example) still produces a query root on `graphql@17`.

--- a/packages/merge/src/typedefs-mergers/merge-typedefs.ts
+++ b/packages/merge/src/typedefs-mergers/merge-typedefs.ts
@@ -268,7 +268,10 @@ export function mergeGraphQLTypes(typeSource: TypeSource, config: Config): Defin
       kind: Kind.SCHEMA_DEFINITION,
       operationTypes: [],
     };
-    const operationTypes = (schemaDef.operationTypes as OperationTypeDefinitionNode[]) || [];
+    // graphql@17 leaves `operationTypes` undefined on schema extensions, so the default operation
+    // types have to be written back onto the node instead of into a detached array.
+    const mutableSchemaDef = schemaDef as { operationTypes?: OperationTypeDefinitionNode[] };
+    const operationTypes = (mutableSchemaDef.operationTypes ??= []);
     for (const opTypeDefNodeType in DEFAULT_OPERATION_TYPE_NAME_MAP) {
       const opTypeDefNode = operationTypes.find(
         operationType => operationType.operation === opTypeDefNodeType,

--- a/packages/merge/tests/merge-typedefs.spec.ts
+++ b/packages/merge/tests/merge-typedefs.spec.ts
@@ -1893,6 +1893,29 @@ describe('Merge TypeDefs', () => {
     expect(print(merged)).toBeSimilarString(print(expected));
   });
 
+  it('keeps the default operation types when a schema extension has no operation block', () => {
+    const merged = mergeTypeDefs(
+      [
+        /* GraphQL */ `
+          directive @link(url: String!, import: [String]) repeatable on SCHEMA
+
+          extend schema @link(url: "https://specs.apollo.dev/federation/v2.9", import: ["@key"])
+
+          type Query {
+            hello: String
+          }
+        `,
+      ],
+      { convertExtensions: true },
+    );
+
+    const queryType = makeExecutableSchema({ typeDefs: merged }).getQueryType();
+
+    expect(queryType).toBeDefined();
+    assertSome(queryType);
+    expect(queryType.name).toEqual('Query');
+  });
+
   it('keeps repeatable directives on schema definitions across documents', () => {
     const schema1 = parse(/* GraphQL */ `
       directive @tag(name: String!) repeatable on SCHEMA


### PR DESCRIPTION
Follow-up to #8263.

The `|| []` there stops the crash, but the fallback array never gets assigned back to `schemaDef`, so
the default query/mutation/subscription entries pushed into it are lost. The write-back below tests
`schemaDef.operationTypes.length`, still undefined, so the merged schema comes out with no roots:
`Query` sits in the type map with all its fields, `getQueryType()` returns undefined, and you get
`Query root type must be provided.`

Doesn't happen on 16, where the parser gives you `[]` instead of `undefined` and the expression aliases
the node's own array.

### Repro

`schema.graphql`:

```graphql
directive @link(url: String!, import: [String]) repeatable on SCHEMA

extend schema @link(url: "https://specs.apollo.dev/federation/v2.9", import: ["@key"])

extend type Query {
  hello: String
}
```

`repro.mjs`:

```js
import { readFileSync } from 'node:fs';
import { join } from 'node:path';
import { assertValidSchema, buildASTSchema, version } from 'graphql';
import { mergeTypeDefs } from '@graphql-tools/merge';

const sdl = readFileSync(join(import.meta.dirname, './schema.graphql'), 'utf8');
const schema = buildASTSchema(mergeTypeDefs([sdl], { convertExtensions: true }), {
  assumeValidSDL: true,
});

console.log('graphql        :', version);
console.log('getQueryType() :', String(schema.getQueryType()?.name));
console.log('has Query type :', !!schema.getType('Query'));
try {
  assertValidSchema(schema);
  console.log('valid          : ok');
} catch (e) {
  console.log('valid          :', e.message);
}
```

```
npm i graphql@17.0.2 @graphql-tools/merge@9.2.3 && node repro.mjs
graphql        : 17.0.2
getQueryType() : undefined
has Query type : true
valid          : Query root type must be provided.

npm i graphql@16.14.2 @graphql-tools/merge@9.2.3 && node repro.mjs
graphql        : 16.14.2
getQueryType() : Query
has Query type : true
valid          : ok
```

With the one-line change applied, graphql 17 gives `Query` / `ok` too.

Any `schema` extension without an operation block hits this, so federation SDL does by default.

`operationTypes` is readonly on the node type, hence the cast. Happy to reshape it if you'd rather
build the array and assign once at the end.
