### PR TITLE
fix(deps): bump @xmldom/xmldom to 0.9.12 (CVE-2026-83610)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9795,10 +9795,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
-      "deprecated": "this version has critical issues, please update to the latest version",
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.12.tgz",
+      "integrity": "sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==",
       "license": "MIT",
       "engines": {
         "node": ">=14.6"

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "wonka": "6.3.6"
   },
   "overrides": {
+    "@xmldom/xmldom": "0.9.12",
     "cookie": "2.0.1",
     "esbuild": "0.28.1",
     "estree-util-value-to-estree": "3.5.0",


### PR DESCRIPTION
## Summary
- Resolves [Dependabot alert #255](https://github.com/ardatan/graphql-tools/security/dependabot/255) ([GHSA-6gmq-8vp8-gcm6](https://github.com/advisories/GHSA-6gmq-8vp8-gcm6) / CVE-2026-83610)
- `@xmldom/xmldom` is a transitive dependency of the website docs stack (`speech-rule-engine` → `mathjax-full` → … → `nextra`), pinned at `0.9.10`
- Add an npm `overrides` entry and lockfile resolution to patched `0.9.12`

## Test plan
- [ ] Confirm `npm ls @xmldom/xmldom` resolves to `0.9.12`
- [ ] Confirm Dependabot alert #255 closes after merge
- [ ] Smoke-check website build if desired (`website` workspace)


Made with [Cursor](https://cursor.com)