### PR TITLE
Fix/merge extend schema operation types

### DIFF
--- a/.changeset/merge-schema-extension-operation-types.md
+++ b/.changeset/merge-schema-extension-operation-types.md
@@ -1,0 +1,7 @@
+---
+'@graphql-tools/merge': patch
+---
+
+Fix `mergeTypeDefs` (and `useSchemaDefinition`, on by default) silently dropping backfilled root operation types when the source document contains a `extend schema` block that declares no operation types itself (e.g. `extend schema @link(...)`).
+
+On graphql@17, `SchemaExtensionNode.operationTypes` is `undefined` for such a block instead of `[]`. The backfill logic built the missing `query`/`mutation`/`subscription` entries into a fresh, disconnected array instead of the one attached to the schema node, so they were computed and then discarded — leaving the merged output with an empty `extend schema { ... }` and forcing consumers to declare `schema { query: Query }` manually.

--- a/packages/merge/src/typedefs-mergers/merge-typedefs.ts
+++ b/packages/merge/src/typedefs-mergers/merge-typedefs.ts
@@ -268,7 +268,13 @@ export function mergeGraphQLTypes(typeSource: TypeSource, config: Config): Defin
       kind: Kind.SCHEMA_DEFINITION,
       operationTypes: [],
     };
-    const operationTypes = (schemaDef.operationTypes as OperationTypeDefinitionNode[]) || [];
+    // `schemaDef.operationTypes` can be `undefined` for a schema extension that declares no
+    // operation types (e.g. `extend schema @foo`). Normalize it in place so the operation types
+    // backfilled below are attached to `schemaDef` itself, not a disconnected local array.
+    if (schemaDef.operationTypes == null) {
+      schemaDef.operationTypes = [];
+    }
+    const operationTypes = schemaDef.operationTypes as OperationTypeDefinitionNode[];
     for (const opTypeDefNodeType in DEFAULT_OPERATION_TYPE_NAME_MAP) {
       const opTypeDefNode = operationTypes.find(
         operationType => operationType.operation === opTypeDefNodeType,

--- a/packages/merge/src/typedefs-mergers/merge-typedefs.ts
+++ b/packages/merge/src/typedefs-mergers/merge-typedefs.ts
@@ -268,12 +268,13 @@ export function mergeGraphQLTypes(typeSource: TypeSource, config: Config): Defin
       kind: Kind.SCHEMA_DEFINITION,
       operationTypes: [],
     };
-    // `schemaDef.operationTypes` can be `undefined` for a schema extension that declares no
-    // operation types (e.g. `extend schema @foo`). Normalize it once so `operationTypes` below
-    // is the same array as `schemaDef.operationTypes`, not a disconnected copy - every push
-    // below then lands on `schemaDef` itself, and we can keep reading `operationTypes` instead
-    // of going back through `schemaDef` later.
-    const operationTypes = (schemaDef.operationTypes ??= []) as OperationTypeDefinitionNode[];
+    // `schemaDef.operationTypes` is readonly (it's a graphql-js AST node) and can be `undefined`
+    // for a schema extension that declares no operation types (e.g. `extend schema @foo`). Copy
+    // it into a plain mutable array here rather than assigning back into `schemaDef` - the
+    // backfilled result is attached below by building a new node instead.
+    const operationTypes = [
+      ...((schemaDef.operationTypes as OperationTypeDefinitionNode[] | undefined) ?? []),
+    ];
     for (const opTypeDefNodeType in DEFAULT_OPERATION_TYPE_NAME_MAP) {
       const opTypeDefNode = operationTypes.find(
         operationType => operationType.operation === opTypeDefNodeType,
@@ -295,7 +296,7 @@ export function mergeGraphQLTypes(typeSource: TypeSource, config: Config): Defin
     }
 
     if (operationTypes.length > 0) {
-      mergedNodes[schemaDefSymbol] = schemaDef;
+      mergedNodes[schemaDefSymbol] = { ...schemaDef, operationTypes };
     }
   }
 

--- a/packages/merge/src/typedefs-mergers/merge-typedefs.ts
+++ b/packages/merge/src/typedefs-mergers/merge-typedefs.ts
@@ -269,12 +269,11 @@ export function mergeGraphQLTypes(typeSource: TypeSource, config: Config): Defin
       operationTypes: [],
     };
     // `schemaDef.operationTypes` can be `undefined` for a schema extension that declares no
-    // operation types (e.g. `extend schema @foo`). Normalize it in place so the operation types
-    // backfilled below are attached to `schemaDef` itself, not a disconnected local array.
-    if (schemaDef.operationTypes == null) {
-      schemaDef.operationTypes = [];
-    }
-    const operationTypes = schemaDef.operationTypes as OperationTypeDefinitionNode[];
+    // operation types (e.g. `extend schema @foo`). Normalize it once so `operationTypes` below
+    // is the same array as `schemaDef.operationTypes`, not a disconnected copy - every push
+    // below then lands on `schemaDef` itself, and we can keep reading `operationTypes` instead
+    // of going back through `schemaDef` later.
+    const operationTypes = (schemaDef.operationTypes ??= []) as OperationTypeDefinitionNode[];
     for (const opTypeDefNodeType in DEFAULT_OPERATION_TYPE_NAME_MAP) {
       const opTypeDefNode = operationTypes.find(
         operationType => operationType.operation === opTypeDefNodeType,
@@ -295,7 +294,7 @@ export function mergeGraphQLTypes(typeSource: TypeSource, config: Config): Defin
       }
     }
 
-    if (schemaDef?.operationTypes?.length != null && schemaDef.operationTypes.length > 0) {
+    if (operationTypes.length > 0) {
       mergedNodes[schemaDefSymbol] = schemaDef;
     }
   }

--- a/packages/merge/tests/merge-typedefs.spec.ts
+++ b/packages/merge/tests/merge-typedefs.spec.ts
@@ -1879,6 +1879,83 @@ describe('Merge TypeDefs', () => {
     expect(print(merged)).toBeSimilarString(print(expected));
   });
 
+  it('backfills query, mutation and subscription onto an "extend schema" that declares none', () => {
+    const ast = parse(/* GraphQL */ `
+      directive @foo on SCHEMA
+
+      extend schema @foo
+
+      type Query {
+        hello: String
+      }
+
+      type Mutation {
+        doThing: Boolean
+      }
+
+      type Subscription {
+        onThing: Boolean
+      }
+    `);
+    const merged = mergeTypeDefs([ast]);
+    const expected = parse(/* GraphQL */ `
+      directive @foo on SCHEMA
+
+      extend schema @foo {
+        query: Query
+        mutation: Mutation
+        subscription: Subscription
+      }
+
+      type Query {
+        hello: String
+      }
+
+      type Mutation {
+        doThing: Boolean
+      }
+
+      type Subscription {
+        onThing: Boolean
+      }
+    `);
+    expect(print(merged)).toBeSimilarString(print(expected));
+  });
+
+  it('only backfills operation types for root types that actually exist', () => {
+    const ast = parse(/* GraphQL */ `
+      directive @foo on SCHEMA
+
+      extend schema @foo
+
+      type Query {
+        hello: String
+      }
+
+      type Mutation {
+        doThing: Boolean
+      }
+    `);
+    const merged = mergeTypeDefs([ast]);
+    const expected = parse(/* GraphQL */ `
+      directive @foo on SCHEMA
+
+      extend schema @foo {
+        query: Query
+        mutation: Mutation
+      }
+
+      type Query {
+        hello: String
+      }
+
+      type Mutation {
+        doThing: Boolean
+      }
+    `);
+    expect(print(merged)).toBeSimilarString(print(expected));
+  });
+
   it('keeps repeatable directives on schema definitions across documents', () => {
     const schema1 = parse(/* GraphQL */ `
       directive @tag(name: String!) repeatable on SCHEMA

--- a/packages/merge/tests/merge-typedefs.spec.ts
+++ b/packages/merge/tests/merge-typedefs.spec.ts
@@ -1854,6 +1854,31 @@ describe('Merge TypeDefs', () => {
     expect(print(merged)).toBeSimilarString(print(expected));
   });
 
+  it('backfills root operation types onto an "extend schema" that declares none (e.g. only a directive)', () => {
+    const ast = parse(/* GraphQL */ `
+      directive @foo on SCHEMA
+
+      extend schema @foo
+
+      type Query {
+        hello: String
+      }
+    `);
+    const merged = mergeTypeDefs([ast]);
+    const expected = parse(/* GraphQL */ `
+      directive @foo on SCHEMA
+
+      extend schema @foo {
+        query: Query
+      }
+
+      type Query {
+        hello: String
+      }
+    `);
+    expect(print(merged)).toBeSimilarString(print(expected));
+  });
+
   it('keeps repeatable directives on schema definitions across documents', () => {
     const schema1 = parse(/* GraphQL */ `
       directive @tag(name: String!) repeatable on SCHEMA


### PR DESCRIPTION
## Description

`extend schema` syntax overrides the default implicit `schema { query: Query, mutation: Mutation, subscription: Subscription }` and creates an empty `schema { }` instead. 

On graphql < 17, this is backfilled correctly i.e. if there is `type Query`, the `merge` function will create `schema { query: Query }`.

On graphql@17, `SchemaExtensionNode.operationTypes` is `undefined` instead of an empty array. The backfill logic built the missing `query`/`mutation`/`subscription` entries into a fresh, disconnected array instead of the one attached to the schema node, so they were computed and then discarded — leaving the merged output with an empty `extend schema { ... }` and forcing consumers to declare `schema { query: Query }` manually.

This PR fixes it by creating a default empty array when `operationTypes` is undeclared.

Related  https://github.com/graphql-hive/console/pull/8394#discussion_r3843732679

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit test

