### PR TITLE
fix: refresh @graphql-tools/delegate patch for 12.2.0

### DIFF
--- a/patches/@graphql-tools+delegate+12.2.0.patch
+++ b/patches/@graphql-tools+delegate+12.2.0.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/@graphql-tools/delegate/dist/index.cjs b/node_modules/@graphql-tools/delegate/dist/index.cjs
-index 6d0a779..18f0866 100644
+index c569eb4..2688470 100644
 --- a/node_modules/@graphql-tools/delegate/dist/index.cjs
 +++ b/node_modules/@graphql-tools/delegate/dist/index.cjs
-@@ -3052,7 +3052,7 @@ function delegateToSchema(options) {
+@@ -3075,7 +3075,7 @@ function delegateToSchema(options) {
      }
    }
    const fragments = info ? getFragmentDefinitions(info) : void 0;
@@ -12,18 +12,18 @@ index 6d0a779..18f0866 100644
      subgraphName: schema.name,
      fragments,
 diff --git a/node_modules/@graphql-tools/delegate/dist/index.js b/node_modules/@graphql-tools/delegate/dist/index.js
-index 5a4dadc..a91b7d3 100644
+index 58f0115..95a02cb 100644
 --- a/node_modules/@graphql-tools/delegate/dist/index.js
 +++ b/node_modules/@graphql-tools/delegate/dist/index.js
 @@ -1,6 +1,6 @@
- import { memoize2, memoize1, collectFields, relocatedError, mergeDeep, promiseReduce, pathToArray, getResponseKeyFromInfo, memoize3, getDefinedRootType, createGraphQLError, implementsAbstractType, getRootTypeNames, astFromArg, astFromValueUntyped, asArray, isAsyncIterable, getOperationASTFromRequest } from '@graphql-tools/utils';
+ import { memoize2, memoize1, collectFields, relocatedError, mergeDeep, promiseReduce, pathToArray, memoize3, getDefinedRootType, createGraphQLError, implementsAbstractType, getRootTypeNames, astFromArg, astFromValueUntyped, asArray, isAsyncIterable, getOperationASTFromRequest } from '@graphql-tools/utils';
  export { createDeferred } from '@graphql-tools/utils';
 -import { GraphQLError, locatedError, isAbstractType, getNullableType, isLeafType, isCompositeType, isListType, responsePathAsArray, Kind, TypeInfo, versionInfo, visit, visitWithTypeInfo, isNullableType, isUnionType, getNamedType, isObjectType, isInterfaceType, typeFromAST, isTypeSubTypeOf, isNonNullType, isInputObjectType, defaultFieldResolver, isSchema, OperationTypeNode, validate } from 'graphql';
 +import { GraphQLError, locatedError, isAbstractType, getNullableType, isLeafType, isCompositeType, isListType, responsePathAsArray, Kind, TypeInfo, versionInfo, visit, visitWithTypeInfo, isNullableType, isUnionType, getNamedType, isObjectType, isInterfaceType, typeFromAST, isTypeSubTypeOf, isNonNullType, isInputObjectType, defaultFieldResolver, isSchema, validate } from 'graphql';
  import { handleMaybePromise, isPromise, createDeferredPromise, mapAsyncIterator } from '@whatwg-node/promise-helpers';
  import { CRITICAL_ERROR, executorFromSchema } from '@graphql-tools/executor';
  export { executorFromSchema as createDefaultExecutor } from '@graphql-tools/executor';
-@@ -3052,7 +3052,7 @@ function delegateToSchema(options) {
+@@ -3075,7 +3075,7 @@ function delegateToSchema(options) {
      }
    }
    const fragments = info ? getFragmentDefinitions(info) : void 0;


### PR DESCRIPTION
## Summary
- Master CI fails at `npm install` / `patch-package` because the lockfile has `@graphql-tools/delegate@12.2.0` while `patches/@graphql-tools+delegate+12.1.3.patch` still targets 12.1.3.
- Regenerates the same GraphQL 15-compatible `OperationTypeNode` string comparison patch for 12.2.0.

Fixes the Setup env failure seen in https://github.com/ardatan/graphql-tools/actions/runs/34656665790

## Test plan
- [ ] CI green on this PR (especially any job that runs `npm install` / postinstall)
- [ ] Locally: `npx patch-package` applies all patches with exit 0