### PR TITLE
fix(executor-legacy-ws): enable TLS cert validation by default (GHSA-6fw5-9hq8-w87g)

### DIFF
--- a/.changeset/ghsa-legacy-ws-tls.md
+++ b/.changeset/ghsa-legacy-ws-tls.md
@@ -1,18 +1,17 @@
 ---
-'@graphql-tools/executor-legacy-ws': major
-'@graphql-tools/url-loader': major
+'@graphql-tools/executor-legacy-ws': patch
+'@graphql-tools/url-loader': patch
 ---
 
-**Security / breaking:** Enable TLS certificate validation by default for legacy GraphQL WebSocket (`graphql-ws` protocol) connections over `wss://`.
+**Security:** Enable TLS certificate validation by default for legacy GraphQL WebSocket (`graphql-ws` protocol) connections over `wss://`.
 
 `buildWSLegacyExecutor()` previously hardcoded `rejectUnauthorized: false`, so Node.js clients accepted any certificate (including self-signed or attacker-controlled ones). Credentials in `connectionParams` / `headers` and subscription payloads could be exposed to a network MITM. This addresses [GHSA-6fw5-9hq8-w87g](https://github.com/ardatan/graphql-tools/security/advisories/GHSA-6fw5-9hq8-w87g) (CWE-295).
 
-### Breaking change
-- Default is now `rejectUnauthorized: true` (Node TLS verifies the peer certificate).
-- Connections that previously succeeded against untrusted or self-signed certificates will now fail unless you explicitly opt out.
+### Corrected behavior
+- Default is now `rejectUnauthorized: true` (Node TLS verifies the peer certificate), matching secure-by-default expectations.
+- Connections to endpoints with untrusted/self-signed certificates will fail unless you opt out.
 
-### Migration
-Trusted / local self-signed setups must pass `rejectUnauthorized: false`:
+### Opt-out (trusted / local self-signed only)
 
 ```ts
 buildWSLegacyExecutor(url, WebSocket, {

--- a/.changeset/ghsa-legacy-ws-tls.md
+++ b/.changeset/ghsa-legacy-ws-tls.md
@@ -3,4 +3,30 @@
 '@graphql-tools/url-loader': patch
 ---
 
-Enable TLS certificate validation by default in the legacy WebSocket executor (`rejectUnauthorized` now defaults to `true`, with an opt-out for trusted self-signed setups). Fixes GHSA-6fw5-9hq8-w87g.
+**Security:** Enable TLS certificate validation by default for legacy GraphQL WebSocket (`graphql-ws` protocol) connections over `wss://`.
+
+`buildWSLegacyExecutor()` previously hardcoded `rejectUnauthorized: false`, so Node.js clients accepted any certificate (including self-signed or attacker-controlled ones). Credentials in `connectionParams` / `headers` and subscription payloads could be exposed to a network MITM. This addresses [GHSA-6fw5-9hq8-w87g](https://github.com/ardatan/graphql-tools/security/advisories/GHSA-6fw5-9hq8-w87g) (CWE-295).
+
+### Behavior change
+- Default is now `rejectUnauthorized: true` (Node TLS verifies the peer certificate).
+- Connections to endpoints with untrusted/self-signed certificates will fail unless you opt out.
+
+### Opt-out (trusted / local self-signed only)
+
+```ts
+buildWSLegacyExecutor(url, WebSocket, {
+  rejectUnauthorized: false,
+  connectionParams: { /* ... */ },
+})
+```
+
+Or via `UrlLoader` / `LoadFromUrlOptions` when `subscriptionsProtocol` is `LEGACY_WS`:
+
+```ts
+{
+  subscriptionsProtocol: SubscriptionProtocol.LEGACY_WS,
+  rejectUnauthorized: false,
+}
+```
+
+Browser WebSocket clients were never affected by this flag (browsers always validate certificates).

--- a/.changeset/ghsa-legacy-ws-tls.md
+++ b/.changeset/ghsa-legacy-ws-tls.md
@@ -1,0 +1,6 @@
+---
+'@graphql-tools/executor-legacy-ws': patch
+'@graphql-tools/url-loader': patch
+---
+
+Enable TLS certificate validation by default in the legacy WebSocket executor (`rejectUnauthorized` now defaults to `true`, with an opt-out for trusted self-signed setups). Fixes GHSA-6fw5-9hq8-w87g.

--- a/.changeset/ghsa-legacy-ws-tls.md
+++ b/.changeset/ghsa-legacy-ws-tls.md
@@ -1,17 +1,18 @@
 ---
-'@graphql-tools/executor-legacy-ws': patch
-'@graphql-tools/url-loader': patch
+'@graphql-tools/executor-legacy-ws': major
+'@graphql-tools/url-loader': major
 ---
 
-**Security:** Enable TLS certificate validation by default for legacy GraphQL WebSocket (`graphql-ws` protocol) connections over `wss://`.
+**Security / breaking:** Enable TLS certificate validation by default for legacy GraphQL WebSocket (`graphql-ws` protocol) connections over `wss://`.
 
 `buildWSLegacyExecutor()` previously hardcoded `rejectUnauthorized: false`, so Node.js clients accepted any certificate (including self-signed or attacker-controlled ones). Credentials in `connectionParams` / `headers` and subscription payloads could be exposed to a network MITM. This addresses [GHSA-6fw5-9hq8-w87g](https://github.com/ardatan/graphql-tools/security/advisories/GHSA-6fw5-9hq8-w87g) (CWE-295).
 
-### Behavior change
+### Breaking change
 - Default is now `rejectUnauthorized: true` (Node TLS verifies the peer certificate).
-- Connections to endpoints with untrusted/self-signed certificates will fail unless you opt out.
+- Connections that previously succeeded against untrusted or self-signed certificates will now fail unless you explicitly opt out.
 
-### Opt-out (trusted / local self-signed only)
+### Migration
+Trusted / local self-signed setups must pass `rejectUnauthorized: false`:
 
 ```ts
 buildWSLegacyExecutor(url, WebSocket, {

--- a/packages/executors/legacy-ws/src/index.ts
+++ b/packages/executors/legacy-ws/src/index.ts
@@ -22,6 +22,12 @@ export enum LEGACY_WS {
 export interface LegacyWSExecutorOpts {
   connectionParams?: Record<string, unknown> | (() => Record<string, unknown>);
   headers?: Record<string, any>;
+  /**
+   * Whether to reject unauthorized TLS certificates when connecting over `wss://`.
+   * Defaults to `true`. Set to `false` only for trusted environments that use
+   * self-signed certificates (for example local development).
+   */
+  rejectUnauthorized?: boolean;
 }
 
 export function buildWSLegacyExecutor(
@@ -37,7 +43,7 @@ export function buildWSLegacyExecutor(
       websocket = new WebSocketImpl(subscriptionsEndpoint, 'graphql-ws', {
         followRedirects: true,
         headers: options?.headers,
-        rejectUnauthorized: false,
+        rejectUnauthorized: options?.rejectUnauthorized ?? true,
         skipUTF8Validation: true,
       });
 

--- a/packages/loaders/url/src/index.ts
+++ b/packages/loaders/url/src/index.ts
@@ -96,6 +96,11 @@ export interface LoadFromUrlOptions
    */
   connectionParams?: Record<string, unknown> | (() => Record<string, unknown>);
   /**
+   * Whether to reject unauthorized TLS certificates for legacy `wss://` subscriptions.
+   * Defaults to `true`. Only applies when `subscriptionsProtocol` is `LEGACY_WS`.
+   */
+  rejectUnauthorized?: boolean;
+  /**
    * Enable Batching
    */
   batch?: boolean;


### PR DESCRIPTION
## Summary
- Correct insecure default: stop hardcoding `rejectUnauthorized: false` in `@graphql-tools/executor-legacy-ws`; default to `true` so `wss://` connections validate certificates.
- Expose optional `rejectUnauthorized` on `LegacyWSExecutorOpts` and `LoadFromUrlOptions` for trusted self-signed setups (e.g. local dev).
- Addresses [GHSA-6fw5-9hq8-w87g](https://github.com/ardatan/graphql-tools/security/advisories/GHSA-6fw5-9hq8-w87g) (CWE-295).
- Released as a **patch** (incorrect insecure default, not a documented contract).

## Test plan
- [ ] Confirm default Node `wss://` connection rejects a self-signed peer certificate
- [ ] Confirm `rejectUnauthorized: false` still allows self-signed in trusted/dev setups
- [ ] Confirm `UrlLoader` + `SubscriptionProtocol.LEGACY_WS` still works against a valid TLS endpoint
- [ ] After release (`executor-legacy-ws@1.1.35`), publish the GHSA with `patched_versions: >= 1.1.35`