### PR TITLE
test: reproduce #8420 — CodeFileLoader import() rejects absolute Windows paths (failing)

### DIFF
--- a/packages/loaders/code-file/tests/windows-absolute-path.spec.ts
+++ b/packages/loaders/code-file/tests/windows-absolute-path.spec.ts
@@ -1,0 +1,51 @@
+import { execFileSync } from 'child_process';
+import { mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+
+// `tryToLoadFromExport` calls `await import(filepath)` on a raw, absolute
+// filesystem path. Node's dynamic `import()` always resolves its specifier
+// through the ESM loader, regardless of whether the calling module is itself
+// CJS or ESM. On Windows, an absolute path like `C:\Users\me\schema.js` gets
+// misparsed as a URL with scheme "c:", throwing
+// `ERR_UNSUPPORTED_ESM_URL_SCHEME`. See:
+// https://github.com/ardatan/graphql-tools/issues/8420
+//
+// This suite's babel/ts-jest transform rewrites `await import(...)` into a
+// `require()`-based call for the CJS test environment, which hides the bug
+// entirely (it never touches Node's real ESM loader), so instead of testing
+// through Jest's own transform, this spawns a real Node process (via `tsx`,
+// to run the TypeScript source directly with no build step) to exercise the
+// actual runtime behavior.
+(process.platform === 'win32' ? describe : describe.skip)(
+  'CodeFileLoader with absolute Windows paths (issue #8420)',
+  () => {
+    it('loads a schema module referenced by an absolute path with a drive letter', () => {
+      const tsxCli = join(dirname(require.resolve('tsx/package.json')), 'dist/cli.mjs');
+
+      const loadFromModulePath = join(__dirname, '../src/load-from-module.ts');
+      const fixturePath = join(__dirname, 'test-files/loaders/module-exports.js');
+
+      const tmpDir = mkdtempSync(join(tmpdir(), 'code-file-loader-'));
+      const scriptPath = join(tmpDir, 'run.mjs');
+
+      writeFileSync(
+        scriptPath,
+        [
+          "import { pathToFileURL } from 'url';",
+          `const { tryToLoadFromExport } = await import(pathToFileURL(${JSON.stringify(
+            loadFromModulePath,
+          )}).href);`,
+          `const result = await tryToLoadFromExport(${JSON.stringify(fixturePath)});`,
+          'console.log(JSON.stringify({ hasSchema: !!result }));',
+        ].join('\n'),
+      );
+
+      const output = execFileSync(process.execPath, [tsxCli, scriptPath], {
+        encoding: 'utf8',
+      });
+
+      expect(JSON.parse(output.trim())).toEqual({ hasSchema: true });
+    });
+  },
+);


### PR DESCRIPTION
## What

Checkpoint PR for #8420: a new test that reproduces the reported bug and is currently **failing on purpose**. This PR does not fix anything — it only proves the bug is real and pins down its exact failure mode so a follow-up fix PR can build directly on top of this commit.

## The bug

`tryToLoadFromExport()` in [`load-from-module.ts`](https://github.com/ardatan/graphql-tools/blob/master/packages/loaders/code-file/src/load-from-module.ts) calls `await import(filepath)` directly on a raw, absolute filesystem path. Node's dynamic `import()` always resolves its specifier through the ESM loader, even when the calling module is CommonJS. On native Windows, an absolute path like `C:\Users\me\schema.js` gets misparsed as a URL with scheme `c:`, throwing:

```
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. Received protocol 'c:'
```

The same pattern also exists in `CodeFileLoader`'s own `require` option handling (`packages/loaders/code-file/src/index.ts`), per the issue.

## Why the test is shaped this way

This suite's babel/ts-jest transform rewrites `await import(...)` into a `require()`-based call for the CJS test environment, which silently hides the bug — it never touches Node's real ESM loader, so a normal Jest test against the TS source passes even though the shipped code is broken. To exercise the actual runtime behavior, [the new test](packages/loaders/code-file/tests/windows-absolute-path.spec.ts) spawns a real Node process (via `tsx`, so it runs the TypeScript source directly with no build step) and calls `tryToLoadFromExport` with a real absolute path pointing at an existing test fixture.

The test is scoped to `process.platform === 'win32'` (skipped elsewhere), since `ERR_UNSUPPORTED_ESM_URL_SCHEME` is specific to Windows-style absolute paths being misparsed as a URL with a drive-letter "scheme" — this matches the CI matrix, which already runs the Windows job (`windows-latest`) in [tests.yml](.github/workflows/tests.yml).

## Verification

Ran locally on native Windows (Node 24.16.0) — the test fails exactly as expected, reproducing the reported error verbatim:

```
FAIL Unit Test packages/loaders/code-file/tests/windows-absolute-path.spec.ts
  CodeFileLoader with absolute Windows paths (issue #8420)
    × loads a schema module referenced by an absolute path with a drive letter

Error: Unable to load from file "...\module-exports.js":
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by
the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'
```

## Status

**This PR is intentionally red** and not meant to merge as-is — that's the point of a checkpoint. A follow-up fix PR builds directly on top of this commit (converting absolute paths to `file://` URLs via `url.pathToFileURL()` before passing them to `import()`, as suggested in the issue) and should turn this test green.

Relates to #8420