### PR TITLE
Fix prototype pollution in `mergeDeep`

### DIFF
--- a/.changeset/wet-ears-rush.md
+++ b/.changeset/wet-ears-rush.md
@@ -1,0 +1,9 @@
+---
+'@graphql-tools/utils': patch
+---
+
+Fix prototype pollution in `mergeDeep`
+
+Source keys named `__proto__`, `constructor` or `prototype` are now skipped at every recursion level, and the check for an existing key uses `hasOwnProperty` instead of `in`, so inherited properties are never used as merge targets.
+
+Previously, merging untrusted data such as `JSON.parse('{"constructor":{"__proto__":{"call":"x"}}}')` could reach and overwrite properties on `Object.prototype` or `Function.prototype`.

--- a/packages/utils/src/mergeDeep.ts
+++ b/packages/utils/src/mergeDeep.ts
@@ -83,12 +83,16 @@ export function mergeDeep<S extends any[]>(
       }
 
       for (const key in source) {
+        // never let a source key reach the prototype chain
+        if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+          continue;
+        }
         // An own key present with value `undefined` is an explicit override and must win,
         // distinct from the key being altogether absent from `source`. Assigning directly
         // (rather than recursing through mergeDeep) avoids the top-level `source === undefined`
         // skip above, which would otherwise silently discard this override and keep the prior
         // value.
-        if (key in output && source[key] !== undefined) {
+        if (Object.prototype.hasOwnProperty.call(output, key) && source[key] !== undefined) {
           output[key] = mergeDeep(
             [output[key], source[key]],
             respectPrototype,

--- a/packages/utils/tests/mergeDeep.test.ts
+++ b/packages/utils/tests/mergeDeep.test.ts
@@ -114,6 +114,23 @@ describe('mergeDeep', () => {
     expect(mergeDeep([])).toEqual(undefined);
   });
 
+  it('does not let an own __proto__ key from a source change the prototype of the output', () => {
+    // json parsing makes __proto__ a real own enumerable key, unlike an object literal
+    const payload = JSON.parse('{"nested":{"__proto__":{"polluted":"yes"}}}');
+    const merged = mergeDeep([{ nested: { a: 1 } }, payload]);
+    expect(merged.nested.a).toEqual(1);
+    expect(merged.nested.polluted).toBeUndefined();
+    expect(Object.getPrototypeOf(merged.nested)).toBe(Object.prototype);
+  });
+
+  it('does not walk into inherited constructor/prototype when merging', () => {
+    const payload = JSON.parse('{"constructor":{"prototype":{"polluted":"yes"}}}');
+    const merged = mergeDeep([{ a: 1 }, payload]);
+    expect(merged.a).toEqual(1);
+    expect(({} as any).polluted).toBeUndefined();
+    expect(Object.prototype).not.toHaveProperty('polluted');
+  });
+
   it('preserves non-enumerable symbol properties from the first source', () => {
     const sym = Symbol('annotation');
     const first: any = { a: 1 };


### PR DESCRIPTION
Source keys named `__proto__`, `constructor` or `prototype` are now skipped at every recursion level, and the check for an existing key uses `hasOwnProperty` instead of `in`, so inherited properties are never used as merge targets.

Previously, merging untrusted data such as `JSON.parse('{"constructor":{"__proto__":{"call":"x"}}}')` could reach and overwrite properties on `Object.prototype` or `Function.prototype`.